### PR TITLE
Add Software Partner Programme

### DIFF
--- a/static/js/find-a-partner.js
+++ b/static/js/find-a-partner.js
@@ -154,7 +154,7 @@
     );
   }
 
-  // Check if element shold be filtered
+  // Check if element should be filtered
   function filterCheck(filterText) {
     var match = false;
     filters.forEach((filter) => {

--- a/static/js/find-a-partner.js
+++ b/static/js/find-a-partner.js
@@ -158,7 +158,7 @@
   function filterCheck(filterText) {
     var match = false;
     filters.forEach((filter) => {
-      if (filterText.includes(filter) && !match) {
+      if (filterText.includes(filter.toLowerCase()) && !match) {
         match = true;
       }
     });
@@ -182,7 +182,7 @@
     const queryFilters = urlParams.get("filters");
     if (queryFilters) {
       queryFilters.split(",").forEach((filter) => {
-        var checkboxObject = document.querySelector("#" + filter);
+        var checkboxObject = document.querySelector("#" + filter.toLocaleLowerCase());
         if (checkboxObject) {
           checkboxObject.checked = true;
         }

--- a/templates/partners/_secondary-navigation.html
+++ b/templates/partners/_secondary-navigation.html
@@ -22,6 +22,9 @@
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'public-cloud' %}p-link--active{% else %}p-link--soft{% endif %}" href="/partners/public-cloud">Public Cloud</a>
         </li>
         <li class="breadcrumbs__item">
+          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'software' %}p-link--active{% else %}p-link--soft{% endif %}" href="/partners/software">Software</a>
+        </li>
+        <li class="breadcrumbs__item">
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'become-a-partner' %}p-link--active{% else %}p-link--soft{% endif %}" href="/partners/become-a-partner">Become a partner</a>
         </li>
         <li class="breadcrumbs__item">

--- a/templates/partners/become-a-partner.html
+++ b/templates/partners/become-a-partner.html
@@ -427,7 +427,7 @@
               <option value="Global System Integrator">Global System Integrator</option>
               <option value="VAR / Channel"> VAR / Channel</option>
               <option value="Regional System Integrator"> Regional System Integrator</option>
-              <option value="ISV"> ISV</option>
+              <option value="ISV"> Software publisher</option>
               <option value="Managed Service Provider"> Managed Service Provider</option>
             </select>
 

--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -87,8 +87,8 @@
           <label for="public-cloud">Public Cloud</label>
         </p>
         <p>
-          <input type="checkbox" class="js-find-a-partner__filter" name="ISV" id="software">
-          <label for="software">Software</label>
+          <input type="checkbox" class="js-find-a-partner__filter" name="isv" id="isv">
+          <label for="isv">Software</label>
         </p>
       </div>
       <div class="col-4">

--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -86,6 +86,10 @@
           <input type="checkbox" class="js-find-a-partner__filter" name="public-cloud" id="public-cloud">
           <label for="public-cloud">Public Cloud</label>
         </p>
+        <p>
+          <input type="checkbox" class="js-find-a-partner__filter" name="ISV" id="software">
+          <label for="software">Software</label>
+        </p>
       </div>
       <div class="col-4">
         <p class="p-heading--four">Services offered</p>

--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -8,7 +8,7 @@
       <div class="row">
         <div class="col-8">
           <h1>Find a Canonical partner</h1>
-          <p>Canonical’s network of Ubuntu partners spans the full range of our product suite. We offer partner programmes for public clouds, IHVs/OEMs, desktop, channel/resellers and global systems integrators.</p>
+          <p>Canonical’s network of Ubuntu partners spans the full range of our product suite. We offer partner programmes for public clouds, IHVs/OEMs, desktop, channel/resellers, software publishers and global systems integrators.</p>
         </div>
         <div class="col-4 u-hide--small u-align--center u-vertically-center">
           <img src="https://assets.ubuntu.com/v1/18dc67e0-lrg-magnifier-icon.svg" alt="">

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -64,6 +64,15 @@
         </div>
       </div>
     </div>
+    <div class="col-4 col-medium-3">
+      <div class="p-media-object--strip">
+        <img src="https://assets.ubuntu.com/v1/77c3e32f-Software_partner_3.svg" alt="image for software partners" class="p-media-object__image">
+        <div class="p-media-object__details">
+          <h1 class="p-media-object__title"><a href="/partners/software">Software&nbsp;&rsaquo;</a></h1>
+          <p class="p-media-object__content">Learn how our partner's software works best with Canonical's products</p>
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -69,7 +69,7 @@
         <img src="https://assets.ubuntu.com/v1/77c3e32f-Software_partner_3.svg" alt="image for software partners" class="p-media-object__image">
         <div class="p-media-object__details">
           <h1 class="p-media-object__title"><a href="/partners/software">Software&nbsp;&rsaquo;</a></h1>
-          <p class="p-media-object__content">Learn how our partner's software works best with Canonical's products</p>
+          <p class="p-media-object__content">Learn how our partners' software works best with Canonical's products</p>
         </div>
       </div>
     </div>

--- a/templates/partners/software.html
+++ b/templates/partners/software.html
@@ -2,38 +2,71 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1rnp14t9u065_1bGRSXWyvKTHMUIMjpLjQAKe-zbPCDI/edit#heading=h.1kcf4pjl5zqw{% endblock %}
 
-{% block title %}Software Partner Programme | Partners{% endblock %}
+{% block title %}Software partner programme | Partners{% endblock %}
 
-{% block meta_description %}Canonical’s Software Partner Programme helps ISV and Open Source Partners detail how their software works with Canonical’s products, to ensure that the products are deployed in a precise manner for optimal performance and a great user experience.{% endblock %}
+{% block meta_description %}Canonical's Software Partner Programme helps ISV and Open Source Partners detail how their software works with Canonical's products, to ensure that the products are deployed in a precise manner for optimal performance and a great user experience.{% endblock %}
 
 {% block content %}
-<section class="p-strip--suru-bottomed is-deep" style="padding-bottom: 8rem; padding-top: 3rem;">
-  <div class="row">
-    <div class="col-6">
-      <h1>Software Partner Programme</h1>
-      <p>Canonical’s Software Partner Programme helps ISV and Open Source Partners detail how their software works with Canonical’s products, to ensure that the products are deployed in a precise manner for optimal performance and a great user experience. </p>
-      <a href="/contact-us" class="p-button--positive">Become a Partner</a>
-    </div>
-    <div class="col-6 u-align--center u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/c0244599-latest-ubuntu-download.svg" width="350" height="314" alt="">
+<section class="p-strip--image is-dark">
+  <div class="p-strip--suru-top">
+    <div class="row">
+      <div class="col-7">
+        <h1>Software partner programme</h1>
+        <p>Canonical's Software Partner Programme helps ISV and Open Source Partners detail how their software works with Canonical's products, to ensure that the products are deployed in a precise manner for optimal performance and a great user experience. </p>
+        <a href="/contact-us" class="p-button--positive">Become a partner</a>
+      </div>
+      <div class="col-5 u-hide--small u-align--center u-vertically-center">
+        <div>
+          <img src="https://assets.ubuntu.com/v1/aba9cfb9-Software_partner_1.svg" width="120" height="120" alt="">
+          <img src="https://assets.ubuntu.com/v1/27ed2e78-Software_partner_2.svg" width="120" height="120" alt="">
+          <img src="https://assets.ubuntu.com/v1/77c3e32f-Software_partner_3.svg" width="120" height="120" alt="">
+        </div>
+      </div>
     </div>
   </div>
 </section>
+<style>
+  .p-strip--suru-top {
+    background-image:
+      linear-gradient(to top right, #fff 0%, #fff 49%, transparent 50%),
+      linear-gradient(to top right, rgba(74, 24, 60, 0) 0%, rgba(74, 24, 60, 0) 49.9%, rgba(74, 24, 60, 0.3) 50%, rgba(74, 24, 60, 0.3) 100%),
+      linear-gradient(to bottom right, rgba(210, 180, 202, 0.05) 0%, rgba(210, 180, 202, 0.05) 49.9%, rgba(210, 180, 202, 0) 50%, rgba(210, 180, 202, 0) 100%),
+      linear-gradient(216deg, #E95420 0%, #5E2750 33%, #2C001E 71%);
+    background-repeat: no-repeat;
+    background-size: 110% 10%, 70% 100%, 100% 40%, 100% 100%;
+    background-position: bottom -0.2px left, top right, top left;
+    padding-bottom: 6rem;
+    padding-top: 3rem;
+  }
+
+  @media (max-width: 772px) {
+    .p-strip--suru-top {
+      background-image:
+        linear-gradient(to top right, #fff 0%, #fff 49%, transparent 50%),
+        linear-gradient(to top right, rgba(74, 24, 60, 0) 0%, rgba(74, 24, 60, 0) 49.9%, rgba(74, 24, 60, 0.3) 50%, rgba(74, 24, 60, 0.3) 100%),
+        linear-gradient(to bottom right, rgba(210, 180, 202, 0.05) 0%, rgba(210, 180, 202, 0.05) 49.9%, rgba(210, 180, 202, 0) 50%, rgba(210, 180, 202, 0) 100%),
+        linear-gradient(216deg, #E95420 0%, #5E2750 33%, #2C001E 71%);
+      background-repeat: no-repeat;
+      background-size: 105% 5%, 70% 100%, 100% 40%, 100% 100%;
+      background-position: bottom -1px left, top right, top left;
+    }
+  }
+</style>
 
 {% if partners %}
 <section class="p-strip is-deep">
   <div class="u-fixed-width u-align--center">
-    <h4 class="p-muted-heading u-no-max-width">Meet some of our software partners</h4>
+    <h4 class="p-muted-heading u-no-max-width">Some of our software partners</h4>
   </div>
   <div class="u-fixed-width">
     <ul class="p-inline-images u-no-margin--bottom">
       {% for partner in partners %}
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 5rem;" alt="{{ partner.slug}}">
+        <img class="p-inline-images__logo" src="{{ partner.logo }}" style="object-fit: cover; min-width: 6rem; max-height: 6rem;" alt="{{ partner.slug}}">
       </li>
       {% endfor %}
     </ul>
-    <p class="u-align-text--center"><a href="/partners/find-a-partner?filters=software">See all of our software partners&nbsp;&rsaquo;</a></p>
+    <p class="u-align-text--center"><a href="/partners/find-a-partner?filters=isv">See all of our software partners&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 {% endif %}
@@ -42,12 +75,10 @@
   <div class="row">
     <div class="col-8">
       <h2>What's included</h2>
-      <p>Canonical’s Software Partner Programme helps ISV and Open Source Partners detail how their software works with Canonical’s products, to ensure that the products are deployed in a precise manner for optimal performance and a great user experience.</p>
-      <p>
-        <a href="/partners/become-a-partner" class="p-button--positive">
-          Become a partner
-        </a>
-      </p>
+      <p>Canonical's products power a broad range of Software Partners as they solve the application and infrastructure challenges facing business and society today, from products powering the world's webservers, through the premium 3D computer graphics software toolset to the Robotics platform of choice in research, education and product development &mdash; Canonical works behind the scenes to make our Software Partners' solutions reality.</p>
+    </div>
+    <div class="col-4 u-hide--small u-align--center u-vertically-center">
+      <img src="https://assets.ubuntu.com/v1/69aaa876-compliance.svg" width="150" height="150" alt="">
     </div>
   </div>
   <div class="row p-divider">
@@ -72,6 +103,15 @@
         <li class="p-list__item is-ticked">Work with Canonical for Custom Image Builds (cloud-specific, FIPS, CIS-hardened, Minimal, PCI-ready), and enjoy ongoing maintenance across your software lifecycle</li>
         <li class="p-list__item is-ticked">Test your product using Canonical's OpenStack and Kubernetes Partner Cloud, with Field Engineering expertise on hand to assist</li>
       </ul>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <p>
+        <a href="/partners/become-a-partner" class="p-button--positive">
+          Become a partner
+        </a>
+      </p>
     </div>
   </div>
 </section>

--- a/templates/partners/software.html
+++ b/templates/partners/software.html
@@ -1,0 +1,81 @@
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1rnp14t9u065_1bGRSXWyvKTHMUIMjpLjQAKe-zbPCDI/edit#heading=h.1kcf4pjl5zqw{% endblock %}
+
+{% block title %}Software Partner Programme | Partners{% endblock %}
+
+{% block meta_description %}Canonical’s Software Partner Programme helps ISV and Open Source Partners detail how their software works with Canonical’s products, to ensure that the products are deployed in a precise manner for optimal performance and a great user experience.{% endblock %}
+
+{% block content %}
+<section class="p-strip--suru-bottomed is-deep" style="padding-bottom: 8rem; padding-top: 3rem;">
+  <div class="row">
+    <div class="col-6">
+      <h1>Software Partner Programme</h1>
+      <p>Canonical’s Software Partner Programme helps ISV and Open Source Partners detail how their software works with Canonical’s products, to ensure that the products are deployed in a precise manner for optimal performance and a great user experience. </p>
+      <a href="/contact-us" class="p-button--positive">Become a Partner</a>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/c0244599-latest-ubuntu-download.svg" width="350" height="314" alt="">
+    </div>
+  </div>
+</section>
+
+{% if partners %}
+<section class="p-strip is-deep">
+  <div class="u-fixed-width u-align--center">
+    <h4 class="p-muted-heading u-no-max-width">Meet some of our software partners</h4>
+  </div>
+  <div class="u-fixed-width">
+    <ul class="p-inline-images u-no-margin--bottom">
+      {% for partner in partners %}
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 5rem;" alt="{{ partner.slug}}">
+      </li>
+      {% endfor %}
+    </ul>
+    <p class="u-align-text--center"><a href="/partners/find-a-partner?filters=software">See all of our software partners&nbsp;&rsaquo;</a></p>
+  </div>
+</section>
+{% endif %}
+
+<section class="p-strip--light is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h2>What's included</h2>
+      <p>Canonical’s Software Partner Programme helps ISV and Open Source Partners detail how their software works with Canonical’s products, to ensure that the products are deployed in a precise manner for optimal performance and a great user experience.</p>
+      <p>
+        <a href="/partners/become-a-partner" class="p-button--positive">
+          Become a partner
+        </a>
+      </p>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="u-no-fixed-width">
+      <h4>Why partner with Canonical?</h4>
+    </div>
+    <div class="col-6">
+      <h5>Benefits</h5>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Be featured as a Software Partner on the Canonical website</li>
+        <li class="p-list__item is-ticked">Showcase your software products and platforms as <strong>Validated with Ubuntu</strong> and have them listed on Canonical&#39;s website</li>
+        <li class="p-list__item is-ticked">Use our trademarks and logos on your own website</li>
+        <li class="p-list__item is-ticked">Promote your software as Validated with Ubuntu</li>
+        <li class="p-list__item is-ticked">Enjoy co-marketing opportunities including joint events, videos, blogs, PR and demos to potential customers</li>
+        <li class="p-list__item is-ticked">Validate unlimited product combinations</li>
+        <li class="p-list__item is-ticked"><a href="/partners/become-a-partner">Join free</a></li>
+      </ul>
+    </div>
+    <div class="col-6 p-divider__block">
+      <h5>Premium benefits</h5>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Work with Canonical for Custom Image Builds (cloud-specific, FIPS, CIS-hardened, Minimal, PCI-ready), and enjoy ongoing maintenance across your software lifecycle</li>
+        <li class="p-list__item is-ticked">Test your product using Canonical's OpenStack and Kubernetes Partner Cloud, with Field Engineering expertise on hand to assist</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+{% include 'partial/_partners-footer.html' %}
+
+{% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -35,8 +35,7 @@ partners_api = Partners(session)
 
 @app.route("/")
 def index():
-    partner_groups = partners_api.get_partner_groups()
-    return flask.render_template("index.html", partner_groups=partner_groups)
+    return flask.render_template("index.html")
 
 
 @app.route("/secure-boot-master-ca.crl")
@@ -175,7 +174,8 @@ def department_group(department):
 
     if flask.request.method == "POST":
         response = greenhouse.submit_application(
-            flask.request.form, flask.request.files,
+            flask.request.form,
+            flask.request.files,
         )
         if response.status_code == 200:
             message = {

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -175,8 +175,7 @@ def department_group(department):
 
     if flask.request.method == "POST":
         response = greenhouse.submit_application(
-            flask.request.form,
-            flask.request.files,
+            flask.request.form, flask.request.files,
         )
         if response.status_code == 200:
             message = {
@@ -217,6 +216,7 @@ def find_a_partner():
 @app.route("/partners/gsi")
 @app.route("/partners/ihv-and-oem")
 @app.route("/partners/public-cloud")
+@app.route("/partners/software")
 def partner_details():
     partners = partners_api._get(
         partners_api.partner_page_map[flask.request.path.split("/")[2]]

--- a/webapp/partners.py
+++ b/webapp/partners.py
@@ -11,6 +11,7 @@ class Partners:
         "iot": "programme__name=Internet%20of%20Things&featured=true",
         "gsi": "programme__name=Global%20System%20Integrators&featured=true",
         "public-cloud": "programme__name=Public%20Cloud&featured=true",
+        "software": "programme__name=ISV",
     }
 
     def __init__(self, session):
@@ -52,6 +53,10 @@ class Partners:
             "Server": self._get("technology__name=Cloud/server&featured=true"),
             "Serverless": self._get("programme__name=Desktop&featured=true"),
             "Silicon": self._get("programme__name=Desktop&featured=true"),
+            "Snapcraft": self._get(
+                "programme__name=Internet%20of%20Things&featured=true"
+            ),
+            "Software": self._get("programme__name=ISV"),
             "Snapcraft": self._get(
                 "programme__name=Internet%20of%20Things&featured=true"
             ),

--- a/webapp/partners.py
+++ b/webapp/partners.py
@@ -57,9 +57,6 @@ class Partners:
                 "programme__name=Internet%20of%20Things&featured=true"
             ),
             "Software": self._get("programme__name=ISV"),
-            "Snapcraft": self._get(
-                "programme__name=Internet%20of%20Things&featured=true"
-            ),
             "Training": self._get("programme__name=Desktop&featured=true"),
         }
 


### PR DESCRIPTION
## Done

- Add /partners/software page
- Add partners to partners.ubuntu.com
- Add filter to /partners/find-a-partner page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8002/partners/software
    - http://0.0.0.0:8002/partners/find-a-partner?filters=software
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes [#3893](https://github.com/canonical-web-and-design/web-squad/issues/3893)

