### PR TITLE
Exclude qq.com domain from applications

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -183,6 +183,11 @@ def job_details(job_id, job_title):
         flask.abort(404)
 
     if flask.request.method == "POST":
+        # Temporary fix to exlude a spammy domain
+        # https://github.com/canonical-web-and-design/canonical.com/issues/437
+        if flask.request.form["email"].endswith("qq.com"):
+            flask.abort(406)
+
         response = greenhouse.submit_application(
             flask.request.form, flask.request.files, job_id
         )


### PR DESCRIPTION
## Done

Exclud qq.com domain (see #437 )

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/3521601
- Fill the form with a email random domain
- Apply -> Should work
- Now fill the form with a qq.com domain
- Apply -> should 404