### PR TITLE
Add extra footer link only to careers pages

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -35,11 +35,6 @@
       background: rgba(255, 255, 255, 0.25);
       margin: 2rem 0;
     }
-
-    .p-inline-list--middot .p-inline-list__item::after {
-      color: $color-mid-light;
-      right: -0.8rem;
-    }
   }
   @media (max-width: $breakpoint-x-small) {
     .p-footer {

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -9,8 +9,8 @@
         <ul class="p-inline-list--middot">
           <li class="p-inline-list__item"><a href="/contact-us" class="p-footer__link">Contact information</a></li>
           <li class="p-inline-list__item"><a href="https://ubuntu.com/legal" class="p-footer__link">Legal information</a></li>
-          {% if current_path == "/careers" %}
-           <li class="p-inline-list__item"><a class="p-footer__link" href="https://docs.google.com/document/d/1_ExS3fRc8odw8extzVeZWkrZU78DekJ3Ei_dUOayGLI/edit">Equal Employment Opportunity Commitment</a></li>
+          {% if "/careers" in current_path %}
+            <li class="p-inline-list__item"><a class="p-footer__link" href="https://docs.google.com/document/d/1_ExS3fRc8odw8extzVeZWkrZU78DekJ3Ei_dUOayGLI/edit">Equal Employment Opportunity Commitment</a></li>
           {% endif %}
           <li class="p-inline-list__item"><a href="https://github.com/canonical-web-and-design/canonical.com/issues/new" class="p-footer__link">Improve this site</a></li>
           <li class="p-inline-list__item"><a href="/projects" class="p-footer__link">Projects</a></li>

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -6,7 +6,7 @@
     <div class="row">
       <div class="col-9">
         <p>&copy; {{ current_year }} Canonical Ltd.</p>
-        <ul class="p-inline-list--middot">
+        <ul class="p-inline-list--middot is-dark">
           <li class="p-inline-list__item"><a href="/contact-us" class="p-footer__link">Contact information</a></li>
           <li class="p-inline-list__item"><a href="https://ubuntu.com/legal" class="p-footer__link">Legal information</a></li>
           {% if "/careers" in current_path %}
@@ -20,13 +20,13 @@
       <div class="col-3 u-align--right">
         <ul class="p-inline-list">
           <li class="p-inline-list__item">
-              <a href="https://www.linkedin.com/company/234280" class="p-icon--linkedin"></a>
+            <a href="https://www.linkedin.com/company/234280" class="p-icon--linkedin">LinkedIn</a>
           </li>
           <li class="p-inline-list__item">
-            <a href="https://twitter.com/Canonical" class="p-icon--twitter"></a>
+            <a href="https://twitter.com/Canonical" class="p-icon--twitter">Twitter</a>
           </li>
           <li class="p-inline-list__item">
-            <a href="https://www.youtube.com/user/celebrateubuntu" class="p-icon--youtube"></a>
+            <a href="https://www.youtube.com/user/celebrateubuntu" class="p-icon--youtube">YouTube</a>
           </li>
         </ul>
       </div>

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -10,7 +10,7 @@
           <li class="p-inline-list__item"><a href="/contact-us" class="p-footer__link">Contact information</a></li>
           <li class="p-inline-list__item"><a href="https://ubuntu.com/legal" class="p-footer__link">Legal information</a></li>
           {% if "/careers" in current_path %}
-            <li class="p-inline-list__item"><a class="p-footer__link" href="https://docs.google.com/document/d/1_ExS3fRc8odw8extzVeZWkrZU78DekJ3Ei_dUOayGLI/edit">Equal Employment Opportunity Commitment</a></li>
+            <li class="p-inline-list__item"><a class="p-footer__link" href="https://ubuntu.com/legal/equal-employment-opportunity-commitment">Equal Employment Opportunity Commitment</a></li>
           {% endif %}
           <li class="p-inline-list__item"><a href="https://github.com/canonical-web-and-design/canonical.com/issues/new" class="p-footer__link">Improve this site</a></li>
           <li class="p-inline-list__item"><a href="/projects" class="p-footer__link">Projects</a></li>

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -1,3 +1,4 @@
+{% set current_path =  url_for(request.endpoint, **request.view_args)  %}
 <footer class="p-footer is-dark">
     <div class="row">
       <hr />
@@ -8,6 +9,9 @@
         <ul class="p-inline-list--middot">
           <li class="p-inline-list__item"><a href="/contact-us" class="p-footer__link">Contact information</a></li>
           <li class="p-inline-list__item"><a href="https://ubuntu.com/legal" class="p-footer__link">Legal information</a></li>
+          {% if current_path == "/careers" %}
+           <li class="p-inline-list__item"><a class="p-footer__link" href="https://docs.google.com/document/d/1_ExS3fRc8odw8extzVeZWkrZU78DekJ3Ei_dUOayGLI/edit">Equal Employment Opportunity Commitment</a></li>
+          {% endif %}
           <li class="p-inline-list__item"><a href="https://github.com/canonical-web-and-design/canonical.com/issues/new" class="p-footer__link">Improve this site</a></li>
           <li class="p-inline-list__item"><a href="/projects" class="p-footer__link">Projects</a></li>
           <li class="p-inline-list__item"><a class="p-footer__link js-revoke-cookie-manager" href="">Manage your tracker settings</a></li>


### PR DESCRIPTION
## Done

- Added extra footer link only to careers pages as per [copy doc](https://docs.google.com/document/d/1ujvmMK1zUMXrUsc2zwl_hT1MrtOA9yymH1m4hyF708E/edit#)
- ~NOTE: need to confirm link url before this is ready for review~ link is https://ubuntu.com/legal/equal-employment-opportunity-commitment

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://canonical-com-597.demos.haus/careers
- See that the Equal Employment Opportunity link is present in the footer
- Visit any other careers page like https://canonical-com-597.demos.haus/careers/start and see that the added footer link is still there
- Visit a non careers page like https://canonical-com-597.demos.haus/partners and see that the footer link is no longer there


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5675
