### PR TITLE
check "vacancies" is present in the context

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -244,9 +244,11 @@ def department_group(department_slug):
         context["vacancies"] = greenhouse.get_vacancies()
 
     context["templates"] = templates
-    context["vacancies_json"] = [
-        vacancy.to_dict() for vacancy in context["vacancies"]
-    ]
+
+    if "vacancies" in context:
+        context["vacancies_json"] = [
+            vacancy.to_dict() for vacancy in context["vacancies"]
+        ]
     if flask.request.method == "POST":
         response = greenhouse.submit_application(
             flask.request.form,


### PR DESCRIPTION
## Done

- Fixed 500 errors on /careers/[slug] pages that don't show vacancies

## QA

- Visit https://canonical.com/
- Click "careers" in the top nav
- On the careers page, scroll to the "Diversity in our company is part of our strength" section and click the "Ethics" link
- See that the page 500s
- Visit https://canonical-com-607.demos.haus/
- Repeat the process to get to the ethics page
- Check that the page loads and doesn't result in a 500

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/606
