### PR TITLE
update job postings to allow video embeds

### DIFF
--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -81,11 +81,7 @@
 <div class="row">
   <div class="col-6">
     <div class="job-desc">
-      {% set job_content = job.content.replace("<p>&nbsp;</p>", "") %}
-      {% set allowed_tags = ['iframe', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'strong', 'ul', 'ol', 'li', 'i', 'em', 'br'] %}
-      {% set allowed_attributes = {'iframe': ['src', 'height', 'width']} %}
-
-      {{ bleach.clean(job_content, tags=allowed_tags, attributes=allowed_attributes, strip=True) | safe }}
+      {{ job.content | filtered_html_tags | safe }}
     </div>
   </div>
 

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -82,9 +82,10 @@
   <div class="col-6">
     <div class="job-desc">
       {% set job_content = job.content.replace("<p>&nbsp;</p>", "") %}
-      {% set allowed_tags = ['h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'strong', 'ul', 'ol', 'li', 'i', 'em', 'br'] %}
+      {% set allowed_tags = ['iframe', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'strong', 'ul', 'ol', 'li', 'i', 'em', 'br'] %}
+      {% set allowed_attributes = {'iframe': ['src', 'height', 'width']} %}
 
-      {{ bleach.clean(job_content, tags=allowed_tags, strip=True) | safe }}
+      {{ bleach.clean(job_content, tags=allowed_tags, attributes=allowed_attributes, strip=True) | safe }}
     </div>
   </div>
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -2,7 +2,7 @@
 import datetime
 import os
 import re
-from urllib.parse import parse_qs, urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import bleach
 import flask
@@ -425,6 +425,46 @@ def slug(text):
 @app.template_filter()
 def markup(text):
     return markdown.markdown(text)
+
+
+@app.template_filter()
+def filtered_html_tags(content):
+    content = content.replace("<p>&nbsp;</p>", "")
+    allowed_tags = [
+        "iframe",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "p",
+        "a",
+        "strong",
+        "ul",
+        "ol",
+        "li",
+        "i",
+        "em",
+        "br",
+    ]
+    allowed_attributes = {"iframe": allow_src}
+
+    return bleach.clean(
+        content,
+        tags=allowed_tags,
+        attributes=allowed_attributes,
+        strip=True,
+    )
+
+
+def allow_src(tag, name, value):
+    allowed_sources = ["www.youtube.com", "www.vimeo.com"]
+    if name in ("alt", "height", "width"):
+        return True
+    if name == "src":
+        p = urlparse(value)
+        return (not p.netloc) or p.netloc in allowed_sources
+    return False
 
 
 @app.errorhandler(502)


### PR DESCRIPTION
## Done

This was a request from Thibaut:
- updated the job detail page to allow youtube and vimeo videos added in greenhouse to show on the page
- added logic to ensure rendered iframes come only from youtube or vimeo

## QA

- visit https://canonical-com-609.demos.haus/careers/2955155
- see that a youtube video appears in the job description

The best way to verify that the youtube and vimeo restrictions work is:
- Check out this branch
- Update [this line](https://github.com/canonical/canonical.com/pull/609/files#diff-55f12a9f17b4ba61d3e37852150b7d78b8aedbe3629bc4ce8173d4b572297a54R461) to anything other than the two domains that are now
- `dotrun` the project
- visit http://0.0.0.0:8002/careers/2955155
- see that the video does not appear
