### PR TITLE
Update view after rejection

### DIFF
--- a/templates/careers/application/index.html
+++ b/templates/careers/application/index.html
@@ -222,7 +222,7 @@
         </p>
       </div>
     </section>
-    {% elif application["status"] != "active" and application["rejection_reason"]["type"]["id"] == 2 %}
+    {% elif withdrawn %}
     <section class="p-strip--light is-deep">
       <div class="row">
         <h1>Your application has been withdrawn</h1>

--- a/templates/careers/application/index.html
+++ b/templates/careers/application/index.html
@@ -29,7 +29,7 @@
     }
   }
   </script>
-  {% if application["status"] == "active" %}
+  {% if application["status"] == "active" or ( application["status"] != "active" and application["to_be_rejected"] == True ) %}
     <section class="p-strip--light is-deep">
       {% if withdrawal_requested %}
         <div class="u-fixed-width">
@@ -183,33 +183,35 @@
       {% include 'careers/application/partial/_lifestyle.html' %}
     </section>
 
-    {% if "stage_progress" in application and not application["stage_progress"]["assessment"]  %}
-    <section class="p-strip--light is-deep">
-    {% else %}
-    <section class="p-strip is-deep">
-    {% endif %}
-      {% if withdrawal_requested %}
-      <div class="u-fixed-width">
-        <h2>You have requested to withdraw this application.</h2>
-        <p>Your application will remain active until you click on the link we have sent you via email.</p>
-        <p>If you experience any issues please contact your hiring lead.</p>
-      </div>
-      {% elif not withdrawal_requested and wrong_email %}
-      <div class="u-fixed-width">
-        <h2>We could not withdraw your application.</h2>
-        <p>The email you entered does not match the email used to apply to this role. Please try again using the email you used in the application.</p>
-        <button id="showModal" aria-controls="modal">Withdraw application</button>
-        {% include "careers/application/_withdrawal-form.html" %}
-      </div>
+    {% if application["status"] == "active" %}
+      {% if "stage_progress" in application and not application["stage_progress"]["assessment"]  %}
+      <section class="p-strip--light is-deep">
       {% else %}
-      <div class="u-fixed-width">
-        <h2>Do you wish to withdraw your application?</h2>
-        <p>You will be asked for confirmation in the next steps.</p>
-        <button id="showModal" aria-controls="modal">Withdraw application</button>
-        {% include "careers/application/_withdrawal-form.html" %}
-      </div>
+      <section class="p-strip is-deep">
       {% endif %}
-    </section>
+        {% if withdrawal_requested %}
+        <div class="u-fixed-width">
+          <h2>You have requested to withdraw this application.</h2>
+          <p>Your application will remain active until you click on the link we have sent you via email.</p>
+          <p>If you experience any issues please contact your hiring lead.</p>
+        </div>
+        {% elif not withdrawal_requested and wrong_email %}
+        <div class="u-fixed-width">
+          <h2>We could not withdraw your application.</h2>
+          <p>The email you entered does not match the email used to apply to this role. Please try again using the email you used in the application.</p>
+          <button id="showModal" aria-controls="modal">Withdraw application</button>
+          {% include "careers/application/_withdrawal-form.html" %}
+        </div>
+        {% else %}
+        <div class="u-fixed-width">
+          <h2>Do you wish to withdraw your application?</h2>
+          <p>You will be asked for confirmation in the next steps.</p>
+          <button id="showModal" aria-controls="modal">Withdraw application</button>
+          {% include "careers/application/_withdrawal-form.html" %}
+        </div>
+        {% endif %}
+      </section>
+    {% endif %}
 
   {% elif application["status"] == "hired" %}
     <section class="p-strip">
@@ -220,15 +222,11 @@
         </p>
       </div>
     </section>
-  {% else %}
-    <section class="p-strip">
+    {% elif application["status"] != "active" and application["rejection_reason"]["type"]["id"] == 2 %}
+    <section class="p-strip--light is-deep">
       <div class="row">
-        <h1>Thanks for applying {{ application["candidate"]["first_name"] }} {{ application["candidate"]["last_name"] }}!</h1>
-        <p>
-          <i class="p-icon--error"></i> It seems your application on the role {{ application["jobs"][0]["name"] }} was rejected. 
-          Check out <a href="/careers">our career page</a> to see if there 
-          is another role that would match your skills!
-        </p>
+        <h1>Your application has been withdrawn</h1>
+        <p>Thank you for the time you have spent on this application. <br/> Check out <a href="https://canonical.com/careers">our career page</a> to find other roles that match your skills.</p>
       </div>
     </section>
   {% endif %}

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -226,12 +226,21 @@ def faq():
 @application.route("/<string:token>")
 def application_index(token):
     application = _get_application_from_token(token)
+    if (
+        application["status"] != "active"
+        and application["rejection_reason"]["type"]["id"] == 2
+    ):
+        withdrawn = True
+    else:
+        withdrawn = False
+
     return flask.render_template(
         "careers/application/index.html",
         withdrawal_reasons=withdrawal_reasons,
         token=token,
         application=application,
         candidate=application["candidate"],
+        withdrawn=withdrawn,
     )
 
 
@@ -314,7 +323,6 @@ def request_withdrawal(token):
             subject="Withdraw Application Confirmation",
             message=email_message,
         )
-
     return flask.render_template(
         "careers/application/index.html",
         debug_skip_sending=debug_skip_sending,

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -1,5 +1,6 @@
 import json
 import os
+from datetime import datetime, timezone
 from smtplib import SMTP
 import socket
 from email.message import EmailMessage
@@ -79,6 +80,19 @@ def _get_application(application_id):
             interview["stage_name"] = interviews_stage[
                 interview["interview"]["id"]
             ]
+
+    application["to_be_rejected"] = False
+    if (
+        application["rejected_at"]
+        and not application["rejection_reason"]["type"]["id"] == 2
+    ):
+        now = datetime.now(timezone.utc)
+        rejection_time = parse(application["rejected_at"])
+        time_after_rejection = int((now - rejection_time).total_seconds() / 60)
+        if time_after_rejection < 2880:
+            application["to_be_rejected"] = True
+        else:
+            flask.abort(404)
 
     return application
 


### PR DESCRIPTION
## Done

The application needs to display differently when candidates self-reject their applications and hiring leads reject their applications

## QA
QA below
-  If >48 hours: page is deleted (404 page displays)
-  If <48 hours AND the candidate was rejected by Canonical: status of page is unchanged (last step), remove application withdrawal section
- If <48 hours AND the candidate withdrew their application: status of page is unchanged, showing the [withdrawal confirmation page](https://www.figma.com/file/KQSCmTqOjY4gfKvJPyvzj2/Canonical.com-latest-only?node-id=5742%3A10530)

## Issue / Card

Fixes #624 