### PR TITLE
Add meta tag to hide documentation page from search engines

### DIFF
--- a/templates/practice/documentation.html
+++ b/templates/practice/documentation.html
@@ -8,6 +8,11 @@
 
 {% block meta_image %}https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg{% endblock %}
 
+<!-- This should be removed when the page is ready so it can be indexed by search engines. -->
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 {% block content %}
 <section class="p-strip--suru-topped is-bordered">
   <div class="row">

--- a/templates/practice/documentation.html
+++ b/templates/practice/documentation.html
@@ -8,11 +8,10 @@
 
 {% block meta_image %}https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg{% endblock %}
 
-<!-- This should be removed when the page is ready so it can be indexed by search engines. -->
-<head>
-  <meta name="robots" content="noindex">
-</head>
-
+{% block extra_metatags %}
+    <!-- This should be removed when the page is ready so it can be indexed by search engines. -->
+    <meta name="robots" content="noindex">
+{% endblock %}
 {% block content %}
 <section class="p-strip--suru-topped is-bordered">
   <div class="row">


### PR DESCRIPTION
## Done

-Add a meta tag to prevent documentation page from being indexed by search engines

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes #633
