### PR TITLE
Remove buttons for pending pages

### DIFF
--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -26,7 +26,6 @@
     <div class="col-9">
       <p class="p-heading--2 u-no-padding--top">Seamless consumption of open source<br class="u-hide--small">across the compute spectrum</p>
       <p>Join an intense global mission &ndash; to deliver the world's best open source experience,<br class="u-hide--small">from platform to application</p>
-      <button class="p-button">Defining excellence</button>
     </div>
   </div>
 </section>
@@ -50,7 +49,6 @@
     <div class="col-9">
       <p class="p-heading--2">Less commuting, more real travel</p>
       <p>Canonical is uniquely global &ndash; we hire the best open source team, regardless of nationality or language, creed or colour.</p>
-      <button class="p-button">Our vision of remote work</button>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Removed "Defining Excellence" and "Our vision of remote work" buttons as the pages they route to are still pending. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers 
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the 2 buttons have been removed
