### PR TITLE
Allow href attribute on links in job descriptions

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -447,7 +447,7 @@ def filtered_html_tags(content):
         "em",
         "br",
     ]
-    allowed_attributes = {"iframe": allow_src}
+    allowed_attributes = {"iframe": allow_src, "a": "href"}
 
     return bleach.clean(
         content,


### PR DESCRIPTION
## Done
Allow href attribute on links in job descriptions

## QA
- Go to https://canonical.com/careers/3798310/technical-author-ubuntu-and-canonical-products-remote and see the link don't work
- Visit the same page on the demo and see they do

Fixes https://github.com/canonical/canonical.com/issues/640