### PR TITLE
change theme-color to Canonical's accent color

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -11,7 +11,7 @@
     <meta name="author" content="Canonical Ltd" />
     <link rel="canonical" href="{% block canonical_url %}{{ request.url }}{% endblock %}">
 
-    <meta name="theme-color" content="#E95420">
+    <meta name="theme-color" content="#7c355d">
     <meta name="twitter:account_id" content="169015850">
     <meta name="twitter:site" content="@canonical">
     <meta property="og:type" content="website">


### PR DESCRIPTION
## Done

- Fix the theme color

## QA

- Check out this feature branch
- Go to https://canonical-com-643.demos.haus/ on Android (Chrome) or Safari (set the URL style to compact)
- Make sure that the color of the URL bar is Canonical's accent color (purple)

## Issue / Card

Fixes #641 

## Screenshots
![image](https://user-images.githubusercontent.com/36013798/193851756-f752b6ca-1deb-4cd7-a23d-4d2543d0934e.png)
