### PR TITLE
Careers department pages refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
     "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build'",
     "build": "yarn run build-css && yarn run build-js",
     "build-css": "sass static/sass/styles.scss static/css/styles.css --load-path=node_modules --style=compressed && postcss --map false --use autoprefixer --replace 'static/css/**/*.css'",
-    "build-js": "yarn run build-cookie-policy && yarn run build-fuse",
+    "build-js": "yarn run build-cookie-policy && yarn run build-fuse && yarn run build-latest-news",
     "build-cookie-policy": "mkdir -p static/js/modules/cookie-policy && cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js static/js/modules/cookie-policy",
+    "build-latest-news": "mkdir -p static/js/modules/latest-news &&  cp node_modules/@canonical/latest-news/dist/latest-news.js static/js/modules/latest-news",
     "build-fuse": "mkdir -p static/js/modules/fuse && cp node_modules/fuse.js/dist/fuse.js static/js/modules/fuse",
     "format-python": "black --line-length 79 webapp",
     "lint-python": "flake8 --extend-ignore=E203 webapp tests && black --check --line-length 79 webapp tests",
@@ -19,6 +20,7 @@
   },
   "dependencies": {
     "@canonical/cookie-policy": "3.4.0",
+    "@canonical/latest-news": "1.4.1",
     "@testing-library/cypress": "8.0.0",
     "autoprefixer": "10.4.1",
     "concurrently": "5.3.0",

--- a/static/sass/_pattern_blog-card.scss
+++ b/static/sass/_pattern_blog-card.scss
@@ -1,4 +1,26 @@
 @mixin blog-p-card {
+  .u-crop--16-9 {
+    position: relative;
+    &::before {
+      content: "";
+      display: block;
+      padding-top: 56.25%;
+      width: 100%;
+    }
+
+    // Incase img isn't wrapped in a link
+    & a,
+    & div,
+    & img {
+      bottom: 0;
+      left: 0;
+      overflow: hidden;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+  }
+  
   .p-card__category {
     background: url("#{$assets-path}ed42aefa-icon-resource-hub-icon-document.png")
       left center no-repeat;

--- a/templates/careers/admin.html
+++ b/templates/careers/admin.html
@@ -82,10 +82,41 @@
 <section class="p-strip">
   <div class="u-fixed-width">
     <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
-    <h3 class="p-heading--2">Find out more about Engineering</h3>
-    <!-- blogs to go here -->
-  </div>
+    <h3 class="p-heading--2 u-sv3">Find out more about Admin</h3>
+    
+    <div id="latest-articles" class="row">
+      <div style="min-height: 9.1rem">
+        <i class="p-icon--spinner u-animation--spin">Loading...</i>
+      </div>
+    </div>
+    
+    <template style="display:none" id="articles-template">
+      <article class="col-4 col-medium-2 blog-p-card--post">
+        <div class="blog-p-card__content">
+          <div class="u-crop--16-9" style="margin-bottom:1rem;">
+            <div class="article-image" aria-hidden="true"></div>
+          </div>
+          <h3 class="p-heading--4 u-no-margin--bottom">
+            <a class="p-link--soft article-title article-link"></a>
+          </h3>
+          <p class="article-excerpt"></p>
+        </div>
+      </article>
+    </template>
 
+    <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
+    <script>
+      canonicalLatestNews.fetchLatestNews(
+        {
+          articlesContainerSelector: "#latest-articles",
+          articleTemplateSelector: "#articles-template",
+          limit: "3",
+          hostname: "canonical.com",
+          tagId: 1486 
+        }
+      )
+    </script>
+  </div>
 </section>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/admin.html
+++ b/templates/careers/admin.html
@@ -79,44 +79,9 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
-    <h3 class="p-heading--2 u-sv3">Find out more about Admin</h3>
-    
-    <div id="latest-articles" class="row">
-      <div style="min-height: 9.1rem">
-        <i class="p-icon--spinner u-animation--spin">Loading...</i>
-      </div>
-    </div>
-    
-    <template style="display:none" id="articles-template">
-      <article class="col-4 col-medium-2 blog-p-card--post">
-        <div class="blog-p-card__content">
-          <div class="u-crop--16-9" style="margin-bottom:1rem;">
-            <div class="article-image" aria-hidden="true"></div>
-          </div>
-          <h3 class="p-heading--4 u-no-margin--bottom">
-            <a class="p-link--soft article-title article-link"></a>
-          </h3>
-          <p class="article-excerpt"></p>
-        </div>
-      </article>
-    </template>
+{% with section_classes='p-strip', heading_topic='Admin', tag_id='1486', limit='3' %}
+  {% include "shared/_blog-card.html" %}
+{% endwith %}
 
-    <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
-    <script>
-      canonicalLatestNews.fetchLatestNews(
-        {
-          articlesContainerSelector: "#latest-articles",
-          articleTemplateSelector: "#articles-template",
-          limit: "3",
-          hostname: "canonical.com",
-          tagId: 1486 
-        }
-      )
-    </script>
-  </div>
-</section>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/admin.html
+++ b/templates/careers/admin.html
@@ -1,24 +1,91 @@
-{% extends '/careers/base-tabs.html' %}
+{% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1LRQrvgLlNnaBsW1RD7WLlNLZbn6-zj0EUtXr2jtMh3M/edit{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1pNyOXfR07FiBr6TmEMRdB7NZUB5SeBz6COuSxO3ylC0{% endblock meta_copydoc %}
 
 {% block title %}Admin | Careers{% endblock %}
 
 {% block meta_description %}Canonical is a global distributed company with many offices and hundreds of remote workers.  This means the admin team a complex and rewarding role to help the company work effectively as possible.{% endblock %}
 
-{% block overview %}
-  <p>
-    <strong>Canonical is a completely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source. We have a few office locations, but almost everybody works from home. Teams get together every few months at locations around the world to plan and coordinate their projects.</strong>
-  </p>
-  <p>
-    All of this means that administration is central to the effective running of the company. Hundreds of distributed team members count on effective processes to support their travel and operations. Our admin team run events, control expenses, manage travel and coordinate meetings. We are trusted to hold the global team accountable to the company policies. We ensure that the business operates smoothly and we have a significant impact on the quality of the experience that people have at the company.
-  </p>
-  <p>
-    We are a multi-skilled and multi-cultural team. We encourage new members of the team to develop skills across the entire range of admin challenges so that we can help one another as needed and bring our joint insights to bear on continuous improvement. Our team is largely based in offices in Austin, Boston, London, Taipei and Beijing, but we offer some flexibility to work from home. We often run company events around the world in person, so you need the latitude to be in a completely different timezone for up to two weeks at a time, three or four times a year.
-  </p>
-  <hr />
-  <p class="p-muted-heading">
-    <span style="text-transform: capitalize">Austin&nbsp;&#124;&nbsp;Beijing&nbsp;&#124;&nbsp;Boston&nbsp;&#124;&nbsp;London&nbsp;&#124;&nbsp;Taipei</span>
-  </p>
-  <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
+{% block content %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h1 class="p-heading--2">Admin</h1>
+    </div>
+    <div class="col-6">
+      <p>Canonical is a completely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source. We have a few office locations, but almost everybody works from home. Teams get together every few months at locations around the world to plan and coordinate their projects.</p>
+      <a class="p-button--positive" href="/careers/all">View roles</a>
+      <a class="p-button" href="/careers/career-explorer">Career explorer</a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom">Working here</h2>
+      <h3>Projects you'll work on</h3>
+    </div>
+    <div class="col-6">
+      <p>All of this means that administration is central to the effective running of the company. Hundreds of distributed team members count on effective processes to support their travel and operations. Our admin team run events, control expenses, manage travel and coordinate meetings. We are trusted to hold the global team accountable to the company policies. We ensure that the business operates smoothly and we have a significant impact on the quality of the experience that people have at the company.</p>
+    </div>
+  </div>
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/fcdf52cb-department-admin-%402x.jpg",
+        alt="",
+        width="2216",
+        height="834",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-6">
+      <h3>Admin at Canonical</h3>
+    </div>
+    <div class="col-6">
+      <p>We are a multi-skilled and multi-cultural team. We encourage new members of the team to develop skills across the entire range of admin challenges so that we can help one another as needed and bring our joint insights to bear on continuous improvement. Our team is largely based in offices in Austin, Boston, London, Bratislava, Beijing, Taipei and Tokyo, but we offer some flexibility to work from home. We often run company events around the world in person, so you need the latitude to be in a completely different timezone for up to two weeks at a time, three or four times a year.</p>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>See for yourself the work we're doing</h2>
+    <ul class="p-inline-list">
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical" data-size="large" aria-label="Follow @canonical on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical/canonical.com" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star canonical/canonical.com on GitHub">Star</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a class="github-button" href="https://github.com/canonical/canonical.com/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork canonical/canonical.com on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item">
+      <a href="https://www.linkedin.com/company/234280" class="p-icon--linkedin">LinkedIn</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://twitter.com/Canonical" class="p-icon--twitter">Twitter</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://www.youtube.com/user/celebrateubuntu" class="p-icon--youtube">YouTube</a>
+    </li>
+    </ul>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
+    <h3 class="p-heading--2">Find out more about Engineering</h3>
+    <!-- blogs to go here -->
+  </div>
+
+</section>
+<script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/admin.html
+++ b/templates/careers/admin.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1pNyOXfR07FiBr6TmEMRdB7NZUB5SeBz6COuSxO3ylC0{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Kfkdy1rwBUP1L-ToUVvgqv8WkwEa8SurILkwJJh8u0U/{% endblock meta_copydoc %}
 
 {% block title %}Admin | Careers{% endblock %}
 
@@ -79,7 +79,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip', heading_topic='Admin', tag_id='1486', limit='3' %}
+{% with section_classes='p-strip', heading_topic='Admin', tag_id='1216', limit='3' %}
   {% include "shared/_blog-card.html" %}
 {% endwith %}
 

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -1,10 +1,10 @@
 {% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1pNyOXfR07FiBr6TmEMRdB7NZUB5SeBz6COuSxO3ylC0{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/12GWF6eVKezvENc66p3QZ5ZEO8H2QBIlU56RPZNdCPdI/{% endblock meta_copydoc %}
 
 {% block title %}Engineering | Careers{% endblock %}
 
-{% block meta_description %}Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future.{% endblock %}
+{% block meta_description %}Open source is transforming the entire stack. This is your chance to be right at the centre of that revolution, to shape the platforms and tools that millions use to invent our global technology future.{% endblock %}
 
 {% block content %}
 <section class="p-strip--light">
@@ -50,7 +50,7 @@
     </div>
     <div class="col-6">
       <p>With the flexibility to work from anywhere in the world as long as you are an outstanding and reliable team member, Canonical offers engineering career paths that include technical mastery, leadership, or management. We don't prescribe your journey &ndash; explore different kinds of career development and choose the path that suits you best. We do expect world-leading software quality and personal dedication to the challenges you take on.</p>
-      <p>Engineering at Canonical ranges from deep single-product specialisation, to diverse customer-centric field integration, delivery and development, and high-pressure rapid-response to critical situations in our techops team. The right career for you will depend on your interests and aptitudes. If you love the idea of travel and seeing the world, our field engineers work on-site with the world’s best companies to transform their infrastructure with the cutting edge of open source. If you love saving the day, our techops teams fight fires shoulder to shoulder, from security incident response to deep problem analysis and repair. If you love operations, we take a code-first approach to infrastructure and application operations that is raising the bar for the entire industry.</p>
+      <p>Engineering at Canonical ranges from deep single-product specialisation, to diverse customer-centric field integration, delivery and development, and high-pressure rapid-response to critical situations in our techops team. The right career for you will depend on your interests and aptitudes. If you love the idea of travel and seeing the world, our field engineers work on-site with the world's best companies to transform their infrastructure with the cutting edge of open source. If you love saving the day, our techops teams fight fires shoulder to shoulder, from security incident response to deep problem analysis and repair. If you love operations, we take a code-first approach to infrastructure and application operations that is raising the bar for the entire industry.</p>
   </div>
   <div class="p-strip is-shallow">
     <hr>
@@ -91,7 +91,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip', heading_topic='Engineering', tag_id='1486', limit='3' %}
+{% with section_classes='p-strip', heading_topic='Engineering', tag_id='1564', limit='3' %}
   {% include "shared/_blog-card.html" %}
 {% endwith %}
 

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -1,30 +1,103 @@
-{% extends '/careers/base-tabs.html' %}
+{% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/14gNX9sCgQUM1H0Hfl46R3Wvw0E91XjsuyStMV4KvKME{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1pNyOXfR07FiBr6TmEMRdB7NZUB5SeBz6COuSxO3ylC0{% endblock meta_copydoc %}
 
-{% block title %}Engineering | Careers{% endblock %}
+{% block title %}Careers{% endblock %}
 
-{% block meta_description %}Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future.{% endblock %}
+{% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public clouds to certify Ubuntu.{% endblock %}
 
-{% block overview %}
-  <p>
-    <strong>Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high performance computing, from AI and big data to the web and connected devices, open source is the key ingredient for success. Canonical offers the opportunity to work across the entire spectrum.</strong>
-  </p>
-  <p>
-    We publish Ubuntu, the leanest and most efficient open source platform. We care about developer access to the very best of open source, and make it easy to innovate and publish on the cloud, on the desktop, and on smart connected devices for the internet of things. We work across the full range of open source - from the kernel, to applications, from deep system services to the GUI and the web. We care about security, correctness, reliability, performance and efficiency. If you share those values and you have a track record of exceptional software development, this is the place for you.
-  </p>
-  <p>
-    With the flexibility to work from anywhere in the world as long as you are an outstanding and reliable team member, Canonical offers engineering career paths that include technical mastery, leadership, or management. We don’t prescribe your journey - explore different kinds of career development and choose the path that suits you best. We do expect world-leading software quality and personal dedication to the challenges you take on.
-  </p>
-  <p>
-    Engineering at Canonical ranges from deep single-product specialization, to diverse customer-centric field integration, delivery and development, and high-pressure rapid-response to critical situations in our techops team. The right career for you will depend on your interests and aptitudes. If you love the idea of travel and seeing the world, our field engineers work on-site with the world’s best companies to transform their open infrastructure. If you love saving the day, our techops teams fight fires shoulder to shoulder, from security incident response to deep problem analysis and repair. If you love operations, we take a code-first approach to infrastructure and application operations that is raising the bar for the entire industry.
-  </p>
-  <p>
-    We see all of these as engineering roles and we encourage people to build a career that spans diverse aspects of software development and operations. Regardless of your starting point, you have the option to progress in any of those roles, or to gain experience in management or technical leadership.
-  </p>
-  <hr />
-  <p class="p-muted-heading">
-    <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
-  </p>
-  <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
+{% block content %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h1 class="p-heading--2">Engineering</h1>
+    </div>
+    <div class="col-6">
+      <p>Open source is transforming the entire stack. This is your chance to be right at the centre of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud and high performance computing, from AI and big data to the web and connected devices, open source is a key ingredient for success. Canonical offers the opportunity to work across the entire spectrum.</p>
+      <a class="p-button--positive" href="/careers/all">View roles</a>
+      <a class="p-button" href="/careers/career-explorer">Career explorer</a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom">Working here</h2>
+      <h3>Projects you'll work on</h3>
+    </div>
+    <div class="col-6">
+      <p>We publish Ubuntu, the leanest and most efficient open source platform. We care about developer access to the very best of open source, and make it easy to innovate and publish on the cloud, on the desktop, and on smart connected devices for the internet of things. We work across the full range of open source &ndash; from the kernel, to applications, from deep system services to the GUI and the web. We care about security, correctness, reliability, performance and efficiency. If you share those values and you have a track record of exceptional software development, this is the place for you.</p>
+    </div>
+  </div>
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/f540ae09-more-real-travel-image.png",
+        alt="",
+        width="1330",
+        height="500",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-6">
+      <h3>Engineering at Canonical</h3>
+    </div>
+    <div class="col-6">
+      <p>With the flexibility to work from anywhere in the world as long as you are an outstanding and reliable team member, Canonical offers engineering career paths that include technical mastery, leadership, or management. We don't prescribe your journey &ndash; explore different kinds of career development and choose the path that suits you best. We do expect world-leading software quality and personal dedication to the challenges you take on.</p>
+      <p>Engineering at Canonical ranges from deep single-product specialisation, to diverse customer-centric field integration, delivery and development, and high-pressure rapid-response to critical situations in our techops team. The right career for you will depend on your interests and aptitudes. If you love the idea of travel and seeing the world, our field engineers work on-site with the world’s best companies to transform their infrastructure with the cutting edge of open source. If you love saving the day, our techops teams fight fires shoulder to shoulder, from security incident response to deep problem analysis and repair. If you love operations, we take a code-first approach to infrastructure and application operations that is raising the bar for the entire industry.</p>
+  </div>
+  <div class="p-strip is-shallow">
+    <hr>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Career progression</h3>
+    </div>
+    <div class="col-6">
+      <p>We see all of these as engineering roles and we encourage people to build a career that spans diverse aspects of software development and operations. Regardless of your starting point, you have the option to progress in any of those roles, or to gain experience in management or technical leadership.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>See for yourself the work we're doing</h2>
+    <ul class="p-inline-list">
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical" data-size="large" aria-label="Follow @canonical on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical/canonical.com" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star canonical/canonical.com on GitHub">Star</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a class="github-button" href="https://github.com/canonical/canonical.com/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork canonical/canonical.com on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item">
+      <a href="https://www.linkedin.com/company/234280" class="p-icon--linkedin">LinkedIn</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://twitter.com/Canonical" class="p-icon--twitter">Twitter</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://www.youtube.com/user/celebrateubuntu" class="p-icon--youtube">YouTube</a>
+    </li>
+    </ul>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
+    <h3 class="p-heading--2">Find out more about Engineering</h3>
+    <!-- blogs to go here -->
+  </div>
+
+</section>
+<script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -91,13 +91,9 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
-    <h3 class="p-heading--2">Find out more about Engineering</h3>
-    <!-- blogs to go here -->
-  </div>
+{% with section_classes='p-strip', heading_topic='Engineering', tag_id='1486', limit='3' %}
+  {% include "shared/_blog-card.html" %}
+{% endwith %}
 
-</section>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -2,9 +2,9 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1pNyOXfR07FiBr6TmEMRdB7NZUB5SeBz6COuSxO3ylC0{% endblock meta_copydoc %}
 
-{% block title %}Careers{% endblock %}
+{% block title %}Engineering | Careers{% endblock %}
 
-{% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public clouds to certify Ubuntu.{% endblock %}
+{% block meta_description %}Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future.{% endblock %}
 
 {% block content %}
 <section class="p-strip--light">
@@ -33,12 +33,12 @@
   <div class="p-strip is-shallow">
     <div class="u-fixed-width u-hide--small u-hide--medium">
       {{ image (
-        url="https://assets.ubuntu.com/v1/f540ae09-more-real-travel-image.png",
+        url="https://assets.ubuntu.com/v1/379b19b9-department-engineering-%402x.jpg",
         alt="",
-        width="1330",
-        height="500",
+        width="2216",
+        height="834",
         hi_def=True,
-        loading="lazy",
+        loading="lazy"
         ) | safe
       }}
     </div>

--- a/templates/careers/finance.html
+++ b/templates/careers/finance.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1e6A3z1KsVNyShx2mHq3lNrYkXCaHy8x8BA7qzLxeuJ4/edit#{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1e6A3z1KsVNyShx2mHq3lNrYkXCaHy8x8BA7qzLxeuJ4/{% endblock meta_copydoc %}
 
 {% block title %}Finance | Careers{% endblock %}
 
@@ -96,7 +96,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip', heading_topic='Finance', tag_id='1486', limit='3' %}
+{% with section_classes='p-strip', heading_topic='Finance', tag_id='2533', limit='3' %}
   {% include "shared/_blog-card.html" %}
 {% endwith %}
 

--- a/templates/careers/finance.html
+++ b/templates/careers/finance.html
@@ -1,32 +1,108 @@
-{% extends '/careers/base-tabs.html' %}
+{% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1R4i26Ov-ccfrXm8uSdSRApxgXDH3HwZVY8qWQqPpIjg{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1e6A3z1KsVNyShx2mHq3lNrYkXCaHy8x8BA7qzLxeuJ4/edit#{% endblock meta_copydoc %}
 
 {% block title %}Finance | Careers{% endblock %}
 
-{% block meta_description %}Finance at Canonical isn’t just about numbers. It’s about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.{% endblock %}
+{% block meta_description %}Finance at Canonical isn't just about numbers. It's about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.{% endblock %}
 
+{% block content %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h1 class="p-heading--2">Finance</h1>
+    </div>
+    <div class="col-6">
+      <p>Finance at Canonical isn't just about numbers. It's about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.</p>
+      <a class="p-button--positive" href="/careers/all">View roles</a>
+      <a class="p-button" href="/careers/career-explorer">Career explorer</a>
+    </div>
+  </div>
+</section>
 
-{% block overview %}
-  <p><strong>Finance at Canonical isn’t just about numbers. It’s about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.</strong></p>
-  <p>
-    We fuel growth by devising innovative solutions to complex problems in forecasting, accounting, compliance, and project management. From advising all teams across the business to managing day-to-day data, you’ll help keep our business on track to meet (or, better yet, exceed) our goals.
-  </p>
-  <p>
-    With significant growth and a stated path to public markets, industry&ndash;leading analysis is essential. As part of this we:
-  </p>
-  <ul class="p-list">
-    <li class="p-list__item is-ticked">Translate complex data into actionable insights that drive strategic company decisions, whether modelling business scenarios or tracking performance metrics.</li>
-    <li class="p-list__item is-ticked">Manage large-scale projects. Develop and implement insightful strategies that address and solve our complex business needs.</li>
-    <li class="p-list__item is-ticked">Protect Canonical by partnering with our business and engineering teams to identify and address risks related to product launches and other initiatives.</li>
-    <li class="p-list__item is-ticked">Balance our legal and compliance requirements with our company values and the dynamic needs of our users, along with developing efficient systems to ensure Canonical keeps up with regulations.</li>
-  </ul>
-  <p>
-    The finance team at Canonical offers rapid growth in understanding both industry best practice with analytical excellence. We welcome candidates with an outstanding track record, a commitment to teamwork, and a personal interest in the future of software and the financial frameworks that underpin it.
-  </p>
-  <hr />
-  <p class="p-muted-heading">
-    <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
-  </p>
-  <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom">Working here</h2>
+      <h3>Projects you'll work on</h3>
+    </div>
+    <div class="col-6">
+      <p>With significant growth and a stated path to public markets, industry–leading analysis is essential. As part of this we:</p>
+      <ul>
+        <li>Translate complex data into actionable insights that drive strategic company decisions, whether modelling business scenarios or tracking performance metrics.</li>
+        <li>Manage large-scale projects. Develop and implement insightful strategies that address and solve our complex business needs.</li>
+        <li>Protect Canonical by partnering with our business and engineering teams to identify and address risks related to product launches and other initiatives.</li>
+        <li>Balance our legal and compliance requirements with our company values and the dynamic needs of our users, along with developing efficient systems to ensure Canonical keeps up with regulations.</li>
+      </ul>
+    </div>
+  </div>
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/b0df5c27-department-finance-%402x.jpg",
+        alt="",
+        width="2216",
+        height="834",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-6">
+      <h3>Finance at Canonical</h3>
+    </div>
+    <div class="col-6">
+      <p>We fuel growth by devising innovative solutions to complex problems in forecasting, accounting, compliance, and project management. From advising all teams across the business to managing day-to-day data, you’ll help keep our business on track to meet (or, better yet, exceed) our goals.</p>
+  </div>
+  <div class="p-strip is-shallow">
+    <hr>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Who you are</h3>
+    </div>
+    <div class="col-6">
+      <p>The finance team at Canonical offers rapid growth in understanding both industry best practises with analytical excellence. We welcome candidates with an outstanding track record, a commitment to teamwork, and a personal interest in the future of software and the financial frameworks that simplify how customers access our products, solutions, and support.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>See for yourself the work we're doing</h2>
+    <ul class="p-inline-list">
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical" data-size="large" aria-label="Follow @canonical on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical/canonical.com" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star canonical/canonical.com on GitHub">Star</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a class="github-button" href="https://github.com/canonical/canonical.com/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork canonical/canonical.com on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item">
+      <a href="https://www.linkedin.com/company/234280" class="p-icon--linkedin">LinkedIn</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://twitter.com/Canonical" class="p-icon--twitter">Twitter</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://www.youtube.com/user/celebrateubuntu" class="p-icon--youtube">YouTube</a>
+    </li>
+    </ul>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
+    <h3 class="p-heading--2">Find out more about Finance</h3>
+    <!-- blogs to go here -->
+  </div>
+
+</section>
+<script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/finance.html
+++ b/templates/careers/finance.html
@@ -96,13 +96,10 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
-    <h3 class="p-heading--2">Find out more about Finance</h3>
-    <!-- blogs to go here -->
-  </div>
+{% with section_classes='p-strip', heading_topic='Finance', tag_id='1486', limit='3' %}
+  {% include "shared/_blog-card.html" %}
+{% endwith %}
 
-</section>
+
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/human-resources.html
+++ b/templates/careers/human-resources.html
@@ -50,7 +50,7 @@
     </div>
     <div class="col-6">
       <p>Our set-up provides a unique challenge for our HR team, who ensure that we operate consistently on a global basis and are compliant with regional and national regulations. If you are interested in finding, coaching, and developing the best talent, Canonical encourages our management team to hire the best person for the job, no matter who they are or where they are located. If you are fascinated by the technical and legal aspects of HR, Canonical will give you the chance to work with teams in multiple jurisdictions, from Asia to the Americas and so many places in between.</p>
-      <p>Our HR team ensures that we operate consistently across our global footprint and are compliant with all regional and national regulations where we do business.  We strive to hire world-class talent regardless of their location, we're not burdened by traditional models that only market to certain cities or require team members to reside where an office is.  If you have a passion for the technical, legal, and interpersonal aspects of HR, Canonical provides an array of opportunties to make impactful change while working with teams from Asia-Pacific to the Americas and many places in between.</p>
+      <p>Our HR team ensures that we operate consistently across our global footprint and are compliant with all regional and national regulations where we do business.  We strive to hire world-class talent regardless of their location, we're not burdened by traditional models that only market to certain cities or require team members to reside where an office is.  If you have a passion for the technical, legal, and interpersonal aspects of HR, Canonical provides an array of opportunities to make impactful change while working with teams from Asia-Pacific to the Americas and many places in between.</p>
     </div>
   </div>
 </section>
@@ -81,7 +81,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip', heading_topic='Human resources', tag_id='1486', limit='3' %}
+{% with section_classes='p-strip', heading_topic='Human Resources', tag_id='1216', limit='3' %}
   {% include "shared/_blog-card.html" %}
 {% endwith %}
 

--- a/templates/careers/human-resources.html
+++ b/templates/careers/human-resources.html
@@ -81,13 +81,9 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
-    <h3 class="p-heading--2">Find out more about Engineering</h3>
-    <!-- blogs to go here -->
-  </div>
+{% with section_classes='p-strip', heading_topic='Human resources', tag_id='1486', limit='3' %}
+  {% include "shared/_blog-card.html" %}
+{% endwith %}
 
-</section>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/human-resources.html
+++ b/templates/careers/human-resources.html
@@ -1,25 +1,93 @@
-{% extends '/careers/base-tabs.html' %}
+{% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/14YcOjgNRr6k4JQCSB-Qs5MxVO-JNd2P-HjxzGFDvZkY{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1sj-WToRUa9N2c5brs8iAoOfOPHJCeHwvHByq8qcSgK4{% endblock meta_copydoc %}
 
 {% block title %}Human Resources | Careers{% endblock %}
 
-
 {% block meta_description %}Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide, bringing together.{% endblock %}
 
+{% block content %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h1 class="p-heading--2">Human Resources</h1>
+    </div>
+    <div class="col-6">
+      <p> Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 60 countries worldwide, bringing together distinct and diverse perspectives to contribute to the advancement of state-of-the-art technical infrastructure. Our team is united by a passion for open engineering and a commitment to crisp, reliable execution which enables us to exceed our customers' expectations when it comes to next-gen open source technology.</p>
+      <a class="p-button--positive" href="/careers/all">View roles</a>
+      <a class="p-button" href="/careers/career-explorer">Career explorer</a>
+    </div>
+  </div>
+</section>
 
-{% block overview %}
-  <p><strong>Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide, bringing together distinct and diverse perspectives to contribute to the advancement of state-of-the-art technical infrastructure. Our team is united by a passion for open engineering and a commitment to crisp, reliable execution which enables us to exceed our customers’ expectations when it comes to next-generation open source technology.</strong>
-  </p>
-  <p>
-    Our set-up provides a unique challenge for our HR team, who ensure that we operate consistently on a global basis and are compliant with regional and national regulations. If you are interested in finding, coaching, and developing the best talent, Canonical encourages our management team to hire the best person for the job, no matter who they are or where they are located. If you are fascinated by the technical and legal aspects of HR, Canonical will give you the chance to work with teams in multiple jurisdictions, from Asia to the Americas and so many places in between.
-  </p>
-  <p>
-    We pride ourselves on exceptional quality of work and our HR team embody and build that quality within Canonical. Our HR team is central to the development and growth of that capacity and competence. Our commitment to the team is to seek out potential colleagues with the right mix of interests, aptitudes and attitudes, to coach and develop them through a varied career ensuring that they have the right opportunities to learn and the right mix of challenges to suit their interests. Our commitment to the business is to ensure that we operate consistently on a global basis, mindful of the details of regional and national regulations. We are also committed to offering our HR and talent professionals the coaching, learning opportunities, and challenges that will enable them to create a varied and successful career.
-  </p>
-  <hr />
-  <p class="p-muted-heading">
-    <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
-  </p>
-  <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom">Working here</h2>
+      <h3>HR at Canonical</h3>
+    </div>
+    <div class="col-6">
+      <p>We pride ourselves on exceptional quality of work and our HR team embody and build that quality within Canonical. Our HR team is central to the development and growth of that capacity and competence. Our commitment to the team is to seek out potential colleagues with the right mix of interests, ambitions, aptitudes and attitudes, to coach and develop them through a varied career ensuring that they have the right opportunities to learn and grow. Our commitment to the business is to ensure that we operate consistently on a global basis, mindful of regional and national regulations. We are also committed to offering our HR and talent professionals the coaching, learning opportunities, and challenges that will enable them to create a varied and successful career.</p>
+    </div>
+  </div>
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/cdb9248f-department-hr-%402x.jpg",
+        alt="",
+        width="2216",
+        height="834",
+        hi_def=True,
+        loading="auto|lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-6">
+      <h3>Who you are</h3>
+    </div>
+    <div class="col-6">
+      <p>Our set-up provides a unique challenge for our HR team, who ensure that we operate consistently on a global basis and are compliant with regional and national regulations. If you are interested in finding, coaching, and developing the best talent, Canonical encourages our management team to hire the best person for the job, no matter who they are or where they are located. If you are fascinated by the technical and legal aspects of HR, Canonical will give you the chance to work with teams in multiple jurisdictions, from Asia to the Americas and so many places in between.</p>
+      <p>Our HR team ensures that we operate consistently across our global footprint and are compliant with all regional and national regulations where we do business.  We strive to hire world-class talent regardless of their location, we're not burdened by traditional models that only market to certain cities or require team members to reside where an office is.  If you have a passion for the technical, legal, and interpersonal aspects of HR, Canonical provides an array of opportunties to make impactful change while working with teams from Asia-Pacific to the Americas and many places in between.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>See for yourself the work we're doing</h2>
+    <ul class="p-inline-list">
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical" data-size="large" aria-label="Follow @canonical on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical/canonical.com" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star canonical/canonical.com on GitHub">Star</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a class="github-button" href="https://github.com/canonical/canonical.com/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork canonical/canonical.com on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item">
+      <a href="https://www.linkedin.com/company/234280" class="p-icon--linkedin">LinkedIn</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://twitter.com/Canonical" class="p-icon--twitter">Twitter</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://www.youtube.com/user/celebrateubuntu" class="p-icon--youtube">YouTube</a>
+    </li>
+    </ul>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
+    <h3 class="p-heading--2">Find out more about Engineering</h3>
+    <!-- blogs to go here -->
+  </div>
+
+</section>
+<script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/legal.html
+++ b/templates/careers/legal.html
@@ -1,27 +1,93 @@
-{% extends '/careers/base-tabs.html' %}
+{% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1aZSmg1coz5QKm-NLgzU0BwQbqIaGlwDzPGVH3Yju66k{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1TcKYSlfV2G9X_0l-T6rZ-CWd_XJQ_4hHQCPL2CVrCts{% endblock meta_copydoc %}
 
 {% block title %}Legal | Careers{% endblock %}
 
 {% block meta_description %}Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change.{% endblock %}
 
+{% block content %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h1 class="p-heading--2">Legal</h1>
+    </div>
+    <div class="col-6">
+      <p>Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change of the software landscape to open infrastructure and applications, while supporting a fast-moving and global business.</p>
+      <a class="p-button--positive" href="/careers/all">View roles</a>
+      <a class="p-button" href="/careers/career-explorer">Career explorer</a>
+    </div>
+  </div>
+</section>
 
-{% block overview %}
-  <p><strong>Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change of the software landscape to open infrastructure and applications, while supporting a fast-moving and global business.</strong>
-  </p>
-  <p>
-    Enabling enterprises, partners and technology providers across the globe to embrace the latest open source technology means efficient contracting that is both commercially sophisticated and technically interesting. We shape multinational agreements between many of the very largest organisations in a wide range of industries - from telecommunications to retail, financial services to media. And we participate in the world wide process to define and understand the future of collaborative engineering, as open source licenses explore new ways to support the creation of open software by companies and individual contributors.
-  </p>
-  <p>
-    Our goal is to reflect the simplest, cleanest and most understandable contractual framework to our counterparts, that represents current best practice and the latest approaches to software production, consumption and distribution. We pride ourselves on the combination of rigour and business enablement - we support complex deals in a way that protects all parties and minimises friction.
-  </p>
-  <p>
-    Experience at Canonical offers rapid growth in understanding the global legal landscape, both in terms of technology, but also in terms of commercial and corporate contracting. We welcome candidates with an outstanding track record, a commitment to teamwork, and a personal interest in the future of software and the legal frameworks that underpin it.
-  </p>
-  <hr />
-  <p class="p-muted-heading">
-    <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
-  </p>
-  <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom">Working here</h2>
+      <h3>Projects you'll work on</h3>
+    </div>
+    <div class="col-6">
+      <p>Enabling enterprises, partners and technology providers across the globe to embrace the latest open source technology means efficient contracting that is both commercially sophisticated and technically interesting. We shape multinational agreements between many of the very largest organisations in a wide range of industries &ndash; from telecommunications to retail, financial services to media. And we participate in the world wide process to define and understand the future of collaborative engineering, as open source licences explore new ways to support the creation of open software by companies and individual contributors.</p>
+      <p>Our goal is to reflect the simplest, cleanest and most understandable contractual framework to our counterparts, that represents current best practice and the latest approaches to software production, consumption and distribution. We pride ourselves on the combination of rigour and business enablement &ndash; we support complex deals in a way that protects all parties and minimises friction.</p>
+    </div>
+  </div>
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/815e6e4a-department-legal-%402x.jpg",
+        alt="",
+        width="2216",
+        height="834",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-6">
+      <h3>Who you are</h3>
+    </div>
+    <div class="col-6">
+      <p>Experience at Canonical offers rapid growth in understanding the global legal landscape, both in terms of technology, but also in terms of commercial and corporate contracting. We welcome candidates with an outstanding track record, a commitment to teamwork, and a personal interest in the future of software and the legal frameworks that underpin it.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>See for yourself the work we're doing</h2>
+    <ul class="p-inline-list">
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical" data-size="large" aria-label="Follow @canonical on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical/canonical.com" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star canonical/canonical.com on GitHub">Star</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a class="github-button" href="https://github.com/canonical/canonical.com/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork canonical/canonical.com on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item">
+      <a href="https://www.linkedin.com/company/234280" class="p-icon--linkedin">LinkedIn</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://twitter.com/Canonical" class="p-icon--twitter">Twitter</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://www.youtube.com/user/celebrateubuntu" class="p-icon--youtube">YouTube</a>
+    </li>
+    </ul>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
+    <h3 class="p-heading--2">Find out more about Engineering</h3>
+    <!-- blogs to go here -->
+  </div>
+
+</section>
+<script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/legal.html
+++ b/templates/careers/legal.html
@@ -81,13 +81,9 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
-    <h3 class="p-heading--2">Find out more about Engineering</h3>
-    <!-- blogs to go here -->
-  </div>
+{% with section_classes='p-strip', heading_topic='Legal', tag_id='1486', limit='3' %}
+  {% include "shared/_blog-card.html" %}
+{% endwith %}
 
-</section>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/legal.html
+++ b/templates/careers/legal.html
@@ -81,7 +81,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip', heading_topic='Legal', tag_id='1486', limit='3' %}
+{% with section_classes='p-strip', heading_topic='Legal', tag_id='1216', limit='3' %}
   {% include "shared/_blog-card.html" %}
 {% endwith %}
 

--- a/templates/careers/marketing.html
+++ b/templates/careers/marketing.html
@@ -92,13 +92,9 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
-    <h3 class="p-heading--2">Find out more about Engineering</h3>
-    <!-- blogs to go here -->
-  </div>
+{% with section_classes='p-strip', heading_topic='Marketing', tag_id='1486', limit='3' %}
+  {% include "shared/_blog-card.html" %}
+{% endwith %}
 
-</section>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/marketing.html
+++ b/templates/careers/marketing.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1Eq3USN12tdL1sEf0DMYxO9FAJ5Vqkrl_yeYdRsfWNww/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1larR0nWbVEqeUQbIJdgWemr7I6cqzoUhA9MD6sRQZwE{% endblock meta_copydoc %}
 
 {% block title %}Marketing | Careers{% endblock %}
 
@@ -92,7 +92,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip', heading_topic='Marketing', tag_id='1486', limit='3' %}
+{% with section_classes='p-strip', heading_topic='Marketing', tag_id='1216', limit='3' %}
   {% include "shared/_blog-card.html" %}
 {% endwith %}
 

--- a/templates/careers/marketing.html
+++ b/templates/careers/marketing.html
@@ -1,34 +1,104 @@
-{% extends '/careers/base-tabs.html' %}
+{% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1e35Ux74NQ5s4XCUqLFnRAukCJca7AvWDZWofHz1Y2go{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Eq3USN12tdL1sEf0DMYxO9FAJ5Vqkrl_yeYdRsfWNww/edit{% endblock meta_copydoc %}
 
 {% block title %}Marketing | Careers{% endblock %}
 
 {% block meta_description %}We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.{% endblock %}
 
+{% block content %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h1 class="p-heading--2">Marketing</h1>
+    </div>
+    <div class="col-6">
+      <p>We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.</p>
+      <a class="p-button--positive" href="/careers/all">View roles</a>
+      <a class="p-button" href="/careers/career-explorer">Career explorer</a>
+    </div>
+  </div>
+</section>
 
-{% block overview %}
-  <p>
-    <strong>We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.</strong>
-  </p>
-  <p>
-    The best candidates for marketing at Canonical love technology and words. They are tech-savvy and are comfortable working with data at scale - in spreadsheets, business analytics suites and databases. They love data visualisation and presentation. They are passionate about message and language, and strive to find the best way to share a powerful idea that leads people to act.
-  </p>
-  <p>
-    Canonical has a global following of sophisticated tech readers and decision makers, constantly evaluating the state of the art for open infrastructure and applications. Your mission is to reach them at precisely the right moment with clear information showing that Ubuntu and Canonical’s solutions deliver the very best in quality and economics. It’s a fast-paced, high stakes responsibility that demands a high level of intellect and work ethic.
-  </p>
-  <p>
-    Our team also understands that it’s not just about broadcast, it’s about feedback, measurement, iteration and improvement. We use analytics to understand how the world is consuming our narrative, and technology to sift through mountains of engagement data to spot the opportunities that are ready to explore further. We delight in showing that we can engineer growth in engagement, awareness, consumption and commerce just as effectively as our colleagues in software development engineer reliability and performance in their products. We are growth hackers at heart. As the tools evolve, so do we, which creates a learning environment that celebrates new ideas which can prove their effectiveness. We’re a tiny company in an industry of giants, so we have always punched way above our weight and that’s exactly what we expect from new members of the team too.
-  </p>
-  <p>
-    In marketing you are a representative of Canonical and you are an advocate of our brands and products. We all work together across the full portfolio - you are expected to understand the big picture of how Canonical’s products fit together, there are no siloes. These are not behind-the-scenes roles, they are public leadership roles. We expect our team to be just as comfortable delivering our message online as they are face to face at meetups, meetings, conferences, partner workshops, or press events. From the analyst community to the tech press, from the CIO to the graduate engineer, from prospects to existing customers, we think Ubuntu should be the starting point for technology transformation around open source, and our marketing team are the amplifier for our message.
-  </p>
-  <p>
-    This team is all about having the confidence in our ideas and our quality to put us squarely into the frame for companies thinking afresh about their biggest technology questions. Join us if you are passionate about digital marketing and technology products.
-  </p>
-  <hr />
-  <p class="p-muted-heading">
-    <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
-  </p>
-  <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom">Working here</h2>
+      <h3>Projects you'll work on</h3>
+    </div>
+    <div class="col-6">
+      <p>In marketing you are a representative of Canonical and you are an advocate of our brands and products. We all work together across the full portfolio &ndash; you are expected to understand the big picture of how Canonical's products fit together, there are no siloes. These are not behind-the-scenes roles, they are public leadership roles. We expect our team to be just as comfortable delivering our message online as they are face to face at meetups, meetings, conferences, partner workshops, or press events. From the analyst community to the tech press, from the CIO to the graduate engineer, from prospects to existing customers, we think Ubuntu should be the starting point for technology transformation around open source, and our marketing team are the amplifier for our message.</p>
+      <p>This team is all about having the confidence in our ideas and our quality to put us squarely into the frame for companies thinking afresh about their biggest technology questions. Join us if you are passionate about digital marketing and technology products.</p>
+    </div>
+  </div>
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width u-hide--small u-hide--medium">     
+      {{ image (
+        url="https://assets.ubuntu.com/v1/df050be9-department-marketing-%402x.jpg",
+        alt="",
+        width="2216",
+        height="834",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-6">
+      <h3>Marketing at Canonical</h3>
+    </div>
+    <div class="col-6">
+      <p>Our team also understands that it's not just about broadcast, it's about feedback, measurement, iteration and improvement. We use analytics to understand how the world is consuming our narrative, and technology to sift through mountains of engagement data to spot the opportunities that are ready to explore further. We delight in showing that we can engineer growth in engagement, awareness, consumption and commerce just as effectively as our colleagues in software development engineer reliability and performance in their products. We are growth hackers at heart. As the tools evolve, so do we, which creates a learning environment that celebrates new ideas which can prove their effectiveness. We're a tiny company in an industry of giants, so we have always punched way above our weight and that’s exactly what we expect from new members of the team too.</p>
+  </div>
+  <div class="p-strip is-shallow">
+    <hr>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Who you are</h3>
+    </div>
+    <div class="col-6">
+      <p>The best candidates for marketing at Canonical love technology and words. They are tech-savvy and are comfortable working with data at scale &ndash; in spreadsheets, business analytics suites and databases. They love data visualisation and presentation. They are passionate about message and language, and strive to find the best way to share a powerful idea that leads people to act.</p>
+      <p>Canonical has a global following of sophisticated tech readers and decision makers, constantly evaluating the state of the art for open infrastructure and applications. Your mission is to reach them at precisely the right moment with clear information showing that Ubuntu and Canonical's solutions deliver the very best in quality and economics. It’s a fast-paced, high stakes responsibility that demands a high level of intellect and work ethic.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>See for yourself the work we're doing</h2>
+    <ul class="p-inline-list">
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical" data-size="large" aria-label="Follow @canonical on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical/canonical.com" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star canonical/canonical.com on GitHub">Star</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a class="github-button" href="https://github.com/canonical/canonical.com/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork canonical/canonical.com on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item">
+      <a href="https://www.linkedin.com/company/234280" class="p-icon--linkedin">LinkedIn</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://twitter.com/Canonical" class="p-icon--twitter">Twitter</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://www.youtube.com/user/celebrateubuntu" class="p-icon--youtube">YouTube</a>
+    </li>
+    </ul>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
+    <h3 class="p-heading--2">Find out more about Engineering</h3>
+    <!-- blogs to go here -->
+  </div>
+
+</section>
+<script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/operations.html
+++ b/templates/careers/operations.html
@@ -79,7 +79,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip', heading_topic='Operations', tag_id='1486', limit='3' %}
+{% with section_classes='p-strip', heading_topic='Operations', tag_id='3819', limit='3' %}
   {% include "shared/_blog-card.html" %}
 {% endwith %}
 

--- a/templates/careers/operations.html
+++ b/templates/careers/operations.html
@@ -1,26 +1,91 @@
-{% extends '/careers/base-tabs.html' %}
+{% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1y2bqWcHW2rRrb5gA7XTt8_A0q6zPOLkkOIwCIaNLpTk/edit
-{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1zLFku18ZAMVStgkIO3bCoKEXW6ShwMEkB0w9d_nCx9U/{% endblock meta_copydoc %}
 
 {% block title %}Operations | Careers{% endblock %}
 
 {% block meta_description %}Excellence in operations enables Canonical to scale efficiently. We look for people who are passionate about tools and efficiency.{% endblock %}
 
-{% block overview %}
-  <p>
-    <strong>
-      Excellence in operations enables Canonical to scale efficiently. Our core operations &mdash; from IT to commercial operations or logistics &mdash; is central to the idea that we can be an effective global distributed company serving advanced customers in every geography. We celebrate relentless improvement. We look for people who are passionate about tools and efficiency, who are focused on measurement, feedback and continuous improvement, and who will take the time to help their colleagues and counterparts improve.
-    </strong>
-  </p>
+{% block content %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h1 class="p-heading--2">Operations</h1>
+    </div>
+    <div class="col-6">
+      <p>Excellence in operations enables Canonical to scale efficiently. Our core operations $ndash; from IT to commercial operations or logistics &ndash; is central to the idea that we can be an effective global distributed company serving advanced customers in every geography. We celebrate relentless improvement. We look for people who are passionate about tools and efficiency, who are focused on measurement, feedback and continuous improvement, and who will take the time to help their colleagues and counterparts improve.</p>
+      <a class="p-button--positive" href="/careers/all">View roles</a>
+      <a class="p-button" href="/careers/career-explorer">Career explorer</a>
+    </div>
+  </div>
+</section>
 
-  <p>Getting it done right is the best feeling in the world. No shortcuts, no loose ends, no waste. It&rsquo;s only possible to operate with mastery if you understand the domain deeply, you prioritise re-use and iteration, and you bring a sharp mind to the problem. A well-run operation invests in improving its data and its tools to elevate its self-awareness and automate its processes. Fighting fires is the exception, not the norm, and those moments are an opportunity to learn and improve.</p>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom">Working here</h2>
+      <h3>Operations at Canonical</h3>
+    </div>
+    <div class="col-6">
+      <p>Getting it done right is the best feeling in the world. No shortcuts, no loose ends, no waste. It's only possible to operate with mastery if you understand the domain deeply, you prioritise re-use and iteration, and you bring a sharp mind to the problem. A well-run operation invests in improving its data and its tools to elevate its self-awareness and automate its processes. Fighting fires is the exception, not the norm, and those moments are an opportunity to learn and improve.</p>
+    </div>
+  </div>
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/a93df5b0-department-operations-%402x.jpg",
+        alt="",
+        width="2216",
+        height="834",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-6">
+      <h3>Who you are</h3>
+    </div>
+    <div class="col-6">
+      <p>Whether it's running complex technical infrastructure or challenging projects, your consistent focus on data, your willingness to learn, and your personal organisation and teamwork means you're a force for good in the battle against entropy. Time zones are easy and technical customers are your favourite. If that's you &ndash; then there's room for you at Canonical. We don't just run a great business, we run the infrastructure and applications that power many great businesses.</p>
+  </div>
+</section>
 
-  <p>Whether it&rsquo;s running complex technical infrastructure or challenging projects, your consistent focus on data, your willingness to learn, and your personal organisation and teamwork means you&rsquo;re a force for good in the battle against entropy. Time zones are easy and technical customers are your favourite. If that&rsquo;s you - then there&rsquo;s room for you at Canonical. We don&rsquo;t just run a great business, we run the infrastructure and applications that power many great businesses.</p>
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>See for yourself the work we're doing</h2>
+    <ul class="p-inline-list">
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical" data-size="large" aria-label="Follow @canonical on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical/canonical.com" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star canonical/canonical.com on GitHub">Star</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a class="github-button" href="https://github.com/canonical/canonical.com/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork canonical/canonical.com on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item">
+      <a href="https://www.linkedin.com/company/234280" class="p-icon--linkedin">LinkedIn</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://twitter.com/Canonical" class="p-icon--twitter">Twitter</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://www.youtube.com/user/celebrateubuntu" class="p-icon--youtube">YouTube</a>
+    </li>
+    </ul>
+  </div>
+</section>
 
-  <hr />
-  <p class="p-muted-heading">
-    <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
-  </p>
-  <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
+    <h3 class="p-heading--2">Find out more about Engineering</h3>
+    <!-- blogs to go here -->
+  </div>
+
+</section>
+<script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/operations.html
+++ b/templates/careers/operations.html
@@ -79,13 +79,9 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
-    <h3 class="p-heading--2">Find out more about Engineering</h3>
-    <!-- blogs to go here -->
-  </div>
+{% with section_classes='p-strip', heading_topic='Operations', tag_id='1486', limit='3' %}
+  {% include "shared/_blog-card.html" %}
+{% endwith %}
 
-</section>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/project-management.html
+++ b/templates/careers/project-management.html
@@ -4,7 +4,7 @@
 
 {% block title %}Project Management | Careers{% endblock %}
 
-{% block meta_description %}Canonical’s Engagement Project Management Office team owns, drives and communicates delivery excellence by providing strong Project process guidelines,  project continuity and data analytics.{% endblock %}
+{% block meta_description %}Canonical's Engagement Project Management Office team owns, drives and communicates delivery excellence by providing strong Project process guidelines,  project continuity and data analytics.{% endblock %}
 
 {% block content %}
 <section class="p-strip--light">
@@ -92,13 +92,9 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
-    <h3 class="p-heading--2">Find out more about Engineering</h3>
-    <!-- blogs to go here -->
-  </div>
+{% with section_classes='p-strip', heading_topic='Project Management', tag_id='1486', limit='3' %}
+  {% include "shared/_blog-card.html" %}
+{% endwith %}
 
-</section>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/project-management.html
+++ b/templates/careers/project-management.html
@@ -4,7 +4,7 @@
 
 {% block title %}Project Management | Careers{% endblock %}
 
-{% block meta_description %}Canonical's Engagement Project Management Office team owns, drives and communicates delivery excellence by providing strong Project process guidelines,  project continuity and data analytics.{% endblock %}
+{% block meta_description %}Canonical's Engagement Project Management Office team owns, drives and communicates delivery excellence by providing strong Project process guidelines, project continuity and data analytics.{% endblock %}
 
 {% block content %}
 <section class="p-strip--light">
@@ -27,8 +27,7 @@
       <h3>Projects you'll work on</h3>
     </div>
     <div class="col-6">
-      <p>In marketing you are a representative of Canonical and you are an advocate of our brands and products. We all work together across the full portfolio &ndash; you are expected to understand the big picture of how Canonical's products fit together, there are no siloes. These are not behind-the-scenes roles, they are public leadership roles. We expect our team to be just as comfortable delivering our message online as they are face to face at meetups, meetings, conferences, partner workshops, or press events. From the analyst community to the tech press, from the CIO to the graduate engineer, from prospects to existing customers, we think Ubuntu should be the starting point for technology transformation around open source, and our marketing team are the amplifier for our message.</p>
-      <p>This team is all about having the confidence in our ideas and our quality to put us squarely into the frame for companies thinking afresh about their biggest technology questions. Join us if you are passionate about digital marketing and technology products.</p>
+      <p>Project and program managers at Canonical lead the delivery of a wide variety of projects ranging from commercial customer projects, like enablement of Ubuntu on new hardware and the delivery of complex private clouds, to internal Canonical strategic projects and programs.</p>
     </div>
   </div>
   <div class="p-strip is-shallow">
@@ -47,11 +46,11 @@
   
   <div class="row">
     <div class="col-6">
-      <h3>Projecty Management at Canonical</h3>
+      <h3>Project Management at Canonical</h3>
     </div>
     <div class="col-6">
-      <p>Project managers create, manage and maintain project-specific schedules ensuring projects are delivered within time, resource and scope expectations. Each project manager is responsible for multiple projects simultaneously. Managing each project through its life-cycle and ensuring that the goals for both Canonical and the client are met.</p>
-      <p>One advanced role is the Technical Program Manager, who provides technical account leadership and insight as the primary technical interface for our key enterprise accounts. The Technical Program Manager is a high-profile technical engagement program management position where customer relationship management and advocacy for Canonical's technical assets are strategically crucial.ntum.</p>
+      <p>Canonical Project managers spearhead Canonical's Execution Excellence Strategy. They are responsible for ensuring project success through owning, driving, communicating and respectfully engaging all stakeholders, valuing integrity and accountability.Project managers at Canonical, create, manage and maintain project-specific schedules ensuring projects are delivered within time, resource and scope expectations. Each project manager is responsible for multiple projects simultaneously. Managing each project through its life-cycle and ensuring that the goals for both Canonical and the client are met.</p>
+      <p>One advanced role is the Technical Program Manager, who provides technical account leadership and insight as the primary technical interface for our key enterprise accounts. The Technical Program Manager is a high-profile technical engagement program management position where customer relationship management and advocacy for Canonical's technical assets are strategically crucial.</p>
     </div>
   <div class="p-strip is-shallow">
     <hr>
@@ -92,7 +91,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip', heading_topic='Project Management', tag_id='1486', limit='3' %}
+{% with section_classes='p-strip', heading_topic='Project Management', tag_id='1216', limit='3' %}
   {% include "shared/_blog-card.html" %}
 {% endwith %}
 

--- a/templates/careers/project-management.html
+++ b/templates/careers/project-management.html
@@ -1,26 +1,104 @@
-{% extends '/careers/base-tabs.html' %}
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1hc5olKZcPIHFtxYAHvYFS_c-NZIYy3ZT8WqG7r021MI/{% endblock meta_copydoc %}
 
 {% block title %}Project Management | Careers{% endblock %}
 
 {% block meta_description %}Canonical’s Engagement Project Management Office team owns, drives and communicates delivery excellence by providing strong Project process guidelines,  project continuity and data analytics.{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1IMXbRXvmvSKe_SrKvEiQIRCwz3I9BfVcQRQuHODaG8s{% endblock meta_copydoc %}
+{% block content %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h1 class="p-heading--2">Project Management</h1>
+    </div>
+    <div class="col-6">
+      <p>Project Managers at Canonical are engaged during all phases of the project, from pre-sales support to delivery to the handoff of complete projects to support or managed services.</p>
+      <a class="p-button--positive" href="/careers/all">View roles</a>
+      <a class="p-button" href="/careers/career-explorer">Career explorer</a>
+    </div>
+  </div>
+</section>
 
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom">Working here</h2>
+      <h3>Projects you'll work on</h3>
+    </div>
+    <div class="col-6">
+      <p>In marketing you are a representative of Canonical and you are an advocate of our brands and products. We all work together across the full portfolio &ndash; you are expected to understand the big picture of how Canonical's products fit together, there are no siloes. These are not behind-the-scenes roles, they are public leadership roles. We expect our team to be just as comfortable delivering our message online as they are face to face at meetups, meetings, conferences, partner workshops, or press events. From the analyst community to the tech press, from the CIO to the graduate engineer, from prospects to existing customers, we think Ubuntu should be the starting point for technology transformation around open source, and our marketing team are the amplifier for our message.</p>
+      <p>This team is all about having the confidence in our ideas and our quality to put us squarely into the frame for companies thinking afresh about their biggest technology questions. Join us if you are passionate about digital marketing and technology products.</p>
+    </div>
+  </div>
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width u-hide--small u-hide--medium">     
+      {{ image (
+        url="https://assets.ubuntu.com/v1/6195ae44-department-project-management-%402x.jpg",
+        alt="",
+        width="2216",
+        height="834",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-6">
+      <h3>Projecty Management at Canonical</h3>
+    </div>
+    <div class="col-6">
+      <p>Project managers create, manage and maintain project-specific schedules ensuring projects are delivered within time, resource and scope expectations. Each project manager is responsible for multiple projects simultaneously. Managing each project through its life-cycle and ensuring that the goals for both Canonical and the client are met.</p>
+      <p>One advanced role is the Technical Program Manager, who provides technical account leadership and insight as the primary technical interface for our key enterprise accounts. The Technical Program Manager is a high-profile technical engagement program management position where customer relationship management and advocacy for Canonical's technical assets are strategically crucial.ntum.</p>
+    </div>
+  <div class="p-strip is-shallow">
+    <hr>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Who you are</h3>
+    </div>
+    <div class="col-6">
+      <p>All Program Managers are responsible for facilitating customer-focused collaboration, team upskilling and driving innovation initiatives. Program managers proactively evaluate enterprise client situations and drive client vision that could ultimately lead to additional revenue-generating business opportunities.</p>
+    </div>
+  </div>
+</section>
 
-{% block overview %}
-  <p><strong>Project Managers at Canonical are engaged during all phases of the project, from pre-sales support to delivery to the handoff of complete projects to support or managed services.</strong></p>
-  <p>
-    Project managers create, manage and maintain project-specific schedules ensuring projects are delivered within time, resource and scope expectations. Each project manager is responsible for multiple projects simultaneously. Managing each project through its life-cycle and ensuring that the goals for both Canonical and the client are met.
-  </p>
-  <p>
-    One advanced role is the Technical Program Manager, who provides technical account leadership and insight as the primary technical interface for our key enterprise accounts. The Technical Program Manager is a high-profile technical engagement program management position where customer relationship management and advocacy for Canonical's technical assets are strategically crucial.
-  </p>
-  <p>
-    All Program Managers are responsible for facilitating customer-focused collaboration, team upskilling and driving innovation initiatives. Program managers proactively evaluate enterprise client situations and drive client vision that could ultimately lead to additional revenue-generating business opportunities.
-  </p>
-  <hr />
-  <p class="p-muted-heading">
-    <span style="text-transform: capitalize">EMEA&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
-  </p>
-  <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>See for yourself the work we're doing</h2>
+    <ul class="p-inline-list">
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical" data-size="large" aria-label="Follow @canonical on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical/canonical.com" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star canonical/canonical.com on GitHub">Star</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a class="github-button" href="https://github.com/canonical/canonical.com/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork canonical/canonical.com on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item">
+      <a href="https://www.linkedin.com/company/234280" class="p-icon--linkedin">LinkedIn</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://twitter.com/Canonical" class="p-icon--twitter">Twitter</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://www.youtube.com/user/celebrateubuntu" class="p-icon--youtube">YouTube</a>
+    </li>
+    </ul>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
+    <h3 class="p-heading--2">Find out more about Engineering</h3>
+    <!-- blogs to go here -->
+  </div>
+
+</section>
+<script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/sales.html
+++ b/templates/careers/sales.html
@@ -49,7 +49,7 @@
       <h3>Sales at Canonical</h3>
     </div>
     <div class="col-6">
-      <p>Enterprises love Ubuntu and  Enterprises deploy Open Source . Become the trusted advisor and work on multi-million dollar contracts to build, support and manage open source projects to drive innovation.</p>
+      <p>Enterprises love Ubuntu and Enterprises deploy Open Source. Become the trusted advisor and work on multi-million dollar contracts to build, support and manage open source projects to drive innovation.</p>
   </div>
   <div class="p-strip is-shallow">
     <hr>
@@ -92,7 +92,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip', heading_topic='Sales', tag_id='1486', limit='3' %}
+{% with section_classes='p-strip', heading_topic='Sales', tag_id='2307', limit='3' %}
   {% include "shared/_blog-card.html" %}
 {% endwith %}
 

--- a/templates/careers/sales.html
+++ b/templates/careers/sales.html
@@ -1,27 +1,104 @@
-{% extends '/careers/base-tabs.html' %}
+{% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1fGBFiIfy7C58UXcJ0Q7q6VKxClxBfPyeWBSyO9GrStI{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1yCukmqr7do6iJgl6hKui9lAslWJ6Gol4O2E5ctCE7PY{% endblock meta_copydoc %}
 
 {% block title %}Sales | Careers{% endblock %}
 
 {% block meta_description %}Canonical is looking for Sales Professionals that are Trusted Advisors which bring confidence to our customers that we understand their transformation to multi-cloud, and we can bring the right solutions to the table in order to solve those problems.{% endblock %}
 
-{% block overview %}
-  <p>
-    <strong>You love technology, and you love doing business. You know what the enterprise technology future looks like, and you enjoy helping customers get there.</strong>
-  </p>
-  <p>
-    Your approach is consultative, you are results and goal-oriented, and you know how to invest your time to maximise the benefit for customers and the company.
-  </p>
-  <p>
-    You build long term relationships, and you always promote the approach that is in the customers best interests, regardless of short term consequences. You are interested in the state of the art, you love to represent a company that knows how to transform customer operations, and you are keen to see new customers benefit from that knowledge.
-  </p>
-  <p>
-    You are organised, persistent, friendly and hard-working. You are effective in a digital world, keeping track of your plans and your progress, collaborating with colleagues to deliver for your customers. You are professionally competitive - respectful of the competition and determined to improve until you win regularly.
-  </p>
-  <hr />
-  <p class="p-muted-heading">
-    <span style="text-transform: capitalize">EMEA&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;Asia-Pacific</span>
-  </p>
-  <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
+{% block content %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h1 class="p-heading--2">Sales</h1>
+    </div>
+    <div class="col-6">
+      <p>You love technology, and you love doing business. You know what the enterprise technology future looks like, and you enjoy helping customers get there.</p>
+      <a class="p-button--positive" href="/careers/all">View roles</a>
+      <a class="p-button" href="/careers/career-explorer">Career explorer</a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom">Working here</h2>
+      <h3>Projects you'll work on</h3>
+    </div>
+    <div class="col-6">
+      <p>You will help your customers to use and deploy Open Source software at scale and make it secure.</p>
+    </div>
+  </div>
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/9acad1b0-department-sales-%402x.jpg",
+        alt="",
+        width="2216",
+        height="834",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-6">
+      <h3>Sales at Canonical</h3>
+    </div>
+    <div class="col-6">
+      <p>Enterprises love Ubuntu and  Enterprises deploy Open Source . Become the trusted advisor and work on multi-million dollar contracts to build, support and manage open source projects to drive innovation.</p>
+  </div>
+  <div class="p-strip is-shallow">
+    <hr>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Who you are</h3>
+    </div>
+    <div class="col-6">
+      <p>Your approach is consultative, you are results and goal-oriented, and you know how to invest your time to maximise the benefit for customers and the company.</p>
+      <p>You build long term relationships, and you always promote the approach that is in the customers best interests, regardless of short term consequences. You are interested in the state of the art, you love to represent a company that knows how to transform customer operations, and you are keen to see new customers benefit from that knowledge.</p>
+      <p>You are organised, persistent, friendly and hard-working. You are effective in a digital world, keeping track of your plans and your progress, collaborating with colleagues to deliver for your customers. You are professionally competitive &ndash; respectful of the competition and determined to improve until you win regularly.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>See for yourself the work we're doing</h2>
+    <ul class="p-inline-list">
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical" data-size="large" aria-label="Follow @canonical on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item u-no-margin--right">
+        <a class="github-button" href="https://github.com/canonical/canonical.com" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star canonical/canonical.com on GitHub">Star</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a class="github-button" href="https://github.com/canonical/canonical.com/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork canonical/canonical.com on GitHub"></a>
+      </li>
+      <li class="p-inline-list__item">
+      <a href="https://www.linkedin.com/company/234280" class="p-icon--linkedin">LinkedIn</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://twitter.com/Canonical" class="p-icon--twitter">Twitter</a>
+    </li>
+    <li class="p-inline-list__item">
+      <a href="https://www.youtube.com/user/celebrateubuntu" class="p-icon--youtube">YouTube</a>
+    </li>
+    </ul>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
+    <h3 class="p-heading--2">Find out more about Engineering</h3>
+    <!-- blogs to go here -->
+  </div>
+
+</section>
+<script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/sales.html
+++ b/templates/careers/sales.html
@@ -92,13 +92,9 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
-    <h3 class="p-heading--2">Find out more about Engineering</h3>
-    <!-- blogs to go here -->
-  </div>
+{% with section_classes='p-strip', heading_topic='Sales', tag_id='1486', limit='3' %}
+  {% include "shared/_blog-card.html" %}
+{% endwith %}
 
-</section>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/support-engineering.html
+++ b/templates/careers/support-engineering.html
@@ -90,13 +90,9 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
-    <h3 class="p-heading--2">Find out more about Engineering</h3>
-    <!-- blogs to go here -->
-  </div>
+{% with section_classes='p-strip', heading_topic='Support Engineering', tag_id='1486', limit='3' %}
+  {% include "shared/_blog-card.html" %}
+{% endwith %}
 
-</section>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/careers/support-engineering.html
+++ b/templates/careers/support-engineering.html
@@ -1,19 +1,19 @@
 {% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1Eq3USN12tdL1sEf0DMYxO9FAJ5Vqkrl_yeYdRsfWNww/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1TkePZPzjdIMRTPIep6C1f8SnTPmkKiGdMyUEPMK9rH8{% endblock meta_copydoc %}
 
-{% block title %}Web & design | Careers{% endblock %}
+{% block title %}Support Engineering | Careers{% endblock %}
 
-{% block meta_description %}The design team at Canonical crafts and builds the user-experience for sophisticated technical specialists across a wide range of industries and geographies.{% endblock %}
+{% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public clouds to certify Ubuntu.{% endblock %}
 
 {% block content %}
 <section class="p-strip--light">
   <div class="row">
     <div class="col-6">
-      <h1 class="p-heading--2">Web and Design</h1>
+      <h1 class="p-heading--2">Support Engineering</h1>
     </div>
     <div class="col-6">
-      <p>Canonical and Ubuntu are central to modern tech &ndash; from cloud to the internet of things, from the web to mobile back-ends, from development to production.</p>
+      <p>Support Engineering role ranges from IT and managed services to developing commercial systems used by our company. We develop, test, ship and operate the systems that drive Canonical and underpin Ubuntu. We believe in a strong customer service ethic and operations through code. The robots we are constructing to run the data centre need to be backed by humans that care about the needs of our users and customers.</p>
       <a class="p-button--positive" href="/careers/all">View roles</a>
       <a class="p-button" href="/careers/career-explorer">Career explorer</a>
     </div>
@@ -27,14 +27,13 @@
       <h3>Projects you'll work on</h3>
     </div>
     <div class="col-6">
-      <p>The design team at Canonical crafts the user experiences of sophisticated technical specialists across a wide range of industries. Driven by the precision craft of our design system. Canonical delivers Ubuntu, and a range of products &ndash; for engineers, admins and enterprises &ndash; to help businesses move to an open source stack.</p>
-      <p>Your opportunity is to shape the user experience across the enterprise infrastructure and application operations landscape. There are challenges at every layer of the stack &ndash; from bare metal data centre operations to virtualisation infrastructure and cloud, to the desktop, to systems management, to serverless and embedded connected devices.</p>
+      <p>In Support Engineering, you will enjoy the excitement of a team environment that is fun, diverse, distributed globally and incredibly competent. Every day, we work to enable our customers to work on some of the most challenging problems in the world.</p>
     </div>
   </div>
   <div class="p-strip is-shallow">
     <div class="u-fixed-width u-hide--small u-hide--medium">
       {{ image (
-        url="https://assets.ubuntu.com/v1/4b0fc90b-department-web-design-%402x.jpg",
+        url="https://assets.ubuntu.com/v1/456c9c0f-department-support-engineering-%402x.jpg",
         alt="",
         width="2216",
         height="834",
@@ -47,11 +46,10 @@
   
   <div class="row">
     <div class="col-6">
-      <h3>Being part of the team</h3>
+      <h3>Engineering at Canonical</h3>
     </div>
     <div class="col-6">
-      <p>Canonical designers work on a range of products, using a centralised design lead &ndash; design system to deliver a consistent experience across a very wide range of web interfaces.</p>
-      <p>Our team has specialists in visual and UX design, and all aspects of web engineering. We collaborate, as product design squads, with globally distributed development engineering teams. Designers need to be effective in working collaboratively in a digital space. We travel to engineering sprints and summits for face-to-face time.</p>
+      <p>While we all enjoy the feeling that comes from passionately working together, we also collectively respect each other's lives away from work. Part of standing together with a global team that is set up to work remotely means you can step away during your off-hours and know that your team has your back. Your manager will guide and mentor you through your work but equally wants you to make sure you are taking the time away from work to help you unwind and refocus. All of us are in this together, and we want you in Support Engineering for the long term.</p>
   </div>
   <div class="p-strip is-shallow">
     <hr>
@@ -61,7 +59,7 @@
       <h3>Who you are</h3>
     </div>
     <div class="col-6">
-      <p>We count on our team to bring together deep design-thinking, technical domain knowledge, with great instincts, through a rigorous process &ndash; to shape products for a very demanding audience. You'll fit in if you have equal appetites for design, innovation and cutting-edge technology.</p>
+      <p>If you enjoy supporting customers, operating software or building software, then Support Engineering at Canonical will present you with the challenging work environment to help you grow. We welcome you to apply with us!</p>
     </div>
   </div>
 </section>

--- a/templates/careers/support-engineering.html
+++ b/templates/careers/support-engineering.html
@@ -4,8 +4,6 @@
 
 {% block title %}Support Engineering | Careers{% endblock %}
 
-{% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public clouds to certify Ubuntu.{% endblock %}
-
 {% block content %}
 <section class="p-strip--light">
   <div class="row">
@@ -13,7 +11,7 @@
       <h1 class="p-heading--2">Support Engineering</h1>
     </div>
     <div class="col-6">
-      <p>Support Engineering role ranges from IT and managed services to developing commercial systems used by our company. We develop, test, ship and operate the systems that drive Canonical and underpin Ubuntu. We believe in a strong customer service ethic and operations through code. The robots we are constructing to run the data centre need to be backed by humans that care about the needs of our users and customers.</p>
+      <p>Support Engineering role ranges from IT experts and managed services operators across a vast portfolio of open source projects. We support, test, fix and operate the Ubuntu OS, infrastructure such as Kubernetes, LXD, OpenStack, MAAS, and a growing portfolio of open source applications. We believe in customer-centricity, working with the community and smart operations through code. The robots we are constructing to run the data centre need to be backed by humans that care about the needs of our users.</p>
       <a class="p-button--positive" href="/careers/all">View roles</a>
       <a class="p-button" href="/careers/career-explorer">Career explorer</a>
     </div>
@@ -46,7 +44,7 @@
   
   <div class="row">
     <div class="col-6">
-      <h3>Engineering at Canonical</h3>
+      <h3>Support Engineering at Canonical</h3>
     </div>
     <div class="col-6">
       <p>While we all enjoy the feeling that comes from passionately working together, we also collectively respect each other's lives away from work. Part of standing together with a global team that is set up to work remotely means you can step away during your off-hours and know that your team has your back. Your manager will guide and mentor you through your work but equally wants you to make sure you are taking the time away from work to help you unwind and refocus. All of us are in this together, and we want you in Support Engineering for the long term.</p>
@@ -59,7 +57,7 @@
       <h3>Who you are</h3>
     </div>
     <div class="col-6">
-      <p>If you enjoy supporting customers, operating software or building software, then Support Engineering at Canonical will present you with the challenging work environment to help you grow. We welcome you to apply with us!</p>
+      <p>If you enjoy helping customers, solving real, complex problems and you thrive operating software or building software, then Support Engineering at Canonical will present you with the challenging work environment to help you learn and grow. We welcome you to apply with us!</p>
     </div>
   </div>
 </section>
@@ -90,7 +88,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip', heading_topic='Support Engineering', tag_id='1486', limit='3' %}
+{% with section_classes='p-strip', heading_topic='Support Engineering', tag_id='1374', limit='3' %}
   {% include "shared/_blog-card.html" %}
 {% endwith %}
 

--- a/templates/careers/web-and-design.html
+++ b/templates/careers/web-and-design.html
@@ -92,7 +92,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip', heading_topic='Web and Design', tag_id='1486', limit='3' %}
+{% with section_classes='p-strip', heading_topic='Web and Design', tag_id='3329', limit='3' %}
   {% include "shared/_blog-card.html" %}
 {% endwith %}
 

--- a/templates/careers/web-and-design.html
+++ b/templates/careers/web-and-design.html
@@ -92,13 +92,9 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
-    <h3 class="p-heading--2">Find out more about Engineering</h3>
-    <!-- blogs to go here -->
-  </div>
+{% with section_classes='p-strip', heading_topic='Web and Design', tag_id='1486', limit='3' %}
+  {% include "shared/_blog-card.html" %}
+{% endwith %}
 
-</section>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 {% endblock %}

--- a/templates/shared/_blog-card.html
+++ b/templates/shared/_blog-card.html
@@ -1,0 +1,49 @@
+<noscript>
+  <section class="u-hide {% if section_classes %}{{ section_classes }}{% else %}p-strip{% endif %}" data-js="latest-news">
+    <div class="row">
+      <div class="row">
+        <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
+        <h3 class="p-heading--2 u-sv3">Find out more about {{ heading_topic }}</h3>
+      </div>
+    </div>
+  </section>
+</noscript>
+
+<section class="u-hide {% if section_classes %}{{ section_classes }}{% else %}p-strip{% endif %}" data-js="latest-news">
+  <div class="row">
+    <div class="row">
+      <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom2">Blogs</h2>
+      <h3 class="p-heading--2 u-sv3">Find out more about {{ heading_topic }}</h3>
+    </div>
+  </div>
+  <div id="latest-articles" class="row">
+    <div style="min-height: 9.1rem">
+      <i class="p-icon--spinner u-animation--spin">Loading...</i>
+    </div>
+  </div>
+  <template style="display:none" id="articles-template">
+    <article class="col-4 col-medium-2 blog-p-card--post">
+      <div class="blog-p-card__content">
+        <div class="u-crop--16-9" style="margin-bottom:1rem;">
+          <div class="article-image" aria-hidden="true"></div>
+        </div>
+        <h3 class="p-heading--4 u-no-margin--bottom">
+          <a class="p-link--soft article-title article-link"></a>
+        </h3>
+        <p class="article-excerpt"></p>
+      </div>
+    </article>
+  </template>
+  <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
+  <script>
+    canonicalLatestNews.fetchLatestNews(
+      {
+        articlesContainerSelector: "#latest-articles",
+        articleTemplateSelector: "#articles-template",
+        hostname: "canonical.com",
+        {% if tag_id %}tagId: "{{ tag_id }}",{% endif %}
+        {% if limit %}limit: "{{ limit }}",{% endif %}
+      }
+    )
+  </script>
+</section>


### PR DESCRIPTION
## Done

- Refreshed department pages based on [redesign](https://www.figma.com/file/KQSCmTqOjY4gfKvJPyvzj2/Canonical.com-latest-only?node-id=6208%3A18373)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: 
    - https://canonical-com-648.demos.haus/careers/engineering
    - https://canonical-com-648.demos.haus/careers/support-engineering
    - https://canonical-com-648.demos.haus/careers/admin
    - https://canonical-com-648.demos.haus/careers/operations
    - https://canonical-com-648.demos.haus/careers/finance
    - https://canonical-com-648.demos.haus/careers/human-resources
    - https://canonical-com-648.demos.haus/careers/legal
    - https://canonical-com-648.demos.haus/careers/marketing
    - https://canonical-com-648.demos.haus/careers/web-and-design
    - https://canonical-com-648.demos.haus/careers/sales
    - https://canonical-com-648.demos.haus/careers/operations
    - https://canonical-com-648.demos.haus/careers/project-management
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5785