### PR TITLE
Fix the /career/start path

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -212,7 +212,7 @@ def job_details(job_id, job_title):
 
 @app.route("/careers/start")
 def start_career():
-    return flask.render_template("/careers/start.html")
+    return flask.render_template("/careers/career-explorer.html")
 
 
 @app.route("/careers")


### PR DESCRIPTION
## Done
- Update the template path in the route

## QA

- Open the demo and add `/careers/start?_ga=2.14098167.1110780800.1665671000-167831397.1628077759` to the URL
- Check it works and in production, it doesn't

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/657