### PR TITLE
Add tracking pixels for StackOverflow advertising campaign

### DIFF
--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -7,6 +7,17 @@
 {% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public clouds to certify Ubuntu.{% endblock %}
 
 {% block content %}
+<!-- StackOverflow ad tracking pixel -->
+<script>
+  (function() {
+  var a = String(Math.floor(Math.random() * 10000000000000000));
+  new Image().src = 'https://pubads.g.doubleclick.net/activity;xsp=5024608;ord='+ a +'?';
+  })();
+</script>
+<noscript>
+  <img src='https://pubads.g.doubleclick.net/activity;xsp=5024608;ord=1?' width=1 height=1 border=0>
+</noscript>
+
 <section class="p-strip--image is-dark is-deep" style="background-image: url(https://assets.ubuntu.com/v1/aebc1742-01_suru2_dark_2K.png); background-position: 100% 55%; background-size: 180%; background-repeat: repeat-x;">
   <div class="row">
     <div class="col-8 col-start-large-4">

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,17 @@
 
 
 {% block content %}
+<!-- StackOverflow ad tracking pixel -->
+<script>
+  (function() {
+  var a = String(Math.floor(Math.random() * 10000000000000000));
+  new Image().src = 'https://pubads.g.doubleclick.net/activity;xsp=4822915;ord='+ a +'?';
+  })();
+</script>
+<noscript>
+  <img src='https://pubads.g.doubleclick.net/activity;xsp=4822915;ord=1?' width=1 height=1 border=0>
+</noscript>
+
 <div class="p-strip--suru-large is-dark u-no-padding--top is-parallax">
   <div class="row u-vertically-center" style="height: 100vh;">
     <div class="col-6 p-heading-highlight--left u-animation--slide-from-top">


### PR DESCRIPTION
As requested by Emily Tu, adding tracking pixel for StackOverflow ad campaign. Instructions send to me over email.

> 1. Canonical_Homepage_Engagement Pixel_Page Views Pixel (ID: 4822915)
>     Only apply to https://canonical.com/
> 2. Canonical_Careers Page_Engagement Pixel_Page Views Pixel (ID: 4877251)
>     Only apply to https://canonical.com/careers

QA
--

Go to `/` and `/careers`. Check the code appears on those pages.