### PR TITLE
update link on careers index

### DIFF
--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -103,7 +103,8 @@
           </div>
         </div>
       </div>
-      <a class="p-button" style="margin-top: 1rem;" href="/careers/all">All departments</a>
+      
+      <a class="p-button" style="margin-top: 1rem;" href="/careers/departments">All departments</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updated "View all departments" link to point to /careers/departments

## QA

- Visit https://canonical-com-662.demos.haus/careers
- Find the "View all departments" link and click it
- You should be taken to /careers/departments, not /careers/all

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/661
