### PR TITLE
Fix secondary nav bug

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -69,6 +69,7 @@ $nudge--small: 0.55rem;
     &--secondary {
       background-color: $color-x-light;
       border-bottom: 1px solid $color-mid-light;
+      z-index: 1;
 
       @media (max-width: $breakpoint-navigation-threshold - 1) {
         padding: $sp-small 1rem;


### PR DESCRIPTION
## Done

Fix secondary nav bug

## QA

1. Click partners in the nav bar 
2. Scroll down the content and check the sticky nav bar displays above the content.

- Before
<img width="1424" alt="image" src="https://user-images.githubusercontent.com/57550290/196916450-a826c179-78aa-4e33-8481-b798ef35b853.png">
- After
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/57550290/196916593-1644ed3a-7b76-4dc6-b86a-5cdb6c80aff9.png">

## Issue / Card

Fixes #663 
