### PR TITLE
Pass the gh_src URL param to the application

### DIFF
--- a/static/js/source-inheritance.js
+++ b/static/js/source-inheritance.js
@@ -1,0 +1,22 @@
+function setSourceField() {
+  if (sessionStorage.getItem("gh_src")) {
+    const ghsrcField = document.getElementById("ghsrc");
+    const ghsrc = sessionStorage.getItem("gh_src");
+    if (ghsrc && ghsrcField) {
+      ghsrcField.value = ghsrc;
+    }
+  }
+}
+
+function setSessionStorage() {
+  const queryString = window.location.search;
+  const urlParams = new URLSearchParams(queryString);
+  const ghsrc = urlParams.get('gh_src');
+
+  if (ghsrc) {
+    sessionStorage.setItem("gh_src", ghsrc);
+  }
+}
+
+setSessionStorage();
+setSourceField();

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -117,6 +117,7 @@
         }
       })()
     </script>
+    <script defer src="{{ versioned_static('js/source-inheritance.js') }}"></script>
   </body>
 
 </html>

--- a/templates/careers/base_job-details.html
+++ b/templates/careers/base_job-details.html
@@ -6,6 +6,4 @@
   {% block careers_content %}{% endblock %}
 </section>
 
-<script defer src="/static/js/careers-filter-and-sort.js"></script>
-
 {% endblock %}

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -128,6 +128,7 @@
         <span class="js-locate-error u-hide" style="color: #c7162b">Location unavailable</span>
         <hr style="margin: 1rem 0;" />
         <p>In submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/data-privacy/recruitment">Recruitment Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy/">Privacy Policy</a>.</p>
+        <input type="hidden" name="mapped_url_token" value="" id="ghsrc" />
         <input type="submit" class="p-button--positive u-no-margin--bottom" name="submit" value="Submit application">
       </fieldset>
     </form>


### PR DESCRIPTION
## Done
- Set a session storage key if the URL contains the param `gh_src`
- On the application page, read the session key and if populated sets the form field `mapped_url_token` which is [used by Greenhouse](https://developers.greenhouse.io/job-board.html#submit-an-application) to set the source of the application
- _Drive by_: Remove the search and filter JS from the apply page which was causing an error

## QA
- Open the demo and go to /careers/all
- Click on a job and inspect by the "Submit application" button that the input named `mapped_url_token` has a blank value
- Go back to the list
- Add the URL param `gh_src=campaign123` and load the page with that
- Check for errors in the console
- If none, visit a job again and see the `mapped_url_token` field is populated with "campaign123"
- Submit a test application to see it all works
