### PR TITLE
fix broken products navigation anchor

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -30,7 +30,7 @@
           </ul>
         </li>
         <li class="p-navigation__item">
-          <a href="#products" class="p-navigation__link">Products</a>
+          <a href="/#products" class="p-navigation__link">Products</a>
         </li>
         <li class="p-navigation__item--dropdown-toggle" id="partners">
           <a href="/partners" aria-controls="partners-menu" class="p-navigation__link">Partners</a>


### PR DESCRIPTION
## Done

Simply added a slash in front of `#products` for the link so that the path is absolute to the domain root instead of relative to the current navigation location.

## Issue / Card

Fixes #674 
