### PR TITLE
fix products link

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -30,7 +30,7 @@
           </ul>
         </li>
         <li class="p-navigation__item">
-          <a href="#products" class="p-navigation__link">Products</a>
+          <a href="/#products" class="p-navigation__link">Products</a>
         </li>
         <li class="p-navigation__item--dropdown-toggle" id="partners">
           <a href="/partners" aria-controls="partners-menu" class="p-navigation__link">Partners</a>


### PR DESCRIPTION
## Done

Fixed the Products link

## QA

- Visit https://canonical-com-676.demos.haus/
- Click "Products"
- See you're scrolled to the products section on the homepage
- Visit https://canonical-com-676.demos.haus/partners
- Click "Products"
- See that you are taken back to the homepage and scrolled to the products section

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/674