### PR TITLE
Fix the withdraw modal padding

### DIFF
--- a/templates/careers/application/index.html
+++ b/templates/careers/application/index.html
@@ -243,9 +243,9 @@
         <div class="col-6">
           <p>The email you entered does not match the email used to apply to this role. Please try again using the email you used in the application.</p>
           <button id="showModal" aria-controls="modal">Withdraw application</button>
-          {% include "careers/application/_withdrawal-form.html" %}
         </div>
       </div>
+      {% include "careers/application/_withdrawal-form.html" %}
       {% else %}
       <div class="row">
         <div class="col-6">
@@ -254,9 +254,9 @@
         <div class="col-6">
           <p>You will be asked for confirmation in the next steps.</p>
           <button id="showModal" aria-controls="modal">Withdraw application</button>
-          {% include "careers/application/_withdrawal-form.html" %}
         </div>
       </div>
+      {% include "careers/application/_withdrawal-form.html" %}
       {% endif %}
     </section>
     {% endif %}


### PR DESCRIPTION
## Done
The withdraw modal is missing padding in production.

## QA
- Open the demo
- [Find an application link](https://pastebin.canonical.com/p/J3GpTM3n5H/)
- Click the withdraw button 
- Check the styling looks ok

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/201782399-dbc29365-22c5-40ed-8a3c-e3e8c434dd38.png)
