### PR TITLE
Fix show all functionality

### DIFF
--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -182,6 +182,7 @@
     showButtons(filteredJobList)
     showJobs(filteredJobList);
     handleShowMoreClick();
+    handleShowAllClick(filteredJobList);
   }
 
   function updateTotalNumber(shownJobs, jobList) {
@@ -274,7 +275,7 @@
         }
       }
     });
-
+    
     if (selectedDeptFilters.length || localFilters.length) {
       filteredJobList = jobsToShow;
       showJobs(filteredJobList)


### PR DESCRIPTION
## Done

- Fix show all functionality when filtering via search bar

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://canonical-com-690.demos.haus/careers/all?search=sales (feel free to use other keywords as well)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Scroll to the end of the list and ensure that the "show all" button works as expected

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/682
