### PR TITLE
Apply redesign and re-order departments

### DIFF
--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -115,10 +115,6 @@
   function departmentFiltersListener(el, selectedDeptFilters, selectedLocationFilters,jobList) {
     let filterName = el.name;
 
-    if (filterName == "People"){
-      filterName = "Human Resources"
-    }
-
     if (el.checked){
       selectedDeptFilters.push(filterName)
       filterJobs(selectedDeptFilters, selectedLocationFilters, jobList);
@@ -259,6 +255,14 @@
     jobList.forEach(job => {
       let jobSector = job.dataset.sector;
       let jobLocation = job.dataset.location;
+      
+      if (jobSector == "Human Resources"){
+        jobSector = "People"
+      }
+
+      if (jobSector == "TechOps"){
+        jobSector = "Support Engineering"
+      }
 
       if (selectedDeptFilters.length > 0 && localFilters.length > 0) {
         if (selectedDeptFilters.includes(jobSector) && parseLocations(jobLocation, localFilters)){

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -115,6 +115,10 @@
   function departmentFiltersListener(el, selectedDeptFilters, selectedLocationFilters,jobList) {
     let filterName = el.name;
 
+    if (filterName == "People"){
+      filterName = "Human Resources"
+    }
+
     if (el.checked){
       selectedDeptFilters.push(filterName)
       filterJobs(selectedDeptFilters, selectedLocationFilters, jobList);

--- a/static/sass/_pattern_search-form.scss
+++ b/static/sass/_pattern_search-form.scss
@@ -7,7 +7,7 @@
 
 
   .p-form--search {
-    width: 100%;
+    width: 50%;
 
     .p-button--positive {
       white-space: nowrap;

--- a/templates/careers/_search.html
+++ b/templates/careers/_search.html
@@ -40,7 +40,7 @@
       location.textContent = job.location
 
       const title = document.createElement('h3')
-      title.setAttribute('class', 'p-heading--4')
+      title.setAttribute('class', 'p-heading--5')
       
       const titleAnchor = document.createElement('a')
       titleAnchor.setAttribute('href', `/careers/${job.id}`)

--- a/templates/careers/all.html
+++ b/templates/careers/all.html
@@ -7,7 +7,7 @@
 {% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public.{% endblock %}
 
 {% block hero %}
-  <section class="p-strip--light is-deep">
+  <section class="p-strip--light">
     <div class="u-fixed-width u-sv3">
         <h1 class="u-no-margin--bottom p-heading--2">Open roles</h1>
     </div>

--- a/templates/careers/all.html
+++ b/templates/careers/all.html
@@ -7,16 +7,14 @@
 {% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public.{% endblock %}
 
 {% block hero %}
-  <section class="p-strip is-deep">
-    <div class="row">
-      <div class="col-3">
+  <section class="p-strip--light is-deep">
+    <div class="u-fixed-width u-sv3">
         <h1 class="u-no-margin--bottom p-heading--2">Open roles</h1>
-      </div>
-      <div class="col-9">
+    </div>
+     <div class="u-fixed-width">
         {% if vacancies %}
           {% include "careers/_search.html" %}
         {% endif %}
-      </div>
     </div>
   </section>
 {% endblock %}

--- a/templates/careers/base.html
+++ b/templates/careers/base.html
@@ -7,7 +7,7 @@
 
 {% block hero %}{% endblock %}
 
-<section class="p-strip u-no-padding--top u-extra-space">
+<section class="p-strip u-extra-space">
   <div class="row">
     {% include 'partial/_careers-navigation.html' %}
     <div class="col-9 col-medium-4">

--- a/templates/careers/base.html
+++ b/templates/careers/base.html
@@ -8,8 +8,6 @@
 {% block hero %}{% endblock %}
 
 <section class="p-strip u-no-padding--top u-extra-space">
-  <hr class="is-fixed-width u-no-margin--bottom">
-
   <div class="row">
     {% include 'partial/_careers-navigation.html' %}
     <div class="col-9 col-medium-4">

--- a/templates/partial/_careers-available-roles.html
+++ b/templates/partial/_careers-available-roles.html
@@ -3,7 +3,7 @@
   Sorry, there are no open positions matching your criteria.
 </h2>
 <div class="js-filter-jobs-container">
-  <div class="p-strip u-no-padding--top">
+  <div class="p-strip u-no-padding--top u-no-padding--bottom">
     <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">All roles</h2>
   </div>
   <hr>

--- a/templates/partial/_careers-navigation.html
+++ b/templates/partial/_careers-navigation.html
@@ -1,12 +1,12 @@
 <div class="col-3 u-hide--small">
   <form action="" method="get" class="js-filter-form">
     <div class="p-form__group">
-      <div class="p-strip u-no-padding--top">
+      <div class="p-strip u-no-padding--top u-no-padding--bottom">
         <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-sv1">Filters</h2>
       </div>
       <h3 class="p-heading--5 u-no-margin--bottom">Department</h3>
       <ul class="p-list u-no-margin--left" style="font-size: 1.1rem;">
-        {% for department in all_departments.values() %}
+        {% for department in sorted_departments.values() %}
           <li  class="p-list__item u-no-padding--top u-no-padding--bottom p-form__control {% if request.path|get_secondary_nav_path == department.slug %}is-active{% endif %}">
             <label class="p-checkbox u-no-margin--bottom">
               <input type="checkbox" aria-labelledby="{{department.slug}}" class="p-checkbox__input js-filter" name="{{department.name}}">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -252,7 +252,7 @@ def all_careers():
         dept_value = dept_list["people"].__dict__
         dept_value["name"] = "People"
         dept_value["slug"] = "people"
-    
+
     if "techops" in dept_list:
         dept_list["support-engineering"] = dept_list["techops"]
         del dept_list["techops"]

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -232,7 +232,7 @@ def all_careers():
 
     dept_order = [
         "engineering",
-        "techops",
+        "support-engineering",
         "marketing",
         "web-and-design",
         "project-management",
@@ -251,6 +251,14 @@ def all_careers():
         del dept_list["human-resources"]
         dept_value = dept_list["people"].__dict__
         dept_value["name"] = "People"
+        dept_value["slug"] = "people"
+    
+    if "techops" in dept_list:
+        dept_list["support-engineering"] = dept_list["techops"]
+        del dept_list["techops"]
+        dept_value = dept_list["support-engineering"].__dict__
+        dept_value["name"] = "Support Engineering"
+        dept_value["slug"] = "support-engineering"
 
     sorted_departments = {k: dept_list[k] for k in dept_order}
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -228,9 +228,35 @@ def careers_index():
 
 @app.route("/careers/all")
 def all_careers():
+    all_departments = (_group_by_department(greenhouse.get_vacancies()),)
+
+    dept_order = [
+        "engineering",
+        "techops",
+        "marketing",
+        "web-and-design",
+        "project-management",
+        "operations",
+        "product",
+        "sales",
+        "finance",
+        "people",
+    ]
+
+    dept_list = all_departments[0]
+
+    # rename hr department and slug
+    if "human-resources" in dept_list:
+        dept_list["people"] = dept_list["human-resources"]
+        del dept_list["human-resources"]
+        dept_value = dept_list["people"].__dict__
+        dept_value["name"] = "People"
+
+    sorted_departments = {k: dept_list[k] for k in dept_order}
+
     return flask.render_template(
         "/careers/all.html",
-        all_departments=_group_by_department(greenhouse.get_vacancies()),
+        sorted_departments=sorted_departments,
         vacancies=[
             vacancy.to_dict() for vacancy in greenhouse.get_vacancies()
         ],


### PR DESCRIPTION
## Done

- Applied styling updates based on [mock-up](https://www.figma.com/file/UsovUAf4zELQgGd9bxhiVe/Careers?node-id=310%3A1822&t=JxZNmeLpAdpskinS-0)
- Applied requested order to departments

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://canonical-com-697.demos.haus/careers/all
- See that the page matches the mock-up and that filters work as expected

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-677