### PR TITLE
Allow job post id to be null

### DIFF
--- a/templates/careers/application/index.html
+++ b/templates/careers/application/index.html
@@ -81,7 +81,7 @@
 
       <div class="row">
         <div class="col-12">
-          <h1 class="p-heading--2 u-sv2"><strong>{{ application["candidate"]["first_name"] }} {{ application["candidate"]["last_name"] }}</strong><br>Application for {{ application["job_post"]["title"] }}</h1>
+          <h1 class="p-heading--2 u-sv2"><strong>{{ application["candidate"]["first_name"] }} {{ application["candidate"]["last_name"] }}</strong><br>Application for {{ application["job_post"]["title"] or application["jobs"][0]["name"] }}</h1>
           {% if "stage_progress" in application and application["stage_progress"]["assessment"] and application['source']['id'] == 2 %}
             <p class="u-no-margin--bottom"><a href="/careers/{{ application['job_post_id'] }}" class="p-link--inverted">Job description for this role</a></p>
           </div>

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -40,7 +40,7 @@ def _get_application(application_id):
     application = harvest.get_application(int(application_id))
     job_post_id = application["job_post_id"]
     application["job_post"] = (
-        harvest.get_job_post(int(job_post_id)) if job_post_id else None
+        harvest.get_job_post(job_post_id) if job_post_id else None
     )
 
     # Add candidate object

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -39,7 +39,9 @@ base_url = "https://harvest.greenhouse.io/v1"
 def _get_application(application_id):
     application = harvest.get_application(int(application_id))
     job_post_id = application["job_post_id"]
-    application["job_post"] = harvest.get_job_post(int(job_post_id))
+    application["job_post"] = (
+        harvest.get_job_post(int(job_post_id)) if job_post_id else None
+    )
 
     # Add candidate object
     application["candidate"] = harvest.get_candidate(


### PR DESCRIPTION
## Done

Since some applications don't have a job post id, and this is only used in the heading, I think the simplest option is use internal Greenhouse job name if the job post is not available.

## QA

- Check out this feature branch
- `dotrun`
-  View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to the candidate page in #698 and check that it's rendered

## Issue / Card

Fixes #698 

