### PR TITLE
Fix mobile homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@
 <div class="p-strip--suru-large is-dark u-no-padding--top is-parallax">
   <div class="row u-vertically-center" style="height: 100vh;">
     <div class="col-6 p-heading-highlight--left u-animation--slide-from-top">
-      <h1 class="p-heading-highlight--left__item " style="margin-bottom: 0.5rem;">Deliver, maintain,<br class="u-hide--medium u-hide--small" />secure and sustain</h1>
+      <h1 class="p-heading-highlight--left__item " style="margin-bottom: 0.5rem;">Deliver, maintain, <br class="u-hide--medium u-hide--small" />secure and sustain</h1>
       <h2>open source from cloud to desktop and devices.</h2>
     </div>
     <div class="col-4 col-start-large-8 u-hide--small u-hide--medium u-animation--slide-from-bottom">

--- a/tests/cypress/integration/sample_spec.js
+++ b/tests/cypress/integration/sample_spec.js
@@ -2,6 +2,6 @@ describe("Canonical home page", () => {
   it("should go to the Canonical homepage and accept the cookie policy", () => {
     cy.visit("/");
     cy.acceptCookiePolicy();
-    cy.findByText(/Deliver, maintain,secure and sustain/).should("be.visible");
+    cy.findByText(/Deliver, maintain, secure and sustain/).should("be.visible");
   });
 });


### PR DESCRIPTION
## Done

Added space in title

## QA

- Go to https://canonical-com-702.demos.haus/, check that `maintain,secure` have space now in mobile view

Before:
![image](https://user-images.githubusercontent.com/14939793/204255740-5fbb33fe-7d57-42ca-a2ea-1c161fb8e57b.png)


## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/693 
