### PR TITLE
Fix 'products' navigation link

### DIFF
--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -61,10 +61,10 @@ initDropdowItems('.p-navigation__dropdown-item');
 
 
 // Init GA tracking
-addGANavEvents("#products", "canonical.com-nav-products");
-addGANavEvents("#company", "canonical.com-nav-company");
-addGANavEvents("#partners", "canonical.com-nav-partners");
-addGANavEvents("#careers", "canonical.com-nav-careers");
+addGANavEvents("#products-nav", "canonical.com-nav-products");
+addGANavEvents("#company-nav", "canonical.com-nav-company");
+addGANavEvents("#partners-nav", "canonical.com-nav-partners");
+addGANavEvents("#careers-nav", "canonical.com-nav-careers");
 
 function addGANavEvents(target, category) {
   var t = document.querySelector(target);

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -15,7 +15,7 @@
 
     <nav class="p-navigation__nav" aria-label="main-navigation">
       <ul class="p-navigation__items">
-        <li class="p-navigation__item--dropdown-toggle" id="company">
+        <li class="p-navigation__item--dropdown-toggle" id="company-nav">
           <a href="/company" aria-controls="company-menu" class="p-navigation__link">Company</a>
           <ul class="p-navigation__dropdown" id="company-menu" aria-hidden="true">
             <li>
@@ -26,10 +26,10 @@
             </li>
           </ul>
         </li>
-        <li class="p-navigation__item" id="products">
-          <a href="/#products" class="p-navigation__link">Products</a>
+        <li class="p-navigation__item" id="products-nav">
+          <a href="#products" class="p-navigation__link">Products</a>
         </li>
-        <li class="p-navigation__item--dropdown-toggle" id="partners">
+        <li class="p-navigation__item--dropdown-toggle" id="partners-nav">
           <a href="/partners" aria-controls="partners-menu" class="p-navigation__link">Partners</a>
           <ul class="p-navigation__dropdown" id="partners-menu" aria-hidden="true">
             <li>
@@ -54,7 +54,7 @@
             </li>            
           </ul>
         </li>
-        <li class="p-navigation__item--dropdown-toggle" id="careers">
+        <li class="p-navigation__item--dropdown-toggle" id="careers-nav">
           <a href="/careers" aria-controls="careers-menu" class="p-navigation__link">Careers</a>
           <ul class="p-navigation__dropdown" id="careers-menu" aria-hidden="true">
             <li>


### PR DESCRIPTION
## Done

Fix 'products' navigation link
Updated the GA events id, so that they use a more unique name.

## QA

- Go to https://canonical-com-703.demos.haus/
- Click on the "Products" link in the navigation, make sure it now scrolls to the "products" section

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/696
