### PR TITLE
Fix sorted departments

### DIFF
--- a/templates/partial/_careers-navigation.html
+++ b/templates/partial/_careers-navigation.html
@@ -4,6 +4,7 @@
       <div class="p-strip u-no-padding--top u-no-padding--bottom">
         <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default u-sv1">Filters</h2>
       </div>
+      {% if sorted_departments %}
       <h3 class="p-heading--5 u-no-margin--bottom">Department</h3>
       <ul class="p-list u-no-margin--left" style="font-size: 1.1rem;">
         {% for department in sorted_departments.values() %}
@@ -15,6 +16,7 @@
           </li>
         {% endfor %}
       </ul>
+      {% endif %}
 
       <h3 class="p-heading--5 u-no-margin--bottom">Location</h3>
       <ul class="p-list u-no-margin--left" style="font-size: 1.1rem;">


### PR DESCRIPTION
## Done

Fix sorted departments going 500 by hiding the departments filter.
Or maybe we should hide the entire filters section?

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/708
