### PR TITLE
Remove filters from pages no longer tied to all roles

### DIFF
--- a/templates/careers/diversity/identity.html
+++ b/templates/careers/diversity/identity.html
@@ -1,4 +1,4 @@
-{% extends '/careers/base.html' %}
+{% extends '/careers/base-tabs.html' %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1C1xp9yIBtTutWEoyZnsttLQmslSMNuCPjDmabi9tx60{% endblock meta_copydoc %}
 
@@ -18,7 +18,7 @@
   </section>
 {% endblock %}
 
-{% block careers_content %}
+{% block overview %}
   <p><strong>At Canonical we believe your identity has no intrinsic bearing on your ability.</strong></p>
   <p><strong>As humans, we all have elements of our identity which we did not choose. Our name. Our skin colour. Our nationality of birth. Our sexuality. Our gender. We may be neurodiverse, or have a disability. Some of these attributes may not be obvious.</strong></p>
   <p>Whatever your identity, you are welcome as a colleague if you share our values, our mission, our work ethic and our skills.</p>

--- a/templates/careers/diversity/index.html
+++ b/templates/careers/diversity/index.html
@@ -1,4 +1,4 @@
-{% extends '/careers/base.html' %}
+{% extends '/careers/base-tabs.html' %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1L8z8Np75JN2wJa72iVrv-eRFzGiqiGW4HZiD8muPOAQ{% endblock meta_copydoc %}
 
@@ -18,7 +18,7 @@
   </section>
 {% endblock %}
 
-{% block careers_content %}
+{% block overview %}
   <p>
     <strong>We believe that talent is evenly distributed around the world. No matter where you were born, or what you look like, or how you like to dress, we think you might have the brilliance and the work ethic and the passion for open source that would make you a Canonical candidate.</strong>
   </p>

--- a/templates/careers/ethics.html
+++ b/templates/careers/ethics.html
@@ -1,12 +1,10 @@
-{% extends '/careers/base.html' %}
+{% extends '/careers/base-tabs.html' %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1K2pY9lFlKvdL3jZ6Ih5sgritIP23z_KQS3DVMlZxbqw{% endblock meta_copydoc %}
 
 {% block title %}Trust | Careers{% endblock %}
 
 {% block meta_description %}Trust in Canonical’s Ubuntu and other products is well-earned and critical to our future. We have a very high expectation of ethical behaviour at the company and in particular among leaders of any sort.{% endblock %}
-
-
 
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
@@ -20,7 +18,7 @@
   </section>
 {% endblock %}
 
-{% block careers_content %}
+{% block overview %}
   <p>
     <strong>Trust is our most precious asset.</strong>
   </p>

--- a/templates/careers/lifestyle.html
+++ b/templates/careers/lifestyle.html
@@ -1,4 +1,4 @@
-{% extends '/careers/base.html' %}
+{% extends '/careers/base-tabs.html' %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/15Ofb6vRUXbQ3evcWmrOu9ymuY37ayg4M_xZ2QXQyIts{% endblock meta_copydoc %}
 
@@ -46,7 +46,7 @@
   </style>
 {% endblock %}
 
-{% block careers_content %}
+{% block overview %}
   <p>
     <strong>Canonical is unlike any other company in the world. It is amazing for people who are organised, passionate about technology, and like to travel. People at Canonical say the people at Canonical are amazing. That’s special.</strong>
   </p>

--- a/templates/careers/progression.html
+++ b/templates/careers/progression.html
@@ -1,4 +1,4 @@
-{% extends '/careers/base.html' %}
+{% extends '/careers/base-tabs.html' %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/13lzdbhQ2mmNPuwBdajOubNyRxXAXTt5lRq0iUk5HfuQ{% endblock meta_copydoc %}
 
@@ -19,7 +19,7 @@
   </section>
 {% endblock %}
 
-{% block careers_content %}
+{% block overview %}
   <p>
     <strong>We hire for talent, passion and work ethic.</strong>
   </p>

--- a/templates/careers/travel.html
+++ b/templates/careers/travel.html
@@ -1,4 +1,4 @@
-{% extends '/careers/base.html' %}
+{% extends '/careers/base-tabs.html' %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1H2ILhAUckOWyah_6V69ImwLWOSRlXkaYnIhOHkUjclc{% endblock meta_copydoc %}
 
@@ -46,7 +46,7 @@
   </style>
 {% endblock %}
 
-{% block careers_content %}
+{% block overview %}
   <p>
     <strong>Less commuting, more real travel.</strong>
   </p>


### PR DESCRIPTION
## Done

- Removed filters from pages that no longer need them.

## Rationale

These pages used to be tabs that were accessible via the all roles page. The design of that page has changed and no longer includes these tabs, it doesn't make sense to show the filters on these pages anymore. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Visit the following pages:
  - https://canonical-com-711.demos.haus/careers/diversity/identity
  - https://canonical-com-711.demos.haus/careers/diversity
  - https://canonical-com-711.demos.haus/careers/ethics
  - https://canonical-com-711.demos.haus/careers/lifestyle
  - https://canonical-com-711.demos.haus/careers/progression
  - https://canonical-com-711.demos.haus/travel
- See that department and location filters have been removed 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-823
