### PR TITLE
Remove get_partner_groups from homepage view

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -42,8 +42,7 @@ app.register_blueprint(application, url_prefix="/careers/application")
 
 @app.route("/")
 def index():
-    partner_groups = partners_api.get_partner_groups()
-    return flask.render_template("index.html", partner_groups=partner_groups)
+    return flask.render_template("index.html")
 
 
 @app.route("/sitemap.xml")

--- a/webapp/partners.py
+++ b/webapp/partners.py
@@ -24,41 +24,5 @@ class Partners:
         else:
             return self.session.get(self.base_url).json()
 
-    def get_partner_groups(self):
-        return {
-            "Apps & snaps": self._get("programme__name=Desktop&featured=true"),
-            "Channel / Reseller": self._get(
-                "programme__name=Channel%20/%20Reseller&featured=true"
-            ),
-            "Charms": self._get(
-                "programme__name=Charm%20Partner%20Programme&featured=true"
-            ),
-            "Cloud": self._get("technology__name=Cloud/server&featured=true"),
-            "Desktop": self._get("programme__name=Desktop&featured=true"),
-            "IHV / OEM": self._get(
-                "programme__name=IHV%20/%20OEM&featured=true"
-            ),
-            "Devices": self._get("programme__name=Desktop&featured=true"),
-            "Internet of Things": self._get(
-                "programme__name=Internet%20of%20Things&featured=true"
-            ),
-            "Global System Integrators": self._get(
-                "programme__name=Global%20System%20Integrators&featured=true"
-            ),
-            "Hosting": self._get(
-                "service__offered=Hosting%20provider&featured=true"
-            ),
-            "Kubernetes": self._get("programme__name=Desktop&featured=true"),
-            "OpenStack": self._get("programme__name=Desktop&featured=true"),
-            "PAAS": self._get("programme__name=Desktop&featured=true"),
-            "Server": self._get("technology__name=Cloud/server&featured=true"),
-            "Serverless": self._get("programme__name=Desktop&featured=true"),
-            "Silicon": self._get("programme__name=Desktop&featured=true"),
-            "Snapcraft": self._get(
-                "programme__name=Internet%20of%20Things&featured=true"
-            ),
-            "Training": self._get("programme__name=Desktop&featured=true"),
-        }
-
     def get_partner_list(self):
         return self._get()


### PR DESCRIPTION
Remove the dependency on the partners API from the index view.

Fixes #196

## QA

Go to [the demo](https://canonical-com-717.demos.haus), check the homepage works.