### PR TITLE
fix products nav issue

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -27,7 +27,7 @@
           </ul>
         </li>
         <li class="p-navigation__item" id="products-nav">
-          <a href="#products" class="p-navigation__link">Products</a>
+          <a href="/#products" class="p-navigation__link">Products</a>
         </li>
         <li class="p-navigation__item--dropdown-toggle" id="partners-nav">
           <a href="/partners" aria-controls="partners-menu" class="p-navigation__link">Partners</a>


### PR DESCRIPTION
## Done

Made the Products nav item's URL absolute, not relative

## QA

- Visit https://canonical-com-718.demos.haus/
- Click "Products"
- See that you're taken to the Products section on the homepage
- Visit any other page i.e. /blog
- Click "Products"
- See that you're taken the same section on the homepage

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/715
