### PR TITLE
add missing month_name context method

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,5 +1,6 @@
 # Standard library
 import datetime
+import calendar
 import os
 import re
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -450,6 +451,11 @@ def months_list(year):
     return months
 
 
+def month_name(string):
+    month = int(string)
+    return calendar.month_name[month]
+
+
 # Template context
 @app.context_processor
 def context():
@@ -457,6 +463,7 @@ def context():
         "modify_query": modify_query,
         "descending_years": descending_years,
         "months_list": months_list,
+        "month_name": month_name,
     }
 
 


### PR DESCRIPTION
## Done

- added missing view helper to the blog

## QA

- Visit https://canonical-com-719.demos.haus/blog/archives?year=2019&month=5
- A page with blog listings should appear (on live this same URL leads to a 500)

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/716
