### PR TITLE
Fix typo on engineering dept page

### DIFF
--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -15,7 +15,7 @@
     </div>
     <div class="col-6">
       <p class="u-sv2">Open source is transforming the entire stack. This is your chance to be right at the centre of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud and high performance computing, from AI and big data to the web and connected devices, open source is a key ingredient for success. Canonical offers the opportunity to work across the entire spectrum.</p>
-      <a class="p-button--positive" href="/careers/all?filter=Engineering">Se all Engineering roles</a>
+      <a class="p-button--positive" href="/careers/all?filter=Engineering">See all Engineering roles</a>
       <a class="p-button" href="/careers/career-explorer">Career explorer</a>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Fixed typo on engineering dept page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://canonical-com-738.demos.haus/careers/engineering
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the CTA copy says "See all Engineering roles" instead of "Se all Engineering roles"

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1000
