### PR TITLE
Expand careers search to also search by skills

### DIFF
--- a/templates/careers/_search.html
+++ b/templates/careers/_search.html
@@ -67,7 +67,7 @@
   let search_term = '';
   const options = {
     threshold: 0.3,
-    keys: ['title', 'description', 'departments']
+    keys: ['title', 'description', 'departments', 'skills']
   }
   const vacancies = {{ vacancies | tojson }};
   const fuse = new Fuse(vacancies, options);


### PR DESCRIPTION
## Done

- The package used (Fuse JS) can take strings and arrays of strings, see [docs](https://fusejs.io/api/options.html#keys). This pr adds 'skills' to the list of keys

## QA

- Go to [canonical.com/careers](https://canonical.com/careers), the current live page,  and input the skill 'analysers'. You will get no results.
- Go to https://canonical-com-739.demos.haus/careers demo, and input the skill 'analysers'. You will get some results.

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/681