### PR TITLE
Hide application withdrawal

### DIFF
--- a/templates/careers/application/index.html
+++ b/templates/careers/application/index.html
@@ -219,6 +219,7 @@
       </div>
     </section>
 
+    <!--
     {% if application["status"] == "active" %}
     <hr class="is-fixed-width">
     <section class="p-strip is-deep">
@@ -257,6 +258,7 @@
       {% endif %}
     </section>
     {% endif %}
+    -->
 
   {% elif application["status"] == "hired" %}
     <section class="p-strip">


### PR DESCRIPTION
## Done

- Comments out the html responsible for application withdrawal as it is currently throwing an error on sentry. This is a temporary fix.

## QA

- Go to [this link](https://pastebin.canonical.com/p/NGsqcPqNKT/) and scroll to the bottom of the page. See that application withdrawal is not visible.

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/740
