### PR TITLE
WD-1142 Remove Working at Canonical from the menu

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -40,7 +40,7 @@
                 <li><a href="/partners/iot-device" class="p-navigation__dropdown-item">Internet of Things device</a></li>
                 <li><a href="/partners/ihv-and-oem" class="p-navigation__dropdown-item">IHV/OEM</a></li>
                 <li><a href="/partners/gsi" class="p-navigation__dropdown-item">Global Seller Initiative</a></li>
-                <li><a href="/partners/public-cloud" class="p-navigation__dropdown-item">Public cloud</a></li>                
+                <li><a href="/partners/public-cloud" class="p-navigation__dropdown-item">Public cloud</a></li>
               </ul>
             </li>
             <li>
@@ -51,7 +51,7 @@
             </li>
             <li>
               <a href="https://partner-portal.canonical.com/" class="p-navigation__dropdown-item">Log into the partner portal</a>
-            </li>            
+            </li>
           </ul>
         </li>
         <li class="p-navigation__item--dropdown-toggle" id="careers-nav">
@@ -66,11 +66,8 @@
             <li>
               <a href="/careers/start" class="p-navigation__dropdown-item">Career finder</a>
             </li>
-            <li>
-              <a href="/careers/departments" class="p-navigation__dropdown-item">Working at Canonical</a>
-            </li>          
           </ul>
-        </li>        
+        </li>
       </ul>
     </nav>
 


### PR DESCRIPTION
## Done

Remove Working at Canonical from the menu temporarily

## QA

- Open the demo
- Click Careers in the navigation
- See there is no "Working at Canonical" link

