### PR TITLE
WD-1163: Fix number of roles in /careers/all

### DIFF
--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -255,27 +255,18 @@
     let jobsToShow = [];
 
     jobList.forEach(job => {
-      let jobSector = job.dataset.sector;
+      let departments = job.departments;
       let jobLocation = job.dataset.location;
-      
-      if (jobSector == "Human Resources"){
-        jobSector = "People"
-      }
+      let matchingDepartments = selectedDeptFilters.filter(value => departments.includes(value));
 
-      if (jobSector == "TechOps"){
-        jobSector = "Support Engineering"
-      }
-
-      if (selectedDeptFilters.length > 0 && localFilters.length > 0) {
-        if (selectedDeptFilters.includes(jobSector) && parseLocations(jobLocation, localFilters)){
+      if (matchingDepartments.length && localFilters.length) {
+        if (matchingDepartments && parseLocations(jobLocation, localFilters)){
           jobsToShow.push(job)
         }
       } else {
         //filter by dept
-        if (selectedDeptFilters.length > 0){
-          if (selectedDeptFilters.includes(jobSector)){
-            jobsToShow.push(job)
-          }
+        if (matchingDepartments.length) {
+          jobsToShow.push(job)
         }
         // filter by location
         if (localFilters.length > 0){

--- a/templates/careers/_search.html
+++ b/templates/careers/_search.html
@@ -24,7 +24,7 @@
       stripDiv.dataset.employment =  job.employment
       stripDiv.dataset.location = job.location
       stripDiv.dataset.management = job.management
-      stripDiv.dataset.sector = job.departments
+      stripDiv.departments = job.departments
       
       const parentDiv = document.createElement('div')
       parentDiv.setAttribute('class', 'row ');

--- a/tests/test_greenhouse.py
+++ b/tests/test_greenhouse.py
@@ -9,9 +9,13 @@ class TestGreenhouseAPI(unittest.TestCase):
         self.assertEqual(parsed_department.slug, department)
 
     def test_parse_feed_department_matched(self):
-        department = "cloud engineering"
-        parsed_department = Department(department)
-        self.assertEqual(parsed_department.slug, "engineering")
+        # Check '&' and ' ' get replaced in slugs
+        web_and_design = Department("Web & Design")
+        self.assertEqual(web_and_design.slug, "web-and-design")
+
+        # Check department renames are happening
+        techops = Department("Techops")
+        self.assertEqual(techops.slug, "support-engineering")
 
 
 if __name__ == "__main__":

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -226,7 +226,7 @@ def careers_index():
 
     dept_list = [
         "engineering",
-        "techops",
+        "support-engineering",
         "marketing",
         "web-and-design",
         "project-management",
@@ -234,7 +234,7 @@ def careers_index():
         "product",
         "sales",
         "finance",
-        "human-resources",
+        "people",
     ]
 
     departments_overview = []
@@ -242,17 +242,9 @@ def careers_index():
     for vacancy in all_departments:
         for dept in dept_list:
             if vacancy[dept]:
-                count = len(vacancy[dept].__dict__["vacancies"])
-
-                if dept == "techops":
-                    name = "Support Engineering"
-                    slug = "support-engineering"
-                elif dept == "human-resources":
-                    name = "People"
-                    slug = "people"
-                else:
-                    name = vacancy[dept].__dict__["name"]
-                    slug = vacancy[dept].__dict__["slug"]
+                count = len(vacancy[dept].vacancies)
+                name = vacancy[dept].name
+                slug = vacancy[dept].slug
 
                 departments_overview.append(
                     {
@@ -289,21 +281,6 @@ def get_sorted_departments():
     ]
 
     dept_list = all_departments[0]
-
-    # rename hr department and slug
-    if "human-resources" in dept_list:
-        dept_list["people"] = dept_list["human-resources"]
-        del dept_list["human-resources"]
-        dept_value = dept_list["people"].__dict__
-        dept_value["name"] = "People"
-        dept_value["slug"] = "people"
-
-    if "techops" in dept_list:
-        dept_list["support-engineering"] = dept_list["techops"]
-        del dept_list["techops"]
-        dept_value = dept_list["support-engineering"].__dict__
-        dept_value["name"] = "Support Engineering"
-        dept_value["slug"] = "support-engineering"
 
     return {k: dept_list[k] for k in dept_order}
 
@@ -356,16 +333,6 @@ def department_group(department_slug):
     fast_track_jobs = []
 
     for vacancy in vacancies[0]:
-        # Check for department name discrepancies
-        if vacancy["departments"] == "Human Resources":
-            vacancy["departments"] = "People"
-
-        if vacancy["departments"] == "Web & Design":
-            vacancy["departments"] = "Web-and-Design"
-
-        if vacancy["departments"] == "TechOps":
-            vacancy["departments"] = "Support-Engineering"
-
         # Check if department role is featured or fast track
         if department_slug in vacancy["departments"]:
             if vacancy["featured"]:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -367,17 +367,12 @@ def department_group(department_slug):
             vacancy["departments"] = "Support-Engineering"
 
         # Check if department role is featured or fast track
-        if (
-            vacancy["featured"]
-            and vacancy["departments"].lower() == department_slug
-        ):
-            featured_jobs.append(vacancy)
+        if department_slug in vacancy["departments"]:
+            if vacancy["featured"]:
+                featured_jobs.append(vacancy)
 
-        if (
-            vacancy["fast_track"]
-            and vacancy["departments"].lower() == department_slug
-        ):
-            fast_track_jobs.append(vacancy)
+            if vacancy["fast_track"]:
+                fast_track_jobs.append(vacancy)
 
     context["templates"] = templates
     sorted_departments = get_sorted_departments()

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -106,9 +106,6 @@ class Vacancy:
         self.fast_track: str = _get_metadata(job, "is_fast_track")
 
     def to_dict(self):
-        sector = ""
-        for department in self.departments:
-            sector = department.name
         return {
             "id": self.id,
             "title": self.title,
@@ -123,7 +120,7 @@ class Vacancy:
             "date": self.date,
             "featured": self.featured,
             "fast_track": self.fast_track,
-            "departments": sector,
+            "departments": [dept.name for dept in self.departments],
         }
 
 

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -62,19 +62,21 @@ def _get_job_slug(job):
 
 class Department(object):
     def __init__(self, name):
-        field = {
-            "cloud engineering": "engineering",
-            "device engineering": "engineering",
-            "operations": "operations",
-            "product management": "product",
+        self.name = name
+        self.slug = name.replace("&", "and").replace(" ", "-").lower()
+
+        # Rename some departments
+        renames = {
+            "techops": {
+                "name": "Support Engineering",
+                "slug": "support-engineering",
+            },
+            "human-resources": {"name": "People", "slug": "people"},
         }
 
-        self.name = name
-
-        if name.lower() in field:
-            self.slug = field[name.lower()]
-        else:
-            self.slug = name.replace("&", "and").replace(" ", "-").lower()
+        if self.slug in renames:
+            self.name = renames[self.slug]["name"]
+            self.slug = renames[self.slug]["slug"]
 
 
 class Vacancy:


### PR DESCRIPTION
Make the number of returned roles on https://canonical-com-751.demos.haus/careers/all for each department matches the numbers declared on https://canonical-com-751.demos.haus/careers.

The issue was that https://canonical-com-751.demos.haus/careers/all wasn't respecting the fact that many vacancies actually have more than one department assigned - it was just matching based on the first department.

## Done

- WD-1163: Turn vacancy.departments into a proper array
- WD-1163: Rename departments within greenhouse.py

In doing this work I've run into many ideas for restructuring the code, and a couple more bugs. I've stored them in this Jira issue:
https://warthogs.atlassian.net/browse/WD-1216

## QA

Go to https://canonical-com-751.demos.haus/careers, look at the numbers. Now click through to https://canonical-com-751.demos.haus/careers/all and filter by those departments. Check the number of returned results matches.
