### PR TITLE
Add cachebusting version strings to all /static/js files

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -97,7 +97,7 @@
     </div>
     {% include 'partial/_footer.html' %}
 
-    <script defer src="/static/js/navigation.js"></script>
+    <script defer src="{{ versioned_static('js/navigation.js') }}"></script>
     <script src="{{ versioned_static('js/modules/cookie-policy/cookie-policy.js') }}"></script>
     <script>
       cpNs.cookiePolicy();

--- a/templates/careers/_vacancies-modal.html
+++ b/templates/careers/_vacancies-modal.html
@@ -24,4 +24,4 @@
   </div>
 </div>
 
-<script async defer src="/static/js/modal.js"></script>
+<script async defer src="{{ versioned_static('js/modal.js') }}"></script>

--- a/templates/careers/apply.html
+++ b/templates/careers/apply.html
@@ -157,8 +157,8 @@
 
 {% include 'careers/_vacancies-modal.html' %}
 
-<script async defer src="/static/js/file-validation.js"></script>
-<script async defer src="/static/js/apply-for-jobs.js"></script>
+<script async defer src="{{ versioned_static('js/file-validation.js') }}"></script>
+<script async defer src="{{ versioned_static('js/apply-for-jobs.js') }}"></script>
 
 <style>
   label::before {

--- a/templates/careers/career-explorer.html
+++ b/templates/careers/career-explorer.html
@@ -119,5 +119,5 @@
       }
     }
   </style>
-  <script defer src="/static/js/careers-game.js"></script>
+  <script defer src="{{ versioned_static('js/careers-game.js') }}"></script>
 {% endblock %}

--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -233,7 +233,7 @@
     }
   </style>
 
-  <script defer src="/static/js/find-a-partner.js"></script>
+  <script defer src="{{ versioned_static('js/find-a-partner.js') }}"></script>
   <script>
     function displayFilters () {
       const toggle = (element, show) => {


### PR DESCRIPTION
Otherwise, whenever these files are changed they will take a whole day
to work in production (because /static files have stale-while-revalidate: 86400)

## QA

Go to these pages:

https://canonical-com-753.demos.haus/
https://canonical-com-753.demos.haus/careers
https://canonical-com-753.demos.haus/careers/all
https://canonical-com-753.demos.haus/partners/find-a-partner
https://canonical-com-753.demos.haus/careers/career-explorer

 Check they still work, especially JavaScript functions. Look in source, check all `/static/js` links have `?v=xxxx` suffixes.