### PR TITLE
Remove broken link from /practice/documentation

### DIFF
--- a/templates/practice/documentation.html
+++ b/templates/practice/documentation.html
@@ -73,7 +73,7 @@
         <div class="row">
           <div class="col-12">
             <p>A central principle we hold is that <strong>documentation is an engineering practice, rather than an engineering task.</strong></p>
-            <p>At Canonical, engineers and product managers make real and substantial contributions to documentation, as part of their everyday work. Documentation is not a siloed activity, it’s a responsibility shared by everyone who works in engineering, product or support.</p>
+            <p>At Canonical, engineers and product managers make real and substantial contributions to documentation, as part of their everyday work. Documentation is not a siloed activity, it's a responsibility shared by everyone who works in engineering, product or support.</p>
             <p>Everyone is expected to think and care about documentation, specialists and non-specialists alike, in just the same way that quality and security are shared concerns.</p>
           </div>
         </div>
@@ -85,7 +85,7 @@
         <div class="row">
           <div class="col-4 p-card">
             <h3>Direction</h4>
-            <p>Where we want to go &mdash; the standards and quality we seek, so that documentation meets its users’ needs.</p>
+            <p>Where we want to go &mdash; the standards and quality we seek, so that documentation meets its users' needs.</p>
           </div>
           <div class="col-4 p-card">
             <h3>Care</h4>
@@ -108,8 +108,8 @@
       <div class="question-heading" id="careers" style="scroll-margin-top: 4.5rem;">
         <h2>Careers and opportunities</h2>
         <p>There is a dedicated career progression in documentation at Canonical, including roles for Technical Author, Senior Technical Author and Documentation Manager.</p>
-        <p>We’re hiring technical authors to join several engineering teams, working on products across Canonical's portfolio - see <a href="https://docs.google.com/document/d/1U-IkZOMzQlfV0zAAmM0PRVUBoZNBeOa-Qrso3i4rDVU/edit?usp=sharing">Working in documentation at Canonical</a> for more.</p>
-        <p>And if you’re applying to Canonical for an engineering role , don’t be surprised to be asked about your work in - or thoughts on - documentation at a job interview. As an engineering manager or director, expect to sit an entire interview dedicated to documentation practice. </p>
+        <p>We're hiring technical authors to join several engineering teams, working on products across Canonical's portfolio.</p>
+        <p>And if you're applying to Canonical for an engineering role , don't be surprised to be asked about your work in - or thoughts on - documentation at a job interview. As an engineering manager or director, expect to sit an entire interview dedicated to documentation practice. </p>
         <div class="p-notification--information">
           <div class="p-notification__content">
             <p class="p-notification__message">Whatever the role, don't hesitate to mention documentation-related work that you're proud of in your application or your interview &mdash; it will be valued.</p>


### PR DESCRIPTION
## Done

Remove a broken link from /practice/documentation, based on the [copydoc](https://docs.google.com/document/d/10tOsj5kKZRddQYYkb1PgxsES47Qic8XJc9xpRaYHd7s/edit)

## QA

- Go to https://canonical-com-758.demos.haus/practice/documentation and check the link has been removed

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1351
