### PR TITLE
Split role description and application form

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -203,7 +203,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   }
 
   h3 {
-    @extend %vf-heading-4;
+    @extend %vf-heading-5;
   }
 
   // Hide any empty p tags or consecutive breaks

--- a/templates/careers/base_job-details.html
+++ b/templates/careers/base_job-details.html
@@ -1,30 +1,42 @@
 {% extends 'base_index.html' %} {% block content %}
 
-{% block hero %}{% endblock %}
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <a id="back-roles" href="{% if request.referrer and 'careers' in request.referrer %}{{ request.referrer }}{% else %}/careers/all{% endif %}" class="u-sv2">&lsaquo;&nbsp;Back to list</a>
+    <a id="back-details" class="u-sv2 u-hide">&lsaquo;&nbsp;Back to role description</a>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h1 class="p-heading--2">{{ job.title }}</h1>
+      <p class="p-muted-heading">{{ job.location }}</p>
+    </div>
+    <div class="col-6" id="details">
+      {% block careers_content %}{% endblock %}
+    </div>
+    <div class="col-6 u-hide" id="application">
+      {% block application_content %}{% endblock %}
+    </div>
+  </div>
+</section>
 
-<section class="p-strip u-extra-space" id="details">
-  {% block careers_content %}{% endblock %}
-</section>
-<section class="p-strip u-extra-space u-hide" id="application">
-  {% block application_content %}{% endblock %}
-</section>
+
 
 <script>
   const apply_button = document.getElementById("apply-button")
   const back_roles = document.getElementById("back-roles")
   const back_details = document.getElementById("back-details")
-  job_details = document.getElementById("details")
-  application_form = document.getElementById("application")
+  const job_details = document.getElementById("details")
+  const application_form = document.getElementById("application")
   const origin_url = window.location.pathname
   
   apply_button.addEventListener("click", function(){
     show_application()
-    window.history.replaceState({}, document.title, `${window.location.pathname}/application`);
+    window.history.replaceState({}, document.title, `${origin_url}/application`)
   })
   
   back_details.addEventListener("click", function(){
     hide_application()
-    window.history.replaceState({}, document.title, origin_url);
+    window.history.replaceState({}, document.title, origin_url)
   })
   
   function show_application(){
@@ -32,6 +44,7 @@
     job_details.classList.add("u-hide")
     application_form.classList.remove("u-hide")
     back_details.classList.remove("u-hide")
+    application_form.scrollIntoView()
   }
 
   function hide_application(){

--- a/templates/careers/base_job-details.html
+++ b/templates/careers/base_job-details.html
@@ -31,14 +31,21 @@
   
   apply_button.addEventListener("click", function(){
     show_application()
-    window.history.replaceState({}, document.title, `${origin_url}/application`)
+    window.history.pushState({}, document.title, `${origin_url}/application`)
   })
   
   back_details.addEventListener("click", function(){
     hide_application()
-    window.history.replaceState({}, document.title, origin_url)
+    window.history.pushState({}, document.title, origin_url)
   })
   
+  // handle back button
+  window.addEventListener('popstate', function (event) {
+    if(!origin_url.includes("application")){
+      hide_application()
+    }
+  });  
+ 
   function show_application(){
     back_roles.classList.add("u-hide")
     job_details.classList.add("u-hide")

--- a/templates/careers/base_job-details.html
+++ b/templates/careers/base_job-details.html
@@ -2,8 +2,44 @@
 
 {% block hero %}{% endblock %}
 
-<section class="p-strip u-extra-space">
+<section class="p-strip u-extra-space" id="details">
   {% block careers_content %}{% endblock %}
 </section>
+<section class="p-strip u-extra-space u-hide" id="application">
+  {% block application_content %}{% endblock %}
+</section>
 
+<script>
+  const apply_button = document.getElementById("apply-button")
+  const back_roles = document.getElementById("back-roles")
+  const back_details = document.getElementById("back-details")
+  job_details = document.getElementById("details")
+  application_form = document.getElementById("application")
+  const origin_url = window.location.pathname
+  
+  apply_button.addEventListener("click", function(){
+    show_application()
+    window.history.replaceState({}, document.title, `${window.location.pathname}/application`);
+  })
+  
+  back_details.addEventListener("click", function(){
+    hide_application()
+    window.history.replaceState({}, document.title, origin_url);
+  })
+  
+  function show_application(){
+    back_roles.classList.add("u-hide")
+    job_details.classList.add("u-hide")
+    application_form.classList.remove("u-hide")
+    back_details.classList.remove("u-hide")
+  }
+
+  function hide_application(){
+    job_details.classList.remove("u-hide")
+    back_roles.classList.remove("u-hide")
+    application_form.classList.add("u-hide")
+    back_details.classList.add("u-hide")
+  }
+</script>
 {% endblock %}
+

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -126,8 +126,4 @@
 
 <script defer src="{{ versioned_static('js/file-validation.js') }}"></script>
 <script defer src="{{ versioned_static('js/apply-for-jobs.js') }}"></script>
-
-<script>
-  
-</script>
 {% endblock %}

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -54,7 +54,8 @@
 <section class="p-strip--suru-topped u-no-padding--bottom">
   <div class="row">
     <div class="col-6">
-      <a href="{% if request.referrer and 'careers' in request.referrer %}{{ request.referrer }}{% else %}/careers/all{% endif %}" class="u-sv2">&lsaquo;&nbsp;Back to list</a>
+      <a id="back-roles" href="{% if request.referrer and 'careers' in request.referrer %}{{ request.referrer }}{% else %}/careers/all{% endif %}" class="u-sv2">&lsaquo;&nbsp;Back to list</a>
+      <a id="back-details" class="u-sv2 u-hide">&lsaquo;&nbsp;Back to role description</a>
     </div>
   </div>
   <div class="row u-equal-height">
@@ -62,9 +63,6 @@
       <h1>{{ job.title }}</h1>
       <p class="p-muted-heading">{{ job.location }}</p>
     </div>
-    <!-- <div class="col-6 u-align--right u-vertically-center">
-      <a class="p-button--positive" href="#apply">Apply for this role</a>
-    </div> -->
   </div>
 </section>
 {% endblock %}
@@ -82,13 +80,18 @@
 </div>
 {% endif %}
 <div class="row">
-  <div class="col-6">
+  <div class="col-8">
     <div class="job-desc">
       {{ job.content | filtered_html_tags | safe }}
     </div>
+    <p><a class="p-button--positive" id="apply-button">Apply</a></p>
   </div>
+</div>
+{% endblock %}
 
-  <div class="col-5 col-start-large-8 p-card--form">
+{% block application_content %}
+<div class="row">
+  <div class="col-8 p-card--form">
     <h3>Apply for this role</h3>
     <form action="{{ request.path }}" method="POST" enctype="multipart/form-data" class="js-roles-list--form" onsubmit="dataLayer.push({
           'event': 'GAEvent',
@@ -138,6 +141,5 @@
   </div>
 </div>
 
-<script defer src="{{ versioned_static('js/file-validation.js') }}"></script>
-<script defer src="{{ versioned_static('js/apply-for-jobs.js') }}"></script>
+
 {% endblock %}

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -141,5 +141,6 @@
   </div>
 </div>
 
-
+<script defer src="{{ versioned_static('js/file-validation.js') }}"></script>
+<script defer src="{{ versioned_static('js/apply-for-jobs.js') }}"></script>
 {% endblock %}

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -50,23 +50,6 @@
 </script>
 {% endblock %}
 
-{% block hero %}
-<section class="p-strip--suru-topped u-no-padding--bottom">
-  <div class="row">
-    <div class="col-6">
-      <a id="back-roles" href="{% if request.referrer and 'careers' in request.referrer %}{{ request.referrer }}{% else %}/careers/all{% endif %}" class="u-sv2">&lsaquo;&nbsp;Back to list</a>
-      <a id="back-details" class="u-sv2 u-hide">&lsaquo;&nbsp;Back to role description</a>
-    </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="col-12">
-      <h1>{{ job.title }}</h1>
-      <p class="p-muted-heading">{{ job.location }}</p>
-    </div>
-  </div>
-</section>
-{% endblock %}
-
 {% block careers_content %}
 {% if message %}
 <div class="row">
@@ -84,7 +67,7 @@
     <div class="job-desc">
       {{ job.content | filtered_html_tags | safe }}
     </div>
-    <p><a class="p-button--positive" id="apply-button">Apply</a></p>
+    <p class="p-button--positive" id="apply-button">Apply</p>
   </div>
 </div>
 {% endblock %}
@@ -143,4 +126,8 @@
 
 <script defer src="{{ versioned_static('js/file-validation.js') }}"></script>
 <script defer src="{{ versioned_static('js/apply-for-jobs.js') }}"></script>
+
+<script>
+  
+</script>
 {% endblock %}


### PR DESCRIPTION
## Done

- Separated application form and job description 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://canonical-com-759.demos.haus/careers/all
- Click on any job posting on and see that you only see the job description
- Scroll down and click "Apply" and see that you are taken to the form and that the url now has the `/application` in the path
- At the top of the page click "Back to role description" and see that the form is once again hidden and the url does not have `/aplication` in the path 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-958
