### PR TITLE
Update URL on input clear

### DIFF
--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -1,5 +1,7 @@
 (function () {
   const urlParams = new URLSearchParams(window.location.search);
+  const baseURL = window.location.origin + window.location.pathname;
+  const search_input = document.querySelector(".js-careers__search-input");
   const domList = document.querySelector(".js-job-list");
   const departmentFilters = document.querySelectorAll(".js-filter");
   const noResults = document.querySelector(".js-filter__no-results");
@@ -120,14 +122,14 @@
     if (el.checked){
       selectedDeptFilters.push(filterName)
       filterJobs(selectedDeptFilters, selectedLocationFilters, jobList);
-      updateURL(selectedDeptFilters, selectedLocationFilters)
+      updateFilterParams(selectedDeptFilters, selectedLocationFilters)
     } else {
       let index = selectedDeptFilters.indexOf(filterName)
       if (index > -1) {
         selectedDeptFilters.splice(index, 1)
       }
       filterJobs(selectedDeptFilters, selectedLocationFilters ,jobList);
-      updateURL(selectedDeptFilters, selectedLocationFilters);
+      updateFilterParams(selectedDeptFilters, selectedLocationFilters);
     }
   }
 
@@ -137,14 +139,14 @@
     if (el.checked){
       selectedLocationFilters.push(locationName)
       filterJobs(selectedDeptFilters, selectedLocationFilters, jobList);
-      updateURL(selectedDeptFilters, selectedLocationFilters);
+      updateFilterParams(selectedDeptFilters, selectedLocationFilters);
     } else {
       let index = selectedLocationFilters.indexOf(locationName)
       if (index > -1) {
         selectedLocationFilters.splice(index, 1)
       }
       filterJobs(selectedDeptFilters, selectedLocationFilters, jobList);
-      updateURL(selectedDeptFilters, selectedLocationFilters);
+      updateFilterParams(selectedDeptFilters, selectedLocationFilters);
     }
   }
 
@@ -303,9 +305,20 @@
     }
   }
 
-  function updateURL(selectedDeptFilters, selectedLocationFilters) {
-    var baseURL = window.location.origin + window.location.pathname;
-
+  // handle search input clear, retain existing filters
+  search_input.addEventListener('input', e => {
+    search_term = e.target.value;
+    updateURL()
+  });
+  
+  function updateURL(){
+    if (search_term == ""){
+      urlParams.delete("search");
+      window.location =(`${baseURL}/?${urlParams.toString()}`);
+    }
+  }
+  
+  function updateFilterParams(selectedDeptFilters, selectedLocationFilters) {
     // if url has filter param but filter array is empty, remove filter from url
     if (urlParams.has("filter") && selectedDeptFilters.length == 0){
       urlParams.delete("filter");

--- a/templates/careers/_search.html
+++ b/templates/careers/_search.html
@@ -1,13 +1,11 @@
 {% if vacancies %}
 <script>
-  const urlParams = new URLSearchParams(window.location.search);
-
   window.addEventListener('DOMContentLoaded', (event) => {
     const search_input = document.querySelector(".js-careers__search-input");
+    const urlParams = new URLSearchParams(window.location.search);
     search_input.addEventListener('input', e => {
       search_term = e.target.value;
       showAutoComplete(search_term);
-      updateURLParams(search_term);
     });   
     showAutoComplete("");
     const querySearchText = urlParams.get("search");
@@ -123,15 +121,6 @@
 
         ul.appendChild(li);
       })
-    }
-  }
-
-  function updateURLParams(search_term){
-    const baseURL = window.location.origin + window.location.pathname;
-
-    if (search_term == ""){
-      urlParams.delete("search");
-      window.location = `${baseURL}/?${urlParams.toString()}`;
     }
   }
 

--- a/templates/careers/_search.html
+++ b/templates/careers/_search.html
@@ -5,6 +5,7 @@
     search_input.addEventListener('input', e => {
       search_term = e.target.value;
       showAutoComplete(search_term);
+      updateURLParams(search_term)
     });   
     showAutoComplete("");
     const urlParams = new URLSearchParams(window.location.search);
@@ -124,34 +125,21 @@
     }
   }
 
-
-  function initSearchResetButtons(selector) {
-    const resetButtons = [].slice.call(document.querySelectorAll(selector));
-    const ul = document.querySelector(".p-search-panel-list");
-    const url = window.location.href
-    const newUrl = url.split("?")[0];
-    resetButtons.forEach(function (button) {
-      button.addEventListener('click', function () {
-        const input = button.parentNode.querySelector('input');
-
-        ul.innerHTML = ''
-        window.location.href = newUrl
-        input.focus();
-      });
-    });
-}
-document.addEventListener('click', closeSearch);
-
-function closeSearch() {
-  const jobContainer = document.querySelector(".p-search-panel");
-  if(!jobContainer.classList.contains("u-hide")){
-    jobContainer.classList.add("u-hide");
+  function updateURLParams(search_term){
+    if (search_term == ""){
+      window.location = `${window.location.origin}${window.location.pathname}`
+    }
   }
-}
 
-document.addEventListener('DOMContentLoaded', function () {
-  initSearchResetButtons('.p-search-box__reset');
-});
+  document.addEventListener('click', closeSearch);
+
+  function closeSearch() {
+    const jobContainer = document.querySelector(".p-search-panel");
+    if(!jobContainer.classList.contains("u-hide")){
+      jobContainer.classList.add("u-hide");
+    }
+  }
+
 </script>
 {% endif %}
 <div class="js-search-jobs-form p-form-container u-hide u-align--bottom">

--- a/templates/careers/_search.html
+++ b/templates/careers/_search.html
@@ -1,14 +1,15 @@
 {% if vacancies %}
 <script>
+  const urlParams = new URLSearchParams(window.location.search);
+
   window.addEventListener('DOMContentLoaded', (event) => {
     const search_input = document.querySelector(".js-careers__search-input");
     search_input.addEventListener('input', e => {
       search_term = e.target.value;
       showAutoComplete(search_term);
-      updateURLParams(search_term)
+      updateURLParams(search_term);
     });   
     showAutoComplete("");
-    const urlParams = new URLSearchParams(window.location.search);
     const querySearchText = urlParams.get("search");
     ShowJobList(querySearchText)
   });
@@ -126,8 +127,11 @@
   }
 
   function updateURLParams(search_term){
+    const baseURL = window.location.origin + window.location.pathname;
+
     if (search_term == ""){
-      window.location = `${window.location.origin}${window.location.pathname}`
+      urlParams.delete("search");
+      window.location = `${baseURL}/?${urlParams.toString()}`;
     }
   }
 


### PR DESCRIPTION
## Done

- Added functionality to update the URL when search input is cleared
- Removed old function that did handled this in a past iteration as it was triggered by an element that no longer exists in the current design

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://canonical-com-762.demos.haus/careers/all
- Search for 'python' (or anything else)
- Once your results are loaded click on the 'x' in the search box and see that search params have cleared form URL

## Issue / Card

Fixes https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/932?modal=detail&selectedIssue=WD-1172