### PR TITLE
Fix search width and featured roles copy

### DIFF
--- a/static/sass/_pattern_search-form.scss
+++ b/static/sass/_pattern_search-form.scss
@@ -30,6 +30,7 @@
 
     .p-form__group {
       flex-grow: 1;
+      width: auto;
 
       &--no-grow {
         flex-grow: 0;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -291,7 +291,8 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
 .p-featured {
   gap: 0;
 
-  &__item {    
+  &__item { 
+    cursor: pointer;
     margin-right: 1px;
     padding: 0 1rem 1rem;
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -292,7 +292,6 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
   gap: 0;
 
   &__item {    
-    border-top: 1px solid $colors--light-theme--border-default;
     margin-right: 1px;
     padding: 0 1rem 1rem;
 
@@ -307,6 +306,12 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
         text-decoration: underline; 
       }
     }
+  }
+
+  &__role {
+    box-shadow: 0 4px 2px -2px $colors--light-theme--border-default;
+    margin-top: .5rem;
+    min-height: 6rem;
   }
 
   &__filler {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -296,6 +296,10 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
     margin-right: 1px;
     padding: 0 1rem 1rem;
 
+    &:nth-child(3n+3){
+      padding-right: 0;
+    }
+
     &:active {
       background-color: $colors--light-theme--background-active;
     }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -311,7 +311,8 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
   &__role {
     box-shadow: 0 4px 2px -2px $colors--light-theme--border-default;
     margin-top: .5rem;
-    min-height: 6rem;
+    min-height: 5rem;
+    padding-top: .5rem;
   }
 
   &__filler {

--- a/templates/shared/_fast_track_jobs.html
+++ b/templates/shared/_fast_track_jobs.html
@@ -5,8 +5,8 @@
 </div>
 <div class="p-featured is-fast-track row">
   {% for job in fast_track_jobs %}
-  <div class="p-featured__item col-small-4 col-medium-3 col-4 u-no-padding--left u-vertically-center">
-    <div class="p-card p-featured__role u-no-margin--bottom u-vertically-center">
+  <div class="p-featured__item col-small-4 col-medium-3 col-4 u-no-padding--left">
+    <div class="p-card p-featured__role u-no-margin--bottom">
       <a class="p-featured__role-url" href="/careers/{{job.id}}">{{ job.title }}</a>
     </div>
   </div>

--- a/templates/shared/_fast_track_jobs.html
+++ b/templates/shared/_fast_track_jobs.html
@@ -5,10 +5,10 @@
 </div>
 <div class="p-featured is-fast-track row">
   {% for job in fast_track_jobs %}
-  <div class="p-featured__item col-small-4 col-medium-3 col-4">
-    <p class="p-featured__role">
+  <div class="p-featured__item col-small-4 col-medium-3 col-4 u-no-padding--left u-vertically-center">
+    <div class="p-card p-featured__role u-no-margin--bottom u-vertically-center">
       <a class="p-featured__role-url" href="/careers/{{job.id}}">{{ job.title }}</a>
-    </p>
+    </div>
   </div>
   {% endfor %}
 </div>

--- a/templates/shared/_featured_jobs.html
+++ b/templates/shared/_featured_jobs.html
@@ -1,6 +1,6 @@
 <section>
   <div class="u-fixed-width">
-    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Featured Jobs</h2>
+    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Featured Roles</h2>
   </div>
   <div class="p-featured row u-sv2">
     {% for job in featured_jobs %}
@@ -10,9 +10,6 @@
              <a class="p-featured__url" href="/careers/{{job.id}}">{{ job.title }}</a>
           </p>
         </div>
-        {% if loop.last and not loop.index % 4 == 0 %}
-          <div class="p-featured__filler u-hide--small col-medium-{{ (4 - loop.last) * 1 }} col-{{ (4 - loop.last) * 3 }}"></div>
-        {% endif %}
       {% endif %}
     {% endfor %}
   </div>

--- a/templates/shared/_featured_jobs.html
+++ b/templates/shared/_featured_jobs.html
@@ -1,9 +1,9 @@
 <section>
   <div class="u-fixed-width">
     <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Featured Roles</h2>
+    <hr class="u-no-margin--bottom">
   </div>
   <div class="p-featured row u-sv2">
-    <hr class="u-fixed-width">
     {% for job in featured_jobs %}
       {% if loop.index < 7 %}
         <div class="p-featured__item col-small-4 col-medium-3 col-4 u-no-padding--left">

--- a/templates/shared/_featured_jobs.html
+++ b/templates/shared/_featured_jobs.html
@@ -3,12 +3,13 @@
     <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Featured Roles</h2>
   </div>
   <div class="p-featured row u-sv2">
+    <hr class="u-fixed-width">
     {% for job in featured_jobs %}
       {% if loop.index < 7 %}
-        <div class="p-featured__item col-small-4 col-medium-3 col-4">
-          <p class="p-featured__role">
-             <a class="p-featured__url" href="/careers/{{job.id}}">{{ job.title }}</a>
-          </p>
+        <div class="p-featured__item col-small-4 col-medium-3 col-4 u-no-padding--left u-vertically-center">
+          <div class="p-card p-featured__role u-no-margin--bottom u-vertically-center">
+            <a class="p-featured__url p-card--content" href="/careers/{{job.id}}">{{ job.title }}</a>
+          </div>
         </div>
       {% endif %}
     {% endfor %}

--- a/templates/shared/_featured_jobs.html
+++ b/templates/shared/_featured_jobs.html
@@ -6,9 +6,9 @@
     <hr class="u-fixed-width">
     {% for job in featured_jobs %}
       {% if loop.index < 7 %}
-        <div class="p-featured__item col-small-4 col-medium-3 col-4 u-no-padding--left u-vertically-center">
-          <div class="p-card p-featured__role u-no-margin--bottom u-vertically-center">
-            <a class="p-featured__url p-card--content" href="/careers/{{job.id}}">{{ job.title }}</a>
+        <div class="p-featured__item col-small-4 col-medium-3 col-4 u-no-padding--left">
+          <div class="p-card p-featured__role u-no-margin--bottom">
+            <p><a class="p-featured__url p-card--content" href="/careers/{{job.id}}">{{ job.title }}</a></p>
           </div>
         </div>
       {% endif %}


### PR DESCRIPTION
## Done

- Fixed search width
- Changed copy from "jobs" to "roles"
- Fixed asymmetrical separators

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/engineering (please also check multiple departments)
- Make sure the bugs listed in linked issue are no longer present

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1785
