### PR TITLE
Show the early stage interview happening today on the application page

### DIFF
--- a/templates/careers/application/partial/_early-stage.html
+++ b/templates/careers/application/partial/_early-stage.html
@@ -16,7 +16,7 @@
         {% endif %}
     {% endfor %}
     {% for interview in application["scheduled_interviews"] %}
-        {% if ( interview["stage_name"] == "Early Stage Interviews" or interview["stage_name"]  == "HR Interview" or interview["stage_name"]  == "Talent Interview" ) and now("%Y%m%d") < interview["start"]["datetime"].strftime('%Y%m%d') %}
+        {% if ( interview["stage_name"] == "Early Stage Interviews" or interview["stage_name"]  == "HR Interview" or interview["stage_name"]  == "Talent Interview" ) and now("%Y%m%d") <= interview["start"]["datetime"].strftime('%Y%m%d') %}
             <hr />
             <h4 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Next interview</h4>
             {% include 'careers/application/_interview-card.html' %}


### PR DESCRIPTION
## Done

Correct the conditional logic on the early-stage interviews section of the application page to render interviews whose start date matches today's date.

## QA

- Open the demo or run it locally
- Check the Talent interview is present for [this candidate](https://pastebin.canonical.com/p/8CKyT22nGg/) and in production, it is not.
