### PR TITLE
Add link with circle of products image to the products page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,9 @@
       <h2>open source from cloud to desktop and devices.</h2>
     </div>
     <div class="col-4 col-start-large-8 u-hide--small u-hide--medium u-animation--slide-from-bottom">
-      <img src="https://assets.ubuntu.com/v1/670abb00-header_illustration.svg" alt="Canonical products logo" width="100%">
+      <a href="https://canonical.com/#products">
+        <img src="https://assets.ubuntu.com/v1/670abb00-header_illustration.svg" alt="Canonical products logo" width="100%">
+      </a>
     </div>
   </div>
   

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,7 @@
     </div>
     <div class="col-4 col-start-large-8 u-hide--small u-hide--medium u-animation--slide-from-bottom">
       <a href="https://canonical.com/#products">
-        <img src="https://assets.ubuntu.com/v1/670abb00-header_illustration.svg" alt="Canonical products logo" width="100%">
+        <img src="https://assets.ubuntu.com/v1/670abb00-header_illustration.svg" alt="Canonical products" width="100%">
       </a>
     </div>
   </div>


### PR DESCRIPTION
## Done

A new link has been added to the homepage's circle of products image, which leads to the products page (https://canonical.com/#products) when clicked.
Alt text for the image has changed to Canonical Products.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #168 

## Screenshots

[if relevant, include a screenshot]
