### PR TITLE
Update meta-description on /documentation

### DIFF
--- a/templates/documentation/index.html
+++ b/templates/documentation/index.html
@@ -6,7 +6,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/10tOsj5kKZRddQYYkb1PgxsES47Qic8XJc9xpRaYHd7s/edit{% endblock %}
 
-{% block meta_description %}A Canonical Technical Author is someone who combines technical curiosity with empathy, rigour and communication skills.{% endblock %}
+{% block meta_description %}At Canonical, we aim to set a standard of excellence in technical documentation, by treating it as a professional discipline within our engineering practice.{% endblock %}
 
 {% block meta_image %}https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg{% endblock %}
 


### PR DESCRIPTION
## Done

Update meta-description on /documentation based on [the copydoc](https://docs.google.com/document/d/10tOsj5kKZRddQYYkb1PgxsES47Qic8XJc9xpRaYHd7s/edit)

## QA

- Visit the page at https://canonical-com-790.demos.haus/documentation and check the head for the correct meta description

