### PR TITLE
WD-2037 Add the department icons to careers index

### DIFF
--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -37,10 +37,20 @@
   </div>
   <div class="row">
     {% for dept in departments_overview %}
-      <div class="col-3">
-        <a class="p-heading--5 u-no-margin--bottom" href="/careers/{{dept.slug}}">{{ dept.name }}</a>
-        <p>{{ dept.count }} roles</p>
+    <div class="col-3">
+      <div class="p-media-object">
+        <img src="https://assets.ubuntu.com/v1/{{dept.icon}}" class="p-media-object__image" style="width: 32px; height: 32px; position: relative; top: 7px;" alt="">
+        <div class="p-media-object__details">
+          <h3 class="p-media-object__title p-heading--5">
+            <a href="/careers/{{dept.slug}}">{{ dept.name }}</a>
+          </h3>
+          <p class="p-media-object__content">{{ dept.count }} roles</p>
+        </div>
       </div>
+    </div>
+    {% if loop.index % 4 == 0 and not loop.last  %}
+    <hr />
+    {% endif %}
     {% endfor %}
   </div>
 </section>

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -37,7 +37,7 @@
   </div>
   <div class="row">
     {% for dept in departments_overview %}
-    <div class="col-3">
+    <div class="col-3 col-medium-2 col-small-2">
       <div class="p-media-object">
         <img src="https://assets.ubuntu.com/v1/{{dept.icon}}" class="p-media-object__image" style="width: 32px; height: 32px; position: relative; top: 7px;" alt="">
         <div class="p-media-object__details">
@@ -49,7 +49,7 @@
       </div>
     </div>
     {% if loop.index % 4 == 0 and not loop.last  %}
-    <hr />
+    <hr class="u-hide u-show--large"/>
     {% endif %}
     {% endfor %}
   </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -232,37 +232,45 @@ def careers_index():
     all_departments = (_group_by_department(greenhouse.get_vacancies()),)
 
     dept_list = [
-        "engineering",
-        "support-engineering",
-        "marketing",
-        "web-and-design",
-        "project-management",
-        "commercial-operations",
-        "product",
-        "sales",
-        "finance",
-        "people",
-        "administration",
-        "legal",
+        {"slug": "engineering", "icon": "84886ac6-Engineering.svg"},
+        {
+            "slug": "support-engineering",
+            "icon": "df08c7f2-Support Engineering.svg",
+        },
+        {"slug": "marketing", "icon": "27b93be4-Marketing.svg"},
+        {"slug": "web-and-design", "icon": "b200e162-design.svg"},
+        {
+            "slug": "project-management",
+            "icon": "0f64ee5c-Project Management.svg",
+        },
+        {"slug": "commercial-operations", "icon": "1f84f8c7-Operations.svg"},
+        {"slug": "product", "icon": "d5341dfa-Product.svg"},
+        {"slug": "sales", "icon": "2dc1ceb1-Sales.svg"},
+        {"slug": "finance", "icon": "8b2110ea-finance.svg"},
+        {"slug": "people", "icon": "01ff5233-Human Resources.svg"},
+        {"slug": "administration", "icon": "a42f5ab5-Admin.svg"},
+        {"slug": "legal", "icon": "4e54c36b-Legal.svg"},
     ]
 
     departments_overview = []
 
     for vacancy in all_departments:
         for dept in dept_list:
-            if vacancy[dept]:
-                if vacancy[dept].vacancies:
-                    count = len(vacancy[dept].vacancies)
+            if vacancy[dept["slug"]]:
+                if vacancy[dept["slug"]].vacancies:
+                    count = len(vacancy[dept["slug"]].vacancies)
                 else:
                     count = 0
-                name = vacancy[dept].name
-                slug = vacancy[dept].slug
+                name = vacancy[dept["slug"]].name
+                slug = vacancy[dept["slug"]].slug
+                icon = dept["icon"]
 
                 departments_overview.append(
                     {
                         "name": name,
                         "count": count,
                         "slug": slug,
+                        "icon": icon,
                     }
                 )
 


### PR DESCRIPTION
## Done
- Add department icons to the `dept_list` which is passed through to the context of the page
- Updated the mark up of the department to render the icon
- Added horizontal rules between lists
- Improve the responsive rendering of the list on medium and small screens

## QA

- Open the demo and visit /careers
- See that the department list matches [the design](https://www.figma.com/file/UsovUAf4zELQgGd9bxhiVe/Careers?node-id=1167%3A10325&t=9GYtgT95zjMHLKVY-1)
- Check different viewports

## Screenshot

![image](https://user-images.githubusercontent.com/1413534/219647616-75224d26-f6a5-4dc9-8f13-0bc9c2ea662c.png)

