### PR TITLE
WD-2116 make search work with lower and upper case

### DIFF
--- a/static/js/find-a-partner.js
+++ b/static/js/find-a-partner.js
@@ -1,6 +1,6 @@
 (function () {
   const numberOfPartnersLabel = document.querySelector(
-    ".js-find-a-partner__number"
+    ".js-find-a-partner__number",
   );
   const searchBox = document.querySelector(".js-find-a-partner__search-input");
   const urlParams = new URLSearchParams(window.location.search);
@@ -71,7 +71,8 @@
       partners.forEach(function (partner) {
         partner.classList.remove("js-searched");
         var searchText = partner.getAttribute("data-searchText").toLowerCase();
-        if (searchText.includes(searchBox.value)) {
+
+        if (searchText.includes(searchBox.value.toLowerCase())) {
           partner.classList.add("js-searched");
         }
       });
@@ -150,7 +151,7 @@
     window.history.pushState(
       { search: searchBox.value, filters: filters },
       "",
-      newUrl
+      newUrl,
     );
   }
 
@@ -203,7 +204,7 @@
   function updateNumberOfPartners() {
     if (numberOfPartnersLabel) {
       numberOfPartnersLabel.innerHTML = document.querySelectorAll(
-        ".js-find-a-partner__partner.js-searched.js-filtered"
+        ".js-find-a-partner__partner.js-searched.js-filtered",
       ).length;
     }
   }


### PR DESCRIPTION
## Done

- Fixed the search filter. Made it work with both lower-case and upper-case search values.

## QA

- Check out the demo on https://canonical-com-801.demos.haus/partners/find-a-partner and ensure the search filter works with lower-case and upper-case inputs, eg: `DELL`, `Dell`, and `dell` should all bring out search results for Dell Technologies.
- You can also test the filter for other partners as well. It should work for all.

## Issue / Card

- [WD-2116](https://warthogs.atlassian.net/browse/WD-2116)


[WD-2116]: https://warthogs.atlassian.net/browse/WD-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ