### PR TITLE
Fix z-indexing on /documentation

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -291,7 +291,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
 .p-featured {
   gap: 0;
 
-  &__item { 
+  &__item {
     cursor: pointer;
     margin-right: 1px;
     padding: 0 1rem 1rem;
@@ -345,4 +345,16 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
 .p-inline-list.is-inlined-with-h2 {
   display: inline-block;
   margin: 1.5rem 0 0 1rem;
+}
+
+// Makes side-navigation fit with the custom top-navigation of c.com
+.p-side-navigation {
+  &--raw-html.is-sticky {
+    top: 4.5rem;
+    z-index: 1;
+  }
+
+  &__drawer {
+  top: 48px;
+  }
 }

--- a/templates/documentation/beyond-canonical.html
+++ b/templates/documentation/beyond-canonical.html
@@ -14,12 +14,12 @@
 <div class="p-strip u-no-padding--top">
   <div class="row" id="documentation">
     <aside class="col-3">
-      <div class="p-side-navigation--raw-html is-sticky" id="drawer" style="top: 4.5rem; z-index: 37;">
+      <div class="p-side-navigation--raw-html is-sticky" id="drawer">
         <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
         </button>
         <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-        <nav class="p-side-navigation__drawer" aria-label="documentation side navigation" style="top: 56px;">
+        <nav class="p-side-navigation__drawer" aria-label="documentation side navigation">
           <div class="p-side-navigation__drawer-header">
             <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
               Toggle table of contents

--- a/templates/documentation/index.html
+++ b/templates/documentation/index.html
@@ -14,12 +14,12 @@
 <section class="p-strip u-no-padding--top">
   <div class="row" id="documentation">
     <aside class="col-3">
-      <div class="p-side-navigation--raw-html is-sticky" id="drawer" style="top: 4.5rem; z-index: 37;">
+      <div class="p-side-navigation--raw-html is-sticky" id="drawer">
         <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
         </button>
         <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-        <nav class="p-side-navigation__drawer" aria-label="documentation side navigation" style="top: 56px;">
+        <nav class="p-side-navigation__drawer" aria-label="documentation side navigation">
           <div class="p-side-navigation__drawer-header">
             <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
               Toggle table of contents

--- a/templates/documentation/work-and-careers.html
+++ b/templates/documentation/work-and-careers.html
@@ -14,12 +14,12 @@
 <section class="p-strip u-no-padding--top">
   <div class="row" id="documentation">
     <aside class="col-3">
-      <div class="p-side-navigation--raw-html is-sticky" id="drawer" style="top: 4.5rem; z-index: 37;">
+      <div class="p-side-navigation--raw-html is-sticky" id="drawer">
         <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
         </button>
         <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-        <nav class="p-side-navigation__drawer" aria-label="documentation side navigation" style="top: 56px;">
+        <nav class="p-side-navigation__drawer" aria-label="documentation side navigation">
           <div class="p-side-navigation__drawer-header">
             <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
               Toggle table of contents


### PR DESCRIPTION
## Done

- Fix z-indexing on /documentation
- Make navigation drawer flush with navigation

## QA

- Go to https://canonical-com-804.demos.haus/documentation on mobile view or a small screen
- Check that when a drop down from the top-navigation is open, it goes over the side-navigation
- Check the navigation drawer is flush with the navigation.

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/803

## Screenshots

before:
![image](https://user-images.githubusercontent.com/58276363/220297940-e68f034c-3747-4398-bf77-06e1a8fac5ed.png)
after:
![image](https://user-images.githubusercontent.com/58276363/220297999-b69ba20d-6841-495e-991a-ec1eaa2d4f5c.png)

before:
![image](https://user-images.githubusercontent.com/58276363/220298151-4760c6e8-f39e-4f00-95b6-26012c84fa93.png)
after:
![image](https://user-images.githubusercontent.com/58276363/220298208-61fc53ca-0d14-4a8d-be7c-1acbdc8d6fc9.png)

before:
