### PR TITLE
Remove the job description overriding styling

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -193,6 +193,27 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
   }
 }
 
+// Override h2 in job descriptions to look like h3
+.job-desc {
+  h1 {
+    @extend %vf-heading-2;
+  }
+
+  h2 {
+    @extend %vf-heading-3;
+  }
+
+  h3 {
+    @extend %vf-heading-5;
+  }
+
+  // Hide any empty p tags or consecutive breaks
+  p:empty,
+  br + br {
+    display: none;
+  }
+}
+
 .desktop-hero {
   background-image: url("#{$assets-path}ce95be94-careers-guy.jpg");
   background-position: right bottom;
@@ -324,4 +345,12 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
 .p-inline-list.is-inlined-with-h2 {
   display: inline-block;
   margin: 1.5rem 0 0 1rem;
+}
+
+// XXX: Ant - 21/02/2023
+// Fix for breakage introduced in Vanilla v3.11.1
+// Reported: https://github.com/canonical/vanilla-framework/issues/4664
+.p-text--x-small-capitalised {
+  font-size: 1rem;
+  font-weight: 400;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -193,27 +193,6 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
   }
 }
 
-// Override h2 in job descriptions to look like h3
-.job-desc {
-  h1 {
-    @extend %vf-heading-2;
-  }
-
-  h2 {
-    @extend %vf-heading-3;
-  }
-
-  h3 {
-    @extend %vf-heading-5;
-  }
-
-  // Hide any empty p tags or consecutive breaks
-  p:empty,
-  br + br {
-    display: none;
-  }
-}
-
 .desktop-hero {
   background-image: url("#{$assets-path}ce95be94-careers-guy.jpg");
   background-position: right bottom;
@@ -291,7 +270,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
 .p-featured {
   gap: 0;
 
-  &__item { 
+  &__item {
     cursor: pointer;
     margin-right: 1px;
     padding: 0 1rem 1rem;


### PR DESCRIPTION
## Done
Remove the job description overriding styling to fix the breakage of the use of `p-text--x-small-capitalised u-align-text--x-small-to-default u-no-margin--bottom`

## QA

- Open the demo and go to /careers/engineering
- See that the titles "Expertise" and  "Featured Roles" are small and capitalised
- Check production is not.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1413534/220339262-b0b58fa2-1620-4003-94ac-b920eab142fd.png) | ![image](https://user-images.githubusercontent.com/1413534/220338904-b64504e2-054e-4514-aaec-818d871754e1.png) |

