### PR TITLE
WD-2138 Remove the fast track roles from departments pages

### DIFF
--- a/templates/shared/_promoted_roles.html
+++ b/templates/shared/_promoted_roles.html
@@ -1,8 +1,4 @@
 <section class="p-strip--light">
-  {% if fast_track_jobs %}
-    {% include "shared/_fast_track_jobs.html" %}
-  {% endif %}
-
   {% if featured_jobs %}
     {% include "shared/_featured_jobs.html" %}
   {% endif %}


### PR DESCRIPTION
## Done

Remove the fast-track roles from departments pages

## QA

- Open the demo and go to /careers/engineering
- See there are no fast track/expertise roles
 
## Screenshot
![image](https://user-images.githubusercontent.com/1413534/220381054-e0a389ff-a7ac-4e8a-8ccc-ecf999e0f36d.png)
