### PR TITLE
Respect the Greenhouse application answer order in select elements

### DIFF
--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -98,7 +98,7 @@
             {% elif question.fields[0].type == "multi_value_single_select" %}
             <select name="{{ question.fields[0].name }}" id="{{ question.fields[0].name }}" {% if question.required %}required{% endif %}>
               <option value="" disabled="disabled" selected="">Select an option</option>
-              {% for answer_option in question.fields[0].get("values",[]) %}
+              {% for answer_option in question.fields[0].get("values",[])|reverse %}
               <option value="{{ answer_option.value }}">{{ answer_option.label }}</option>
               {% endfor %}
             </select>


### PR DESCRIPTION
## Done

- Reverse the rendering order on a single select dropdown in application answers.

## QA

- Go to /careers/3979744/application
- Check the order of the "How did you do in maths, physics or computer science at high school?" start with "Cannot recall" and end with "Top student"

## Screenshot
![image](https://user-images.githubusercontent.com/1413534/223440253-cc46082c-12cd-42c9-b69c-fcc9733312f9.png)

