### PR TITLE
Enable back withdraw application

### DIFF
--- a/templates/careers/application/index.html
+++ b/templates/careers/application/index.html
@@ -217,7 +217,6 @@
       </div>
     </section>
 
-    <!--
     {% if application["status"] == "active" %}
     <hr class="is-fixed-width">
     <section class="p-strip is-deep">
@@ -256,7 +255,6 @@
       {% endif %}
     </section>
     {% endif %}
-    -->
 
   {% elif application["status"] == "hired" %}
     <section class="p-strip">

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -263,8 +263,7 @@ def _send_mail(
     msg["To"] = ", ".join(to_email)
     msg.set_content(message, subtype="html")
 
-    server = SMTP(smtp_server)
-
+    server = SMTP(host=smtp_server)
     if smtp_user and smtp_pass:
         server.ehlo()
         server.starttls()


### PR DESCRIPTION
## Done

- Update smtp credentials on production/staging
- Revert https://github.com/canonical/canonical.com/pull/741

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- I made a testing endpoint locally and sent myself an email with those credentials and got it! You can do the same locally on the file `webapp/application.py`:

```python
@application.route("/testing")
def testing():
    _send_mail(["<USE YOUR EMAIL>@canonical.com"], "lol", "lol")
    return ""
```
- Add credentials to `.env.local`
- connect to the VPN and `dotrun`
- http://0.0.0.0:8002/careers/application/testing
- Check your inbox and make sure you got an email from the right person :)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1005