### PR TITLE
Remove location filters from explorer results

### DIFF
--- a/templates/careers/base.html
+++ b/templates/careers/base.html
@@ -9,7 +9,9 @@
 
 <section class="p-strip u-extra-space">
   <div class="row">
-    {% include 'partial/_careers-navigation.html' %}
+    {% if "results" not in request.url  %}
+      {% include 'partial/_careers-navigation.html' %}
+    {% endif %}
     <div class="col-9 col-medium-4">
       {% block careers_content %}{% endblock %}
     </div>


### PR DESCRIPTION
## Done

This removes the location filters from the results page of the career explorer game. This is a temporary fix while we wait for the [redesign](https://github.com/canonical/canonical.com/pull/794) to be applied. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Open the [demo](https://canonical-com-820.demos.haus/careers/results?core-skills=Developer,Scientist,Organiser,Analyzer,Manager) or complete the game yourself to get to the results page
- See that the location filters have been removed, compared with [live site](https://canonical.com/careers/results?core-skills=Developer,Organiser,Scientist,Analyzer,Manager)

## Context
This was mentioned in https://github.com/canonical/canonical.com/issues/819 ("Specific list of actions which produce unexpected or unhelpful results"  -> point # 6)
