### PR TITLE
Add GIA candidate feedback download link to Candidate page

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -32,6 +32,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
 @include vf-p-icon-user-group;
 @include vf-p-icon-video-play;
 @include vf-p-icon-warning-grey;
+@include vf-p-icon-begin-downloading;
 @include blog-p-card;
 @include canonical-u-animations;
 @include canonical-p-stepped-list;
@@ -373,7 +374,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
 
 .p-list--travel {
   @extend .p-list--divided;
-  
+
   columns: 5;
 
   @media (max-width: 620px){

--- a/templates/careers/application/partial/_assessment.html
+++ b/templates/careers/application/partial/_assessment.html
@@ -10,7 +10,10 @@
             <p class="p-stepped-list__title u-no-margin--bottom">The Written Interview: As the first part of this stage we invite you to submit your answers to some questions specifically designed so that we can find out more about your experience and skill set. This is your opportunity to highlight your key strengths for this position. To ensure that we mitigate against unconscious bias in our hiring process we ask that you refrain from including any personal identifiable information in this document.</p>
           </li>
           <li class="p-stepped-list__item">
-            <p class="p-stepped-list__title u-no-margin--bottom">Psychometric assessment: As part of our professional review this assessment will help us to understand your fluid intelligence.</p>
+            <p class="p-stepped-list__title">Psychometric assessment: As part of our professional review this assessment will help us to understand your fluid intelligence.</p>
+            {% if application["gia_feedback"] %}
+              <p style="padding-left: 2.5rem;" class="u-no-margin--bottom"><a href="{{ application['gia_feedback'].url }}" download>Download your GIA feedback document <i class="p-icon--begin-downloading"></i></a></p>
+            {% endif %}
           </li>
           <li class="p-stepped-list__item">
             <p class="p-stepped-list__title u-no-margin--bottom">Technical tests: Some roles will require a technical assignment to be completed.</p>
@@ -40,7 +43,10 @@
           <p class="p-stepped-list__title u-no-margin--bottom">The Written Interview: As the first part of this stage we invite you to submit your answers to some questions specifically designed so that we can find out more about your experience and skill set. This is your opportunity to highlight your key strengths for this position. To ensure that we mitigate against unconscious bias in our hiring process we ask that you refrain from including any personal identifiable information in this document.</p>
         </li>
         <li class="p-stepped-list__item">
-          <p class="p-stepped-list__title u-no-margin--bottom">Psychometric assessment: As part of our professional review this assessment will help us to understand your fluid intelligence.</p>
+          <p class="p-stepped-list__title">Psychometric assessment: As part of our professional review this assessment will help us to understand your fluid intelligence.</p>
+          {% if application["gia_feedback"] %}
+            <p style="padding-left: 2.5rem;" class="u-no-margin--bottom"><a href="{{ application['gia_feedback'].url }}" download>Download your GIA feedback document <i class="p-icon--begin-downloading"></i></a></p>
+          {% endif %}
         </li>
         <li class="p-stepped-list__item">
           <p class="p-stepped-list__title u-no-margin--bottom">Technical tests: Some roles will require a technical assignment to be completed.</p>

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,6 +1,10 @@
 import unittest
 
-from webapp.application import _milestones_progress, _sort_stages_by_milestone
+from webapp.application import (
+    _milestones_progress,
+    _sort_stages_by_milestone,
+    _get_gia_feedback,
+)
 
 all_stages = [
     {"name": "Application Review"},
@@ -96,6 +100,97 @@ class TestApplicationPageHelpers(unittest.TestCase):
                 "offer": False,
             },
         )
+
+
+class TestGetGiaFeedback(unittest.TestCase):
+    def test_gia_feedback_is_found_correctly(self):
+        attachments = [
+            {
+                "filename": "Joe_Thomas_International_GIA_Report.pdf",
+                "url": "https://Thomas_International_GIA_Report.pdf",
+                "type": "other",
+                "created_at": "2023-03-14T14:56:23.973Z",
+            },
+            {
+                "filename": "Joe_Thomas_International_Candidate_Feedback.pdf",
+                "url": "https://Thomas_International_Candidate_Feedback.pdf",
+                "type": "other",
+                "created_at": "2023-03-14T14:56:19.012Z",
+            },
+            {
+                "filename": "Joe_Thomas_International_GIA_Report.pdf",
+                "url": "https://Thomas_International_GIA_Report.pdf",
+                "type": "other",
+                "created_at": "2023-03-14T14:56:11.164Z",
+            },
+        ]
+        self.assertDictEqual(
+            _get_gia_feedback(attachments),
+            {
+                "filename": "Joe_Thomas_International_Candidate_Feedback.pdf",
+                "url": "https://Thomas_International_Candidate_Feedback.pdf",
+                "type": "other",
+                "created_at": "2023-03-14T14:56:19.012Z",
+            },
+        )
+
+    def test_gia_feedback_returns_one_if_more_available(self):
+        attachments = [
+            {
+                "filename": "Joe_Thomas_International_GIA_Report.pdf",
+                "url": "https://Thomas_International_GIA_Report.pdf",
+                "type": "other",
+                "created_at": "2023-03-14T14:56:23.973Z",
+            },
+            {
+                "filename": "Joe_Thomas_International_Candidate_Feedback.pdf",
+                "url": "https://Thomas_International_Candidate_Feedback.pdf",
+                "type": "other",
+                "created_at": "2023-03-14T14:56:19.012Z",
+            },
+            {
+                "filename": "Joe_Thomas_International_Candidate_Feedback.pdf",
+                "url": "https://Thomas_International_Candidate_Feedback.pdf",
+                "type": "other",
+                "created_at": "2023-03-14T14:56:19.012Z",
+            },
+            {
+                "filename": "Joe_Thomas_International_GIA_Report.pdf",
+                "url": "https://Thomas_International_GIA_Report.pdf",
+                "type": "other",
+                "created_at": "2023-03-14T14:56:11.164Z",
+            },
+        ]
+        self.assertDictEqual(
+            _get_gia_feedback(attachments),
+            {
+                "filename": "Joe_Thomas_International_Candidate_Feedback.pdf",
+                "url": "https://Thomas_International_Candidate_Feedback.pdf",
+                "type": "other",
+                "created_at": "2023-03-14T14:56:19.012Z",
+            },
+        )
+
+    def test_gia_feedback_not_found(self):
+        attachments = [
+            {
+                "filename": "Joe_Thomas_International_GIA_Report.pdf",
+                "url": "https://Thomas_International_GIA_Report.pdf",
+                "type": "other",
+                "created_at": "2023-03-14T14:56:23.973Z",
+            },
+            {
+                "filename": "Joe_Thomas_International_GIA_Report.pdf",
+                "url": "https://Thomas_International_GIA_Report.pdf",
+                "type": "other",
+                "created_at": "2023-03-14T14:56:11.164Z",
+            },
+        ]
+        self.assertEqual(_get_gia_feedback(attachments), None)
+
+    def test_gia_feedback_not_found_when_empty(self):
+        attachments = []
+        self.assertEqual(_get_gia_feedback(attachments), None)
 
 
 if __name__ == "__main__":

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -233,6 +233,19 @@ def _get_application_from_token(token):
     return _get_application(token_application_id)
 
 
+def _get_gia_feedback(attachments):
+    for attachment in attachments:
+        if (
+            attachment
+            and attachment["filename"]
+            and attachment["filename"].endswith(
+                "Thomas_International_Candidate_Feedback.pdf"
+            )
+        ):
+            print(attachment)
+            return attachment
+
+
 def _confirmation_token(
     email, withdrawal_reason_id, withdrawal_message, application_id
 ):
@@ -314,6 +327,10 @@ def application_index(token):
     if application["status"] != "active" and application["rejection_reason"]:
         if application["rejection_reason"]["type"]["id"] == 2:
             withdrawn = True
+
+    gia_feedback = _get_gia_feedback(application["attachments"])
+    if gia_feedback:
+        application["gia_feedback"] = gia_feedback
 
     return flask.render_template(
         "careers/application/index.html",


### PR DESCRIPTION
## Done

- Added a link to the bottom of the GIA section of the assessment if the feedback document is available.
- Added tests for the attachments parser

## QA

- Open the demo and visit [this path](https://pastebin.canonical.com/p/mTbC2gcN65/) (Canonical only)
- See that the candidate has a link to the GIA feedback on the candidate page
- View a few candidates in different states (ask me for tokens if needed)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2946

## Screenshots

![image](https://user-images.githubusercontent.com/1413534/228903452-2a7c4f0e-5389-4bcb-aaee-a08baf3eb38b.png)

