### PR TITLE
WD-2082 Add analytics to fast track and featured roles

### DIFF
--- a/templates/shared/_fast_track_jobs.html
+++ b/templates/shared/_fast_track_jobs.html
@@ -7,7 +7,7 @@
   {% for job in fast_track_jobs %}
   <div class="p-featured__item col-small-4 col-medium-3 col-4 u-no-padding--left">
     <div class="p-card p-featured__role u-no-margin--bottom">
-      <a class="p-featured__role-url" href="/careers/{{job.id}}">{{ job.title }}</a>
+      <a class="p-featured__role-url" href="/careers/{{job.id}}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Fast track job', 'eventAction' : 'Click', 'eventLabel' : '{{ job.title }}', 'eventValue' : undefined });">{{ job.title }}</a>
     </div>
   </div>
   {% endfor %}

--- a/templates/shared/_featured_jobs.html
+++ b/templates/shared/_featured_jobs.html
@@ -8,7 +8,7 @@
       {% if loop.index < 7 %}
         <div class="p-featured__item col-small-4 col-medium-3 col-4 u-no-padding--left">
           <div class="p-card p-featured__role u-no-margin--bottom">
-            <p><a class="p-featured__url p-card--content" href="/careers/{{job.id}}">{{ job.title }}</a></p>
+            <p><a class="p-featured__url p-card--content" href="/careers/{{job.id}}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Featured job', 'eventAction' : 'Click', 'eventLabel' : '{{ job.title }}', 'eventValue' : undefined });">{{ job.title }}</a></p>
           </div>
         </div>
       {% endif %}


### PR DESCRIPTION
## QA

- Go to e.g. https://canonical-com-837.demos.haus/careers/finance
- Click on one of the featured roles and check on [GA](https://analytics.google.com/analytics/web/#/realtime/rt-event/a1018242w108544136p153647982/filter.list=14==(none);7==(direct)/) that the event action shows up?



