### PR TITLE
/partners redesign 

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -20,6 +20,13 @@
 }
 
 // Align social links to bottom on large screens
+@mixin canonical-partners-footer {
+  .partners-footer {
+    border-left: 5px solid #E95420;
+    padding-left:0.6rem;
+  }
+}
+
 @mixin canonical-u-footer-align-bottom {
   @media (min-width: $breakpoint-large) {
     .u-position {

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -23,7 +23,7 @@
 @mixin canonical-partners-footer {
   .partners-footer {
     border-left: 5px solid #E95420;
-    padding-left:0.6rem;
+    padding-left:27px;
   }
 }
 

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -435,32 +435,18 @@
 }
 
 @mixin canonical-p-strip-suru-partners {
-  .p-strip--suru-partners {
-    background-color: #f4f4f3;
-    background-image: url("https://assets.ubuntu.com/v1/b4bb5563-strip.png");
-    background-position: bottom !important;
-    background-repeat: no-repeat;
-    background-size: contain;
-
-    &.is-hero{
-      padding: 8rem;
-
-      @media screen and (max-width: $breakpoint-small - 1) {
-        padding: 4rem;
-      }
-    }
-
-    .col-8 > :nth-child(3){
-      @media screen and (min-width: $breakpoint-large) {
-        padding-bottom: 4rem;
-      }
-    }
+  .p-strip.is-paper {
+    background-color: #f3f3f3;
+    // background-image: url("https://assets.ubuntu.com/v1/6ee7af42-0_website_suru_25.png");
+    // background-position: bottom center;
+    // background-repeat: no-repeat;
+    // background-size: $grid-max-width;
   }
 }
 
 @mixin canonical-p-strip-partners {
   .p-strip--partners {
-    background-color: #f4f4f3;
+    background-color: #f3f3f3;
   }
 }
 

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -10,7 +10,6 @@
   @include canonical-p-strip-suru-half-and-half-reversed;
   @include canonical-p-strip-suru-topped;
   @include canonical-p-strip-suru-partners;
-  @include canonical-p-strip-partners;
   @include canonical-p-strip-suru-top;
   @include canonical-p-strip-standard-dark;
 
@@ -436,16 +435,6 @@
 
 @mixin canonical-p-strip-suru-partners {
   .p-strip.is-paper {
-    background-color: #f3f3f3;
-    // background-image: url("https://assets.ubuntu.com/v1/6ee7af42-0_website_suru_25.png");
-    // background-position: bottom center;
-    // background-repeat: no-repeat;
-    // background-size: $grid-max-width;
-  }
-}
-
-@mixin canonical-p-strip-partners {
-  .p-strip--partners {
     background-color: #f3f3f3;
   }
 }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -441,6 +441,14 @@
     background-position: bottom !important;
     background-repeat: no-repeat;
     background-size: contain;
+
+    &.is-hero{
+      padding: 8rem;
+
+      @media screen and (max-width: $breakpoint-small - 1) {
+        padding: 4rem;
+      }
+    }
   }
 }
 

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -435,28 +435,9 @@
 
 @mixin canonical-p-strip-suru-partners {
   .p-strip--suru-partners {
-    background-image: linear-gradient(
-        to bottom right,
-        rgb(210 180 202 / 5%) 0%,
-        rgb(210 180 202 / 5%) 49.9%,
-        rgb(210 180 202 / 0%) 50%,
-        rgb(210 180 202 / 0%) 100%
-      ),
-      linear-gradient(
-        to top right,
-        rgb(74 24 60 / 0%) 0%,
-        rgb(74 24 60 / 0%) 49.9%,
-        rgb(74 24 60 / 34%) 50%,
-        rgb(74 24 60 / 34%) 100%
-      ),
-      linear-gradient(to top left, #f7f7f7 0%, #f7f7f7 49%, transparent 50%),
-      linear-gradient(140deg, #e95420 0%, #772953 33%, #2c001e 72%);
-    background-position: left top, right top, right 101%;
-    background-repeat: no-repeat;
-    background-size: 70% 80%, 100% 100%, 105% 30%, 100% 100%;
-    color: #fff;
-    padding-bottom: 6rem;
-    padding-top: 6rem;
+    background-position: 100% 75%;
+    background-size: cover;
+    background-image: url("https://assets.ubuntu.com/v1/b4bb5563-strip.png");
   }
 }
 

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -10,6 +10,7 @@
   @include canonical-p-strip-suru-half-and-half-reversed;
   @include canonical-p-strip-suru-topped;
   @include canonical-p-strip-suru-partners;
+  @include canonical-p-strip-partners;
   @include canonical-p-strip-suru-top;
   @include canonical-p-strip-standard-dark;
 
@@ -435,9 +436,17 @@
 
 @mixin canonical-p-strip-suru-partners {
   .p-strip--suru-partners {
-    background-position: 100% 75%;
-    background-size: cover;
+    background-color: #f4f4f3;
     background-image: url("https://assets.ubuntu.com/v1/b4bb5563-strip.png");
+    background-position: bottom !important;
+    background-repeat: no-repeat;
+    background-size: contain;
+  }
+}
+
+@mixin canonical-p-strip-partners {
+  .p-strip--partners {
+    background-color: #f4f4f3;
   }
 }
 

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -449,6 +449,12 @@
         padding: 4rem;
       }
     }
+
+    .col-8 > :nth-child(3){
+      @media screen and (min-width: $breakpoint-large) {
+        padding-bottom: 4rem;
+      }
+    }
   }
 }
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -51,6 +51,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
 @include canonical-search-form;
 @include canonical-u-footer-align-bottom;
 @include canonical-p-careers-progression;
+@include canonical-partners-footer;
 
 .is-grey {
   background-color: $color-mid-x-light;

--- a/templates/partial/_partners-footer.html
+++ b/templates/partial/_partners-footer.html
@@ -1,15 +1,24 @@
-<section class="p-strip is-deep">
+<section class="p-strip is-paper u-no-padding--top">
+  <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
-    <div class="col-6 partners-footer">
-      <h3>Find a partner</h3>
+    <div class="col-6 col-medium-3">
+      <h3 class="p-heading--2">Find a partner</h3>
+    </div>
+    <div class="col-6 col-medium-3">
         <p>Looking for a supplier with Ubuntu expertise? Select from the <br class="u-hide--small">complete list of our partners.</p>
         <a href="/partners/find-a-partner">Find a partner&nbsp;&rsaquo;</a>
     </div>
-    <br class="u-hide--large">
-    <div class="col-6 partners-footer">
-      <h3>Become a partner</h3>
-        <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
-        <a href="/partners/become-a-partner">Talk to us about becoming a partner&nbsp;&rsaquo;</a>
-    </div>
   </div>
+</section>
+<section class="p-strip is-paper is-deep u-no-padding--top">
+  <div class="row">
+    <hr class="is-fixed-width u-no-margin--bottom">
+    <div class="col-6 col-medium-3">
+      <h3 class="p-heading--2">Become a partner</h3>
+    </div>
+    <div class="col-6 col-medium-3">
+      <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
+      <a href="/partners/become-a-partner">Talk to us about becoming a partner&nbsp;&rsaquo;</a>
+    </div>
+</div>
 </section>

--- a/templates/partial/_partners-footer.html
+++ b/templates/partial/_partners-footer.html
@@ -1,10 +1,11 @@
 <section class="p-strip is-deep">
-  <div class="row p-divider">
+  <div class="row">
     <div class="col-6 partners-footer">
       <h3>Find a partner</h3>
         <p>Looking for a supplier with Ubuntu expertise? Select from the <br class="u-hide--small">complete list of our partners.</p>
         <a href="/partners/find-a-partner">Find a partner&nbsp;&rsaquo;</a>
     </div>
+    <br class="u-hide--large">
     <div class="col-6 partners-footer">
       <h3>Become a partner</h3>
         <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>

--- a/templates/partial/_partners-footer.html
+++ b/templates/partial/_partners-footer.html
@@ -1,27 +1,14 @@
-<section class="p-strip--mid-light is-deep">
+<section class="p-strip is-deep">
   <div class="row p-divider">
-    <div class="col-6 p-divider__block">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/2cdff5cc-magnifier-find-a-partner-footer.svg" alt=""
-          class="p-media-object__image">
-        <div class="p-media-object__details">
-          <h2 class="p-media-object__title">Find a partner</h2>
-          <p class="p-media-object__content u-sv3">Looking for a supplier with Ubuntu expertise? Select from the
-            complete list of our partners.</p>
-          <a href="/partners/find-a-partner">Find a partner&nbsp;&rsaquo;</a>
-        </div>
-      </div>
+    <div class="col-6 partners-footer">
+      <h3>Find a partner</h3>
+        <p>Looking for a supplier with Ubuntu expertise? Select from the <br class="u-hide--small">complete list of our partners.</p>
+        <a href="/partners/find-a-partner">Find a partner&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-6 p-divider__block">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/292d1694-become-a-partner-footer.svg" alt="" class="p-media-object__image">
-        <div class="p-media-object__details">
-          <h2 class="p-media-object__title">Become a partner</h2>
-          <p class="p-media-object__content u-sv3">Interested in becoming an Ubuntu partner? Talk to us today to learn
-            more about our programmes.</p>
-          <a href="/partners/become-a-partner">Talk to us about becoming a partner&nbsp;&rsaquo;</a>
-        </div>
-      </div>
+    <div class="col-6 partners-footer">
+      <h3>Become a partner</h3>
+        <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
+        <a href="/partners/become-a-partner">Talk to us about becoming a partner&nbsp;&rsaquo;</a>
     </div>
   </div>
 </section>

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -1,110 +1,108 @@
 {% extends 'base_index.html' %}
 
 {% block content %}
-<section class="p-strip--suru-partners is-deep is-hero">
+
+<div class="u-fixed-width u-align--right">
+  <p class="u-no-margin--bottom u-align-text--right u-sv1">Existing partner? <a href="https://partner-portal.canonical.com">Log in to the partner portal</a></p>
+</div>
+<section class="p-strip is-paper is-deep">
   <div class="row">
-    <div class="col-start-large-4 col-8">
-      <h1>Canonical <br class="u-hide--small">partner programmes</h1>
+    <div class="col-6 col-medium-3">
+      <h1 class="p-heading--2"><strong>Canonical <br class="u-hide--small">partner programmes</strong></h1>
+    </div>
+    <div class="col-6 col-medium-3">
       <p>At Canonical, we provide the services our partners need to ensure their hardware and software works optimally with the Ubuntu platform.</p>
       <p>This means working with technology leaders large and small, to provide the software, services, support and certification they need to complement their core competencies. For technology customers, this has created a thriving market of suppliers with Ubuntu expertise.</p>
     </div>
   </div>
 </section>
 
-<section class="p-strip--partners is-deep">
-  <hr class="is-fixed-width u-no-margin--bottom">
-  <div class="row">
-    <div class="col-3 col-medium-6">
-      <h2 class="p-text--small-caps" style="padding-bottom: 0;">Login</h2>
-    </div>
-    <div class="col-9 col-medium-6">
-      <p>Are you an existing partner? <a href="https://partner-portal.canonical.com">Login to the partner portal</a></p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--partners is-deep">
+<section class="p-strip is-paper u-no-padding--top">
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-3 col-medium-3">
-      <h3 class="p-text--small-caps">Programmes</h3>
+      <h3 class="p-heading--2">Programmes</h3>
     </div>
-    <div class="col-3 col-medium-3">
-      <p>
-        <a href="/partners/public-cloud">Public cloud&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-    <div class="col-6 col-medium-6">
-      <p>Ubuntu on clouds is optimised, tested and certified by Canonical for performance and security</p>
+    <div class="col-9 col-medium-3">
+      <div class="row">
+        <div class="col-3">
+          <p class="p-heading--5">
+            <a href="/partners/public-cloud">Public cloud&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+        <div class="col-6">
+          <p>Ubuntu on clouds is optimised, tested and certified by Canonical for performance and security</p>
+        </div>
+      </div>
+      <hr class="u-no-margin--bottom">
+      <div class="row">
+        <div class="col-3">
+          <p class="p-heading--5">
+            <a href="/partners/ihv-and-oem">IHV/OEM&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+        <div class="col-6">
+          <p>Certified hardware for efficient data centres from the large-scale core to distributed edge</p>
+        </div>
+      </div>
+      <hr class="u-no-margin--bottom">
+      <div class="row">
+        <div class="col-3">
+          <p class="p-heading--5">
+            <a href="https://ubuntu.com/silicon">Silicon&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+        <div class="col-6">
+          <p>Enablement and optimisation of Ubuntu on a wide range of CPUs and chipsets, boards and SOCs</p>
+        </div>
+      </div>
+      <hr class="u-no-margin--bottom">
+      <div class="row">
+        <div class="col-3">
+          <p class="p-heading--5">
+            <a href="/partners/channel-and-reseller">Channel&sol;Reseller&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+        <div class="col-6">
+          <p>Channel partners ensure that local Ubuntu expertise is available on every continent</p>
+        </div>
+      </div>
+      <hr class="u-no-margin--bottom">
+      <div class="row">
+        <div class="col-3">
+          <p class="p-heading--5">
+            <a href="/partners/iot-device">IoT Device&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+        <div class="col-6">
+          <p>TODM, factory, integration and device management partners get your device to market faster</p>
+        </div>
+      </div>
+      <hr class="u-no-margin--bottom">
+      <div class="row">
+        <div class="col-3">
+          <p class="p-heading--5">
+            <a href="/partners/gsi">Global System Integrators&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+        <div class="col-6">
+          <p>Deliver solutions on Ubuntu to drive down costs and accelerate the adoption of open source</p>
+        </div>
+      </div>
+      <hr class="u-no-margin--bottom">
+      <div class="row">
+        <div class="col-3">
+          <p class="p-heading--5">
+            <a href="/partners/desktop">Desktop&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+        <div class="col-6">
+          <p>Pre-installed and certified Ubuntu on desktops, laptops and workstations</p>
+        </div>
+      </div>
     </div>
   </div>
   
-  <div class="row">
-    <hr class="col-start-large-4 col-9 u-no-margin--bottom">
-    <div class="col-start-large-4 col-3">
-      <p>
-        <a href="/partners/ihv-and-oem">IHV/OEM&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-    <div class="col-6 col-medium-6">
-      <p>Certified hardware for efficient data centres from the large-scale core to distributed edge</p>
-    </div>
-  </div>
-  <div class="row">
-    <hr class="col-start-large-4 col-9 u-no-margin--bottom">
-    <div class="col-start-large-4 col-3">
-      <p>
-        <a href="https://ubuntu.com/silicon">Silicon&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-    <div class="col-6 col-medium-6">
-      <p>Enablement and optimisation of Ubuntu on a wide range of CPUs and chipsets, boards and SOCs</p>
-    </div>
-  </div>
-  <div class="row">
-    <hr class="col-start-large-4 col-9 u-no-margin--bottom">
-    <div class="col-start-large-4 col-3">
-      <p>
-        <a href="/partners/channel-and-reseller">Channel&sol;Reseller&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-    <div class="col-6 col-medium-6">
-      <p>Channel partners ensure that local Ubuntu expertise is available on every continent</p>
-    </div>
-  </div>
-  <div class="row">
-    <hr class="col-start-large-4 col-9 u-no-margin--bottom">
-    <div class="col-start-large-4 col-3">
-      <p>
-        <a href="/partners/iot-device">IoT Device&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-    <div class="col-6 col-medium-6">
-      <p>TODM, factory, integration and device management partners get your device to market faster</p>
-    </div>
-  </div>
-  <div class="row">
-    <hr class="col-start-large-4 col-9 u-no-margin--bottom">
-    <div class="col-start-large-4 col-3">
-      <p>
-        <a href="/partners/gsi">Global System Integrators&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-    <div class="col-6 col-medium-6">
-      <p>Deliver solutions on Ubuntu to drive down costs and accelerate the adoption of open source</p>
-    </div>
-  </div>
-  <div class="row">
-    <hr class="col-start-large-4 col-9 u-no-margin--bottom">
-    <div class="col-start-large-4 col-3">
-      <p>
-        <a href="/partners/desktop">Desktop&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-    <div class="col-6 col-medium-6">
-      <p>Pre-installed and certified Ubuntu on desktops, laptops and workstations</p>
-    </div>
-  </div>
 </section>
 
 {% include 'partial/_partners-footer.html' %}

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -75,7 +75,7 @@
           </p>
         </div>
         <div class="col-6">
-          <p>TODM, factory, integration and device management partners get your device to market faster</p>
+          <p>ODM, factory, integration and device management partners get your device to market faster</p>
         </div>
       </div>
       <hr class="u-no-margin--bottom">

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -1,7 +1,7 @@
 {% extends 'base_index.html' %}
 
 {% block content %}
-<section class="p-strip--suru-partners is-deep">
+<section class="p-strip--suru-partners is-deep" style="padding: 8rem;">
   <div class="row">
     <div class="col-start-large-4 col-8">
       <h1>Canonical <br class="u-hide--small">partner programmes</h1>
@@ -11,7 +11,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-deep">
+<section class="p-strip--partners is-deep">
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-3 col-medium-6">
@@ -23,7 +23,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip--partners is-deep">
   <hr class="is-fixed-width u-no-margin--bottom">
 
   <div class="row">

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -1,7 +1,7 @@
 {% extends 'base_index.html' %}
 
 {% block content %}
-<section class="p-strip--suru-partners is-deep" style="padding: 8rem;">
+<section class="p-strip--suru-partners is-deep is-hero">
   <div class="row">
     <div class="col-start-large-4 col-8">
       <h1>Canonical <br class="u-hide--small">partner programmes</h1>

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -1,76 +1,102 @@
 {% extends 'base_index.html' %}
 
 {% block content %}
-<section class="p-strip--suru-partners">
-  <div class="u-fixed-width">
-    <h1>Canonical partner programmes</h1>
-    <p>
-      At Canonical, we provide the services our partners need to ensure their hardware and software works optimally with the Ubuntu platform. This means working with technology leaders large and small, to provide the software, services, support and certification they need to complement their core competencies. For technology customers, this has created a thriving market of suppliers with Ubuntu expertise.
-    </p>
+<section class="p-strip--suru-partners is-deep">
+  <div class="row">
+    <div class="col-start-large-4 col-8">
+      <h1>Canonical <br class="u-hide--small">partner programmes</h1>
+      <p>At Canonical, we provide the services our partners need to ensure their hardware and software works optimally with the Ubuntu platform.</p>
+      <p>This means working with technology leaders large and small, to provide the software, services, support and certification they need to complement their core competencies. For technology customers, this has created a thriving market of suppliers with Ubuntu expertise.</p>
+    </div>
   </div>
 </section>
-<section class="p-strip--light is-shallow" style="margin-top: -1px;">
+
+<section class="p-strip--light is-deep">
+  <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
-    <div class="col-8 u-vertically-center">
+    <div class="col-3 col-medium-6">
+      <h2 class="p-text--small-caps">Login</h2>
+    </div>
+    <div class="col-9 col-medium-6">
       <p>Are you an existing partner? <a href="https://partner-portal.canonical.com">Login to the partner portal</a></p>
     </div>
   </div>
 </section>
-<section class="p-strip is-deep">
-  <div class="row" style="grid-gap: 0.5rem 2rem;">
-    <div class="col-4 col-medium-3">
-      <div class="p-media-object--strip">
-        <img src="https://assets.ubuntu.com/v1/0e94b67f-Cloud.svg" alt="image for cloud" class="p-media-object__image">
-        <div class="p-media-object__details">
-          <h1 class="p-media-object__title"><a href="/partners/public-cloud">Public Cloud&nbsp;&rsaquo;</a></h1>
-          <p class="p-media-object__content">Ubuntu on clouds is optimised, tested and certified by Canonical for performance and security</p>
-        </div>
-      </div>
+
+<section class="p-strip--light">
+  <hr class="is-fixed-width u-no-margin--bottom">
+
+  <div class="row">
+    <div class="col-3 col-medium-3">
+      <h3 class="p-text--small-caps">Programmes</h3>
     </div>
-    <div class="col-4 col-medium-3">
-      <div class="p-media-object--strip">
-        <img src="https://assets.ubuntu.com/v1/55587253-Server.svg" alt="image for ihv/oem" class="p-media-object__image">
-        <div class="p-media-object__details">
-          <h1 class="p-media-object__title"><a href="/partners/ihv-and-oem">IHV/OEM&nbsp;&rsaquo;</a></h1>
-          <p class="p-media-object__content">Certified hardware for efficient data centers from the large-scale core to distributed edge</p>
-        </div>
-      </div>
+    <div class="col-3 col-medium-3">
+      <p>
+        <a href="/partners/public-cloud">Public cloud&nbsp;&rsaquo;</a>
+      </p>
     </div>
-    <div class="col-4 col-medium-3">
-      <div class="p-media-object--strip">
-        <img src="https://assets.ubuntu.com/v1/63dbd58d-Desktop.svg" alt="image for server" class="p-media-object__image">
-        <div class="p-media-object__details">
-          <h1 class="p-media-object__title"><a href="/partners/desktop">Desktop&nbsp;&rsaquo;</a></h1>
-          <p class="p-media-object__content">Pre-installed and certified Ubuntu on desktops, laptops and workstations</p>
-        </div>
-      </div>
+    <div class="col-6 col-medium-6">
+      <p>Ubuntu on clouds is optimised, tested and certified by Canonical for performance and security</p>
     </div>
-    <div class="col-4 col-medium-3">
-      <div class="p-media-object--strip">
-        <img src="https://assets.ubuntu.com/v1/b77d6733-Resellers.svg" alt="image for resellers" class="p-media-object__image">
-        <div class="p-media-object__details">
-          <h1 class="p-media-object__title"><a href="/partners/channel-and-reseller">Channel&sol;Reseller&nbsp;&rsaquo;</a></h1>
-          <p class="p-media-object__content">Channel partners ensure that local Ubuntu expertise is available on every continent</p>
-        </div>
-      </div>
+  </div>
+  <div class="row">
+    <div class="col-start-large-4 col-3">
+      <p>
+        <a href="/partners/ihv-and-oem">IHV/OEM&nbsp;&rsaquo;</a>
+      </p>
     </div>
-    <div class="col-4 col-medium-3">
-      <div class="p-media-object--strip">
-        <img src="https://assets.ubuntu.com/v1/4ef8b431-Devices+%26+IoT.svg" alt="image for iot" class="p-media-object__image">
-        <div class="p-media-object__details">
-          <h1 class="p-media-object__title"><a href="/partners/iot-device">IoT Device&nbsp;&rsaquo;</a></h1>
-          <p class="p-media-object__content">ODM, factory, integration and device management partners get your device to market faster</p>
-        </div>
-      </div>
+    <div class="col-6 col-medium-6">
+      <p>Certified hardware for efficient data centres from the large-scale core to distributed edge</p>
     </div>
-    <div class="col-4 col-medium-3">
-      <div class="p-media-object--strip">
-        <img src="https://assets.ubuntu.com/v1/d3b11ee3-System+Integrators.svg" alt="image for system integratos" class="p-media-object__image">
-        <div class="p-media-object__details">
-          <h1 class="p-media-object__title"><a href="/partners/gsi">Global System Integrators&nbsp;&rsaquo;</a></h1>
-          <p class="p-media-object__content">Deliver solutions on Ubuntu to drive down costs and accelerate the adoption of open source</p>
-        </div>
-      </div>
+  </div>
+  <div class="row">
+    <div class="col-start-large-4 col-3">
+      <p>
+        <a href="https://ubuntu.com/silicon">Silicon&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+    <div class="col-6 col-medium-6">
+      <p>Enablement and optimisation of Ubuntu on a wide range of CPUs and chipsets, boards and SOCs</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-start-large-4 col-3">
+      <p>
+        <a href="/partners/channel-and-reseller">Channel&sol;Reseller&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+    <div class="col-6 col-medium-6">
+      <p>Channel partners ensure that local Ubuntu expertise is available on every continent</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-start-large-4 col-3">
+      <p>
+        <a href="/partners/iot-device">IoT Device&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+    <div class="col-6 col-medium-6">
+      <p>TODM, factory, integration and device management partners get your device to market faster</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-start-large-4 col-3">
+      <p>
+        <a href="/partners/gsi">Global System Integrators&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+    <div class="col-6 col-medium-6">
+      <p>Deliver solutions on Ubuntu to drive down costs and accelerate the adoption of open source</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-start-large-4 col-3">
+      <p>
+        <a href="/partners/desktop">Desktop&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+    <div class="col-6 col-medium-6">
+      <p>Pre-installed and certified Ubuntu on desktops, laptops and workstations</p>
     </div>
   </div>
 </section>

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -21,7 +21,7 @@
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-3 col-medium-3">
-      <h3 class="p-heading--2">Programmes</h3>
+      <h2>Programmes</h2>
     </div>
     <div class="col-9 col-medium-3">
       <div class="row">

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -15,7 +15,7 @@
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-3 col-medium-6">
-      <h2 class="p-text--small-caps">Login</h2>
+      <h2 class="p-text--small-caps" style="padding-bottom: 0;">Login</h2>
     </div>
     <div class="col-9 col-medium-6">
       <p>Are you an existing partner? <a href="https://partner-portal.canonical.com">Login to the partner portal</a></p>
@@ -25,7 +25,6 @@
 
 <section class="p-strip--partners is-deep">
   <hr class="is-fixed-width u-no-margin--bottom">
-
   <div class="row">
     <div class="col-3 col-medium-3">
       <h3 class="p-text--small-caps">Programmes</h3>
@@ -39,7 +38,9 @@
       <p>Ubuntu on clouds is optimised, tested and certified by Canonical for performance and security</p>
     </div>
   </div>
+  
   <div class="row">
+    <hr class="col-start-large-4 col-9 u-no-margin--bottom">
     <div class="col-start-large-4 col-3">
       <p>
         <a href="/partners/ihv-and-oem">IHV/OEM&nbsp;&rsaquo;</a>
@@ -50,6 +51,7 @@
     </div>
   </div>
   <div class="row">
+    <hr class="col-start-large-4 col-9 u-no-margin--bottom">
     <div class="col-start-large-4 col-3">
       <p>
         <a href="https://ubuntu.com/silicon">Silicon&nbsp;&rsaquo;</a>
@@ -60,6 +62,7 @@
     </div>
   </div>
   <div class="row">
+    <hr class="col-start-large-4 col-9 u-no-margin--bottom">
     <div class="col-start-large-4 col-3">
       <p>
         <a href="/partners/channel-and-reseller">Channel&sol;Reseller&nbsp;&rsaquo;</a>
@@ -70,6 +73,7 @@
     </div>
   </div>
   <div class="row">
+    <hr class="col-start-large-4 col-9 u-no-margin--bottom">
     <div class="col-start-large-4 col-3">
       <p>
         <a href="/partners/iot-device">IoT Device&nbsp;&rsaquo;</a>
@@ -80,6 +84,7 @@
     </div>
   </div>
   <div class="row">
+    <hr class="col-start-large-4 col-9 u-no-margin--bottom">
     <div class="col-start-large-4 col-3">
       <p>
         <a href="/partners/gsi">Global System Integrators&nbsp;&rsaquo;</a>
@@ -90,6 +95,7 @@
     </div>
   </div>
   <div class="row">
+    <hr class="col-start-large-4 col-9 u-no-margin--bottom">
     <div class="col-start-large-4 col-3">
       <p>
         <a href="/partners/desktop">Desktop&nbsp;&rsaquo;</a>


### PR DESCRIPTION
## Done

- Added Silicon section to the partners page ([doc](https://docs.google.com/document/d/1q6dkqQ0zcshrfOmdJA_bAip73EaMSEyXAn8bAD7GqNw/edit#heading=h.c32qy927hx83) out of date, please check against existing page)
- Applied redesign as per [mock up](https://www.figma.com/file/a84HnjH4M3E8KErVkPq9eW/Canonical.com%2Fpartners?node-id=1-1147&t=DeygTIESmpYEySFR-0)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://canonical-com-839.demos.haus/partners
- See that the requested changes were made (Only already live partners and Silicon should be on the page, please ignore the rest of the partners on the doc)
- See that the page matches desgin 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-3124