### PR TITLE
Fix QA steps link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 - Check out this feature branch
 - Run the site using the command `./run serve`
 - View the site locally in your web browser at: http://0.0.0.0:8002/
-- Run through the following [QA steps]([https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html](https://discourse.canonical.com/t/qa-steps/152))
+- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
 - [List additional steps to QA the new features or prove the bug has been resolved]
 
 ## Issue / Card


### PR DESCRIPTION
## Done


Fix this link:
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

I think this will not show until we merge this
