### PR TITLE
Fixing "recruitment" typo

### DIFF
--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -35,7 +35,7 @@
       <hr class="is-dark"/>
       <p>
         For further information on data collection,<br>
-        please refer to our <a href="https://ubuntu.com/legal/data-privacy/recruitment">recruiment privacy notice</a> and <a href="https://ubuntu.com/legal/data-privacy">privacy policy</a>.
+        please refer to our <a href="https://ubuntu.com/legal/data-privacy/recruitment">recruitment privacy notice</a> and <a href="https://ubuntu.com/legal/data-privacy">privacy policy</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

Fixing "recruitment" typo in the footer. 

## QA

- Go to demo
- Check footer, does it say recruitment or "recruiment"

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/842#event-9057969398
