### PR TITLE
Fix grid in "We're Canonical" section

### DIFF
--- a/templates/careers/company-culture.html
+++ b/templates/careers/company-culture.html
@@ -36,7 +36,9 @@
         <div class="col-medium-2 col-3">
           <h4 class="p-heading--2 u-data-border--top"><strong>78</strong><br>Languages</h4>
         </div>
-        <p>The future is already here, as open source. Canonical delivers it to the world. We play a critical role in broadening the benefits of open source to more people and more industries than ever before. This means bringing new work opportunities to people regardless of their location too.</p>
+        <div class="col-medium-6 col-9">
+          <p>The future is already here, as open source. Canonical delivers it to the world. We play a critical role in broadening the benefits of open source to more people and more industries than ever before. This means bringing new work opportunities to people regardless of their location too.</p>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

Wraps hanging paragraph in a col element to fix issues with misaligned grid on Careers Culture page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Go to Company Culture page, make sure "We're Canonical" section grid is correctly spaced (4 columns of equal width)

## Screenshots

<img width="1175" alt="image" src="https://user-images.githubusercontent.com/83575/234300048-b2e534ea-2f64-4a1b-98c2-e891f923c8c4.png">
