### PR TITLE
on candidate withdrawal send email to hiring lead - WD-2917 

### DIFF
--- a/templates/careers/application/_withdrawal_notification-email.html
+++ b/templates/careers/application/_withdrawal_notification-email.html
@@ -1,0 +1,7 @@
+<div>
+  <p>Dear {{ hiring_lead_name }},</p>
+  <p>This is an automated email is to inform you that {{ applicant_name }} has withdrawn their application for the {{ position }} position.</p>
+  <p><a href="{{application_url}}">Click here to access the candidate's application.</a></p>
+  <br>
+  <p>Regards,</p>
+</div>

--- a/templates/careers/application/withdrawal.html
+++ b/templates/careers/application/withdrawal.html
@@ -1,6 +1,27 @@
 {% extends 'base_index.html' %} 
 
 {% block content %}
+
+<section class="p-strip--image is-dark is-deep" style="background-position: 100% 0; background-size: 150vw; background-image:url('https://assets.ubuntu.com/v1/78c0cbe3-05_suru2_dark_2K.jpg')">
+    {% if debug_skip_sending %}
+      <!--
+        We want to make it very clear when sending has been skipped, so we don't accidentally
+        end up skipping sending the email in production in a silent way that nobody notices.
+      -->
+
+      <div class="u-fixed-width">
+        <div class="p-notification--caution">
+          <div class="p-notification__content">
+            <h5 class="p-notification__title">[DEBUG] This email wasn't sent because you're in debug mode</h5>
+            <p>The following email would have been sent to {{ hiring_lead_email }}:</p>
+            <p><blockquote>{{ email_message | safe }}</blockquote></p>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+</section>
+
+
 <section class="p-strip--light is-deep">
   <div class="row">
     <h1>Your application has been withdrawn</h1>

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -336,21 +336,22 @@ def application_withdrawal(token):
     withdrawal_reason_id = payload.get("withdrawal_reason_id")
     withdrawal_message = payload.get("withdrawal_message")
 
-    applicant_name = (
+    candidate_name = (
         application["candidate"]["first_name"]
         + " "
         + application["candidate"]["last_name"]
     )
-    applicant_id = application["candidate"]["id"]
+    candidate_id = application["candidate"]["id"]
 
     hiring_lead_name = application["hiring_lead"]["name"]
     hiring_lead_email = application["hiring_lead"]["emails"]
 
     application_url = (
-        f"https://canonical.greenhouse.io/people/{applicant_id}?application_id={payload['application_id']}"
+        f"https://canonical.greenhouse.io/people/{candidate_id}?"
+        f"application_id={payload['application_id']}"
     )
-    new_withdrawal_message = (
-        f"Hello {hiring_lead_name} \nThe candidate {applicant_name} has"
+    hiring_lead_withdrawal_mail = (
+        f"Hello {hiring_lead_name} \nThe candidate {candidate_name} has"
         f"withdrawn themselves from the job with the following reason(s): " 
         "{withdrawal_message}\n you can refer to their"
         f" application here: {application_url}"
@@ -369,7 +370,7 @@ def application_withdrawal(token):
 
     if not debug_skip_sending:
         _send_mail(
-            hiring_lead_email, "Candidate Withdrawal", new_withdrawal_message
+            hiring_lead_email, "Candidate Withdrawal", hiring_lead_withdrawal_mail
         )
 
     return flask.render_template("careers/application/withdrawal.html")

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -352,7 +352,7 @@ def application_withdrawal(token):
     )
     hiring_lead_withdrawal_mail = (
         f"Hello {hiring_lead_name} \nThe candidate {candidate_name} has"
-        f"withdrawn themselves from the job with the following reason(s): " 
+        f"withdrawn themselves from the job with the following reason(s): "
         "{withdrawal_message}\n you can refer to their"
         f" application here: {application_url}"
     )
@@ -370,7 +370,9 @@ def application_withdrawal(token):
 
     if not debug_skip_sending:
         _send_mail(
-            hiring_lead_email, "Candidate Withdrawal", hiring_lead_withdrawal_mail
+            hiring_lead_email, 
+            "Candidate Withdrawal", 
+            hiring_lead_withdrawal_mail
         )
 
     return flask.render_template("careers/application/withdrawal.html")

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -78,7 +78,9 @@ base_url = "https://harvest.greenhouse.io/v1"
 # ===
 
 
-def _sort_stages_by_milestone(stages: List[str], milestones: Dict[str, Tuple[str]]):
+def _sort_stages_by_milestone(
+    stages: List[str], milestones: Dict[str, Tuple[str]]
+):
     """
     Sort the given stages by milestones and filter out not recognized ones
     - stages: the stages to sort
@@ -102,7 +104,10 @@ def _find_most_recent_milestone(stages: List[str]):
         most_recent_finished_stage = most_recent_finished_stage.lower().strip()
         for milestone, stages_in_milestone in milestone_stages.items():
             for stage_in_milestone in stages_in_milestone:
-                if stage_in_milestone.lower().strip() == most_recent_finished_stage:
+                if (
+                    stage_in_milestone.lower().strip()
+                    == most_recent_finished_stage
+                ):
                     return milestone
     # return first milestone otherwise
     return next(iter(milestone_stages))
@@ -138,7 +143,9 @@ def _milestones_progress(stages, current_stage=None):
     candidate_finished_stages = _sort_stages_by_milestone(
         candidate_finished_stages, milestone_stages
     )
-    most_recent_milestone = _find_most_recent_milestone(candidate_finished_stages)
+    most_recent_milestone = _find_most_recent_milestone(
+        candidate_finished_stages
+    )
 
     # Set the progress of all the milestones prior
     # to the current one as completed
@@ -154,10 +161,14 @@ def _milestones_progress(stages, current_stage=None):
 def _get_application(application_id):
     application = harvest.get_application(int(application_id))
     job_post_id = application["job_post_id"]
-    application["job_post"] = harvest.get_job_post(job_post_id) if job_post_id else None
+    application["job_post"] = (
+        harvest.get_job_post(job_post_id) if job_post_id else None
+    )
 
     # Add candidate object
-    application["candidate"] = harvest.get_candidate(application["candidate_id"])
+    application["candidate"] = harvest.get_candidate(
+        application["candidate_id"]
+    )
 
     # Retrieve hiring lead from first job
     job_id = application["jobs"][0]["id"]
@@ -191,9 +202,13 @@ def _get_application(application_id):
     for interview in application["scheduled_interviews"]:
         interview["start"]["datetime"] = parse(interview["start"]["date_time"])
         interview["end"]["datetime"] = parse(interview["end"]["date_time"])
-        difference = interview["end"]["datetime"] - interview["start"]["datetime"]
+        difference = (
+            interview["end"]["datetime"] - interview["start"]["datetime"]
+        )
         interview["duration"] = int(difference.total_seconds() / 60)
-        interview["stage_name"] = interviews_stage[interview["interview"]["id"]]
+        interview["stage_name"] = interviews_stage[
+            interview["interview"]["id"]
+        ]
 
     application["to_be_rejected"] = False
 
@@ -201,7 +216,9 @@ def _get_application(application_id):
         if not application["rejection_reason"]["type"]["id"] == 2:
             now = datetime.now(timezone.utc)
             rejection_time = parse(application["rejected_at"])
-            time_after_rejection = int((now - rejection_time).total_seconds() / 60)
+            time_after_rejection = int(
+                (now - rejection_time).total_seconds() / 60
+            )
             if time_after_rejection < 2880:
                 application["to_be_rejected"] = True
             else:
@@ -379,7 +396,10 @@ def request_withdrawal(token):
     withdrawal_reason_id = flask.request.form["withdrawal-reason"]
     withdrawal_message = withdrawal_reasons[withdrawal_reason_id]
 
-    if withdrawal_reason_id == "33" and "withdrawal-reason-other" in flask.request.form:
+    if (
+        withdrawal_reason_id == "33"
+        and "withdrawal-reason-other" in flask.request.form
+    ):
         withdrawal_message = flask.request.form["withdrawal-reason-other"]
 
     # Reject if user typed the wrong email

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -370,9 +370,9 @@ def application_withdrawal(token):
 
     if not debug_skip_sending:
         _send_mail(
-            hiring_lead_email, 
-            "Candidate Withdrawal", 
-            hiring_lead_withdrawal_mail
+            hiring_lead_email,
+            "Candidate Withdrawal",
+            hiring_lead_withdrawal_mail,
         )
 
     return flask.render_template("careers/application/withdrawal.html")


### PR DESCRIPTION
## Done

When a candidate withdraws send email to notify the hiring lead(s)

## QA

- go to a candidate's application page
- withdraw the application
- at the end you should see a debug email that should be sent to the hiring lead (emails cannot be sent locally)

