### PR TITLE
WD-3415 Design consistency for blockquote pattern

### DIFF
--- a/templates/careers/company-culture.html
+++ b/templates/careers/company-culture.html
@@ -67,9 +67,9 @@
           }}
         </div>
         <div class="col-6 col-medium-3 col-small-3">
-          <blockquote class="p-pull-quote--small u-stack u-no-margin--top">
-            <p class="p-pull-quote__quote">We're a remote-first international company. <br class="u-hide--small">
-              I get to work every day with people from all over the world, which is just amazing.</p>
+          <blockquote class="p-pull-quote--small u-no-margin--top u-stack u-no-padding--left">
+            <h4><em>"We're a remote-first international company. <br class="u-hide--small">
+              I get to work every day with people from all over the world, which is just amazing."</em></h4>
             <span class="p-pull-quote__citation u-no-margin--bottom"><strong>Ken VanDine</strong><br /> Engineering Manager, Ubuntu Desktop</span>
           </blockquote>
         </div>
@@ -105,9 +105,8 @@
           }}
         </div>
         <div class="col-6 col-medium-3 col-small-3">
-          <blockquote class="p-pull-quote--small u-no-margin--top u-stack">
-            <p class="p-pull-quote__quote">I love the trust and the freedom that exists in our organisation. <br class="u-hide--small">Trust and freedom to explore new things.
-              </p>
+          <blockquote class="p-pull-quote--small u-no-margin--top u-stack u-no-padding--left">
+            <h4><em>"I love the trust and the freedom that exists in our organisation. <br class="u-hide--small">Trust and freedom to explore new things."</em></h4>
             <span class="p-pull-quote__citation u-no-margin--bottom"><strong>Thibaut Rouffineau</strong><br /> VP of Marketing</span>
           </blockquote>
         </div>
@@ -144,8 +143,8 @@
           }}
         </div>
         <div class="col-6 col-medium-3 col-small-3">
-          <blockquote class="p-pull-quote--small u-no-margin--top u-stack">
-            <p class="p-pull-quote__quote">This is a company where intelligence and learning are highly valued.</p>
+          <blockquote class="p-pull-quote--small u-no-margin--top u-stack u-no-padding--left">
+            <h4><em>"This is a company where intelligence and learning are highly valued."</em></h4>
             <span class="p-pull-quote__citation u-no-margin--bottom"><strong>Alyson Richens</strong><br /> Customer Success Manager</span>
           </blockquote>
         </div>


### PR DESCRIPTION
## Done

Keep consistency across careers blockquotes, similar to /careers/company-culture


## QA

- Go to https://canonical-com-869.demos.haus/careers/company-culture and check that quotes look the same as https://canonical-com-869.demos.haus/careers/company-culture/diversity. The double quotes should be now "inside", as requested in the [Jira ticket](https://warthogs.atlassian.net/browse/WD-3415?atlOrigin=eyJpIjoiNDYxMzgxOWYzOWU5NGI3MWE5YTk3M2VmMmNjYWVmZjciLCJwIjoiaiJ9)


