### PR TITLE
WD-4367 Add help text to career applications form

### DIFF
--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -90,25 +90,30 @@
           {% for question in job.questions %}
           <label for="{{ question.fields[0].name }}" class="{% if question.required %}is-required{% endif %}">{{ question.label }}</label>
             {% if question.fields[0].type == "input_text" %}
-            <input id="{{ question.fields[0].name }}" name="{{ question.fields[0].name }}" type="text" {% if question.required %}required{% endif %} maxlength="255">
+            <input id="{{ question.fields[0].name }}" name="{{ question.fields[0].name }}" {% if question.description %}aria-describedby="{{ question.fields[0].name }}_help"{% endif %} type="text" {% if question.required %}required{% endif %} maxlength="255">
+            {% if question.description %}<p class="p-form-help-text" id="{{ question.fields[0].name }}_help">{{ question.description | safe }}</p>{% endif %}
             {% elif question.fields[0].type == "input_file" %}
-            <input id="{{ question.fields[0].name }}" name="{{ question.fields[0].name }}" type="file" {% if question.required %}required{% endif %} accept=".pdf, .doc, .docx, .txt, .rtf">
+            <input id="{{ question.fields[0].name }}" name="{{ question.fields[0].name }}" {% if question.description %}aria-describedby="{{ question.fields[0].name }}_help"{% endif %} type="file" {% if question.required %}required{% endif %} accept=".pdf, .doc, .docx, .txt, .rtf">
+            {% if question.description %}<p class="p-form-help-text" id="{{ question.fields[0].name }}_help">{{ question.description | safe }}</p>{% endif %}
             {% elif question.fields[0].type == "textarea" %}
-            <textarea id="{{ question.fields[0].name }}" name="{{ question.fields[0].name }}" type="textarea" {% if question.required %}required{% endif %}></textarea>
+            <textarea id="{{ question.fields[0].name }}" name="{{ question.fields[0].name }}" {% if question.description %}aria-describedby="{{ question.fields[0].name }}_help"{% endif %} type="textarea" {% if question.required %}required{% endif %}></textarea>
+            {% if question.description %}<p class="p-form-help-text" id="{{ question.fields[0].name }}_help">{{ question.description | safe }}</p>{% endif %}
             {% elif question.fields[0].type == "multi_value_single_select" %}
-            <select name="{{ question.fields[0].name }}" id="{{ question.fields[0].name }}" {% if question.required %}required{% endif %}>
+            <select name="{{ question.fields[0].name }}" id="{{ question.fields[0].name }}" {% if question.description %}aria-describedby="{{ question.fields[0].name }}_help"{% endif %} {% if question.required %}required{% endif %}>
               <option value="" disabled="disabled" selected="">Select an option</option>
               {% for answer_option in question.fields[0].get("values",[])|reverse %}
               <option value="{{ answer_option.value }}">{{ answer_option.label }}</option>
               {% endfor %}
             </select>
+            {% if question.description %}<p class="p-form-help-text" id="{{ question.fields[0].name }}_help">{{ question.description | safe }}</p>{% endif %}
             {% elif question.fields[0].type == "multi_value_multi_select" %}
-            <select name="{{ question.fields[0].name }}" id="{{ question.fields[0].name }}" multiple="" {% if question.required %}required{% endif %}>
+            <select name="{{ question.fields[0].name }}" id="{{ question.fields[0].name }}" {% if question.description %}aria-describedby="{{ question.fields[0].name }}_help"{% endif %} multiple="" {% if question.required %}required{% endif %}>
               <option value="" disabled="disabled">Select...</option>
               {% for answer_option in question.fields[0].get("values",[]) %}
               <option value="{{ answer_option.value }}">{{ answer_option.label }}</option>
               {% endfor %}
             </select>
+            {% if question.description %}<p class="p-form-help-text" id="{{ question.fields[0].name }}_help">{{ question.description | safe }}</p>{% endif %}
             {% endif %}
           {% endfor %}
         {% endif %}

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -106,7 +106,7 @@ class Vacancy:
         self.location: str = job["location"]["name"]
         self.employment: str = _get_metadata(job, "employment")
         self.date: str = job["updated_at"]
-        self.questions: dict = job.get("questions", {})
+        self.questions: dict = self.parse_questions(job)
         self.departments: list = list(
             map(
                 lambda d: Department(d),
@@ -123,6 +123,18 @@ class Vacancy:
         self.is_remote: bool = False if job["offices"][0]["location"] else True
         self.featured: str = _get_metadata(job, "is_featured")
         self.fast_track: str = _get_metadata(job, "is_fast_track")
+
+    def parse_questions(self, job):
+        questions = job.get("questions", {})
+        for question in questions:
+            if question["description"]:
+                question["description"] = (
+                    question["description"]
+                    .replace("</p>\n<p>", "<br />")
+                    .replace("<p>", "")
+                    .replace("</p>", "")
+                )
+        return questions
 
     def to_dict(self):
         return {


### PR DESCRIPTION
## Done

Render the input descriptions as input help text.
Parse the descriptions to remove `<p>`'s

## QA

- Open the demo
- Go to /careers/4754075/application
- Check some inputs have descriptions
- Check they have the appropriate `aria-describedby` attributes

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4367

## Screenshots
![image](https://github.com/canonical/canonical.com/assets/1413534/34ab3496-faf6-4817-a07c-4fa104a34117)

