### PR TITLE
WD-4421 Update application job name when transferring roles

### DIFF
--- a/templates/careers/application/index.html
+++ b/templates/careers/application/index.html
@@ -1,6 +1,6 @@
 {% extends '/careers/base_job-details.html' %}
 
-{% block title %}{{ application["candidate"]["first_name"] }}, application for {{ application["jobs"][0]["name"] }}{% endblock %}
+{% block title %}{{ application["candidate"]["first_name"] }}, application for {{ application["role_name"] }}{% endblock %}
 
 {% block extra_metatags %}
   <meta name="robots" content="noindex">
@@ -79,7 +79,7 @@
 
       <div class="row">
         <div class="col-12">
-          <h1 class="p-heading--2 u-sv2"><strong>{{ application["candidate"]["first_name"] }} {{ application["candidate"]["last_name"] }}</strong><br>Application for {{ application["job_post"]["title"] or application["jobs"][0]["name"] }}</h1>
+          <h1 class="p-heading--2 u-sv2"><strong>{{ application["candidate"]["first_name"] }} {{ application["candidate"]["last_name"] }}</strong><br>Application for {{ application["role_name"] }}</h1>
           {% if "stage_progress" in application and application["stage_progress"]["assessment"] and application['source']['id'] == 2 and application['job_post_id'] %}
             <p class="u-no-margin--bottom"><a href="/careers/{{ application['job_post_id'] }}" class="p-link--inverted">Read more about this role&nbsp;&rsaquo;</a></p>
           </div>

--- a/templates/careers/application/partial/_assessment.html
+++ b/templates/careers/application/partial/_assessment.html
@@ -5,10 +5,9 @@
       <p>There are several parts to this stage:</p>
       <a href="" onclick="showProgressDetail('assessment'); event.preventDefault();" class="show-more-assessment">Show more</a>
       <div class="progress-detail-assessment u-hide">
-    {% elif "stage_progress" in application and application["stage_progress"]["assessment"] and not application["stage_progress"]["early_stage"] %}
-      <p>There are several parts to this stage:</p>
+    {% else %}
       <div class="progress-detail-assessment">
-        {% endif %}
+    {% endif %}
         <ol class="p-stepped-list">
           <li class="p-stepped-list__item">
             <p class="p-stepped-list__title u-no-margin--bottom">The Written Interview: As the first part of this stage we invite you to submit your answers to some questions specifically designed so that we can find out more about your experience and skill set. This is your opportunity to highlight your key strengths for this position. To ensure that we mitigate against unconscious bias in our hiring process we ask that you refrain from including any personal identifiable information in this document.</p>

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -158,6 +158,18 @@ def _milestones_progress(stages, current_stage=None):
     return progress
 
 
+def _calculate_job_title(application):
+    """
+    If the applied for job id matches the job post > job id then the job post
+    title is the current role. If not the application has been transferred to
+    another role so return that name.
+    """
+    if application["jobs"][0]["id"] == application["job_post"]["job_id"]:
+        return application["job_post"]["title"]
+    else:
+        return application["jobs"][0]["name"]
+
+
 def _get_application(application_id):
     application = harvest.get_application(int(application_id))
     job_post_id = application["job_post_id"]
@@ -211,6 +223,7 @@ def _get_application(application_id):
         ]
 
     application["to_be_rejected"] = False
+    application["role_name"] = _calculate_job_title(application)
 
     if application["rejected_at"]:
         if not application["rejection_reason"]["type"]["id"] == 2:


### PR DESCRIPTION
## Done
1. Simplify the template logic by parsing a reliable job post name before passing it to the context.
2. Added logic to check for the applied job id matches the job post id. If it does its a post from the same job. If not, the role has been transferred and we need to render the job_name.
3. _Drive by_: converted the `elif` to a `else` as we want one to always be true. Which fixed a rendering issue in production.

## QA

- Open the demo and go to [these URLs](https://pastebin.canonical.com/p/3MnyxvkY3P/) to check they render as expected.
- Check that the first URL in the pastebin renders correctly after the assessment stage unlike production

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4421
