### PR TITLE
Change LXD product URL

### DIFF
--- a/webapp/static_data.py
+++ b/webapp/static_data.py
@@ -57,7 +57,7 @@ homepage_featured_products = [
         footer="maas.io",
     ),
     FeaturedProduct(
-        link="https://linuxcontainers.org",
+        link="https://ubuntu.com/lxd",
         image=f"{base_url}/v1/a737970a-products-lxd-wht-aubergine4.svg",
         alt="LXD",
         content=(


### PR DESCRIPTION
## Done

Changed the LXD product URL from the Linux Containers page to the Ubuntu LXD page

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/892

## QA

- Open demo 
- Go to 'products' section and now both the logo and URL for the LXD product should be linked to the requested URL  
- Change made in the webapp > static_data.py file - the new product URL should pull through to the site home page

