### PR TITLE
Documentation practice

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1,5 +1,3 @@
-$color-tabs-active-bar: #e95420;
-
 @import "../../node_modules/vanilla-framework";
 
 // import cookie policy
@@ -8,6 +6,7 @@ $color-tabs-active-bar: #e95420;
 $color-brand: #7c355d;
 $color-dark: #262626;
 $color-paper: #f3f3f3;
+$color-tabs-active-bar: $colors--light-theme--text-default;
 $nudge--small: 0.55rem;
 $p-small-lh-diff: map-get($line-heights, default-text) -
   map-get($line-heights, small);
@@ -697,7 +696,6 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   width: 100%;
 }
 
-
 .p-testimonial {
   @extend %fixed-width-container;
 
@@ -780,12 +778,12 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 
 .partners-logo {
   max-width: 10rem;
-  
+
   @media (max-width: $breakpoint-large - 1) {
     max-width: 100%;
   }
 }
-  
+
 // used to obfuscate email addresses on projetcs/directory
 .sign {
   color: transparent;

--- a/templates/documentation/_documentation-header.html
+++ b/templates/documentation/_documentation-header.html
@@ -1,24 +1,10 @@
-<section class="p-strip--suru-topped">
+<section class="p-strip">
   <div class="row">
-    <div class="col-7">
-      {% if request.path == "/documentation" %}
-      <h1>Documentation practice at Canonical</h1>
-      {% else %}
-      <p class="p-heading--1">Documentation practice at Canonical</p>
-      {% endif %}
-      <p>At Canonical, we have embarked on a comprehensive, long-term project to transform documentation.</p>
-      <p>Our aim is to create and maintain documentation product and practice that will represent a standard of excellence. We want documentation to be the best it possibly can be.</p>
-    </div>
-    <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg",
-        alt="",
-        width="214",
-        height="248",
-        hi_def=True,
-        loading="auto"
-        ) | safe
-      }}
+    <div class="col-start-large-4 col-8 col-medium-4 col-start-medium-3">
+      <div class="p-block">
+        <h1>Documentation practice<br class="u-hide--small"> at Canonical</h1>
+      </div>
+      <p>At Canonical, we have embarked on a comprehensive, long-term project to transform documentation. Our aim is to create and maintain documentation product and practice that will represent a standard of excellence. We want documentation to be the best it possibly can be.</p>
     </div>
   </div>
 </section>

--- a/templates/documentation/_documentation-tab-navigation.html
+++ b/templates/documentation/_documentation-tab-navigation.html
@@ -1,16 +1,18 @@
-<div class="u-fixed-width">
-  <nav class="p-tabs" data-js="tabs" aria-label="Documentation navigation tabs">
-    <ul class="p-tabs__list" role="tablist">
-      <li class="p-tabs__item" role="presentation">
-        <a href="/documentation" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'overview' or current_tab == 'docs' %}aria-selected="true" {% endif %}>Overview</a>
-      </li>
-      <li class="p-tabs__item" role="presentation">
-        <a href="/documentation/work-and-careers" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'work-and-careers' or current_tab == 'docs' %}aria-selected="true" {% endif %}>Work and careers</a>
-      </li>
-      <li class="p-tabs__item" role="presentation">
-        <a href="/documentation/beyond-canonical" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'beyond-canonical' or current_tab == 'docs' %}aria-selected="true" {% endif %}>Beyond Canonical</a>
-      </li>
-    </ul>
-  </nav>
+<div class="row">
+  <div class="col-9 col-medium-4 col-start-large-4 col-start-medium-3">
+    <nav class="p-tabs" data-js="tabs" aria-label="Documentation navigation tabs">
+      <ul class="p-tabs__list" role="tablist">
+        <li class="p-tabs__item" role="presentation">
+          <a href="/documentation" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'overview' or current_tab == 'docs' %}aria-selected="true" {% endif %}>Overview</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="/documentation/work-and-careers" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'work-and-careers' or current_tab == 'docs' %}aria-selected="true" {% endif %}>Work and careers</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="/documentation/beyond-canonical" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'beyond-canonical' or current_tab == 'docs' %}aria-selected="true" {% endif %}>Beyond Canonical</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
 </div>
 

--- a/templates/documentation/beyond-canonical.html
+++ b/templates/documentation/beyond-canonical.html
@@ -47,6 +47,12 @@
     </aside>
     <main class="col-9">
       <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4" style="scroll-margin-top: 3.5rem;">Documentation practice beyond Canonical</h2>
+        <div class="col-6 col-medium-4">
+          <p>We're working to establish patterns of excellence in documentation in Canonical, but not just for Canonical. The scale of operations at Canonical makes it an effective proving-ground for the models and ideas that we're developing &mdash; models and ideas that are being noticed and adopted more widely in the industry.</p>
+        </div>
+      </div>
+      <div class="row p-block">
         <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="encounters-and-dialogue" style="scroll-margin-top: 3.5rem;">Encounters and dialogue</h2>
         <div class="col-6 col-medium-4">
           <p>We actively seek new encounters with problems in documentation, in order that we may understand how our thinking can apply to them. We need to learn from experiences in other contexts.</p>

--- a/templates/documentation/beyond-canonical.html
+++ b/templates/documentation/beyond-canonical.html
@@ -47,16 +47,16 @@
     </aside>
     <main class="col-7">
       <div id="introduction">
-        <h1 class="p-heading--2">Documentation practice beyond Canonical</h1>
+        <h2>Documentation practice beyond Canonical</h2>
         <p>We're working to establish patterns of excellence in documentation in Canonical, but not just for Canonical. The scale of operations at Canonical makes it an effective proving-ground for the models and ideas that we're developing &mdash; models and ideas that are being noticed and adopted more widely in the industry.</p>
       </div>
       <div class="question-heading" id="encounters-and-dialogue" style="scroll-margin-top: 4.5rem;">
-        <h2 class="p-heading--3">Encounters and dialogue</h2>
+        <h3>Encounters and dialogue</h3>
         <p>We actively seek new encounters with problems in documentation, in order that we may understand how our thinking can apply to them. We need to learn from experiences in other contexts.</p>
         <p>We think, talk and write about the problems and practices of documentation, openly, and with whoever wants to take part part in that dialogue.</p>
       </div>
       <div class="question-heading" id="open-source-events" style="scroll-margin-top: 4.5rem;">
-        <h2 class="p-heading--3">Workshops and talks at open-source events</h2>
+        <h3>Workshops and talks at open-source events</h3>
         <p>We regularly attend events where the topic of documentation is firmly on the table. Recent examples of participation include <a href="https://2022.pyconuk.org/">PyCon UK 2022</a>, <a href="https://www.youtube.com/watch?v=R4O2WoFC-JQ">DjangoCon Europe 2022</a>, <a href="https://events.canonical.com/event/2/">Ubuntu Summit 2022</a>, <a href="https://www.python.org/events/python-events/1379/">PyCon Namibia 2023</a>.</p>
         <figure>
           <img class="p-image" src="https://assets.ubuntu.com/v1/a1630e44-working-at-canonical.jpeg" alt="Workshop participants sitting around a table analyse user needs in documentation situations" width="600" height="400">
@@ -66,17 +66,17 @@
         <p>In turn, open-source software also has a lot of significance for documentation. That's because it's one of the great entry-points into documentation practice. Most people in documentation are not trained technical writers, but the barriers to writing documentation in open-source contexts are low, and the context makes first, hesitant steps easier.</p>
       </div>
       <div class="question-heading" id="supporting-open-source-projects" style="scroll-margin-top: 4.5rem;">
-        <h2 class="p-heading--3">Supporting open-source projects</h2>
+        <h3>Supporting open-source projects</h3>
         <p>Open-source projects inevitably find it easier to secure top-class programming contributions than they do to attract the same level of expertise in documentation.</p>
         <p>We engage with a number of open-source projects, providing guidance, support as well as material documentation contributions. Recent examples include <a href="https://www.python.org/">Python</a> and <a href="https://www.djangoproject.com/">Django</a>.</p>
       </div>
       <div class="question-heading" id="collaboration-with-practitioners" style="scroll-margin-top: 4.5rem;">
-        <h2 class="p-heading--3">Collaboration with other practitioners</h2>
+        <h3>Collaboration with other practitioners</h3>
         <p>We eagerly absorb insight from others in the discipline. The challenges faced by practitioners in other organisations serve to illuminate our own, and we value the exchange of ideas and expertise they offer.</p>
         <p>In particular, we've benefited from the experiences that others have had implementing <a href="https://diataxis.fr/">Diátaxis</a> at scale, or in very different contexts, as a means to refining our own understanding.</p>
       </div>
       <div class="question-heading" id="scientific-research-community" style="scroll-margin-top: 4.5rem;">
-        <h2 class="p-heading--3">Engagement with the scientific research community</h2>
+        <h3>Engagement with the scientific research community</h3>
         <p>The scientific community faces a problem, that risks becoming a crisis, of <em>reproducibility</em>. Ever-more research relies on computation, and much of it is wholly dependent on it. Despite this fact, and despite the valiant effort of software research engineers, software practices in research in general fall very far behind the standards achieved in industry.</p>
         <p>Documentation plays an important role in achieving and maintaining reproducibility. Members of our documentation team have held workshops dedicated to research software documentation, and explored the context in particular research institutions. Our Practice Lead for Documentation is <a href="https://software.ac.uk/about/fellows/daniele-procida">a Fellow of the Software Sustainability Institute</a>, running a long-term project to work with researchers, as much to understand the special problems faced in research as to share good practice that can be adopted.</p>
       </div>

--- a/templates/documentation/beyond-canonical.html
+++ b/templates/documentation/beyond-canonical.html
@@ -45,41 +45,51 @@
         </nav>
       </div>
     </aside>
-    <main class="col-7">
-      <div id="introduction">
-        <h2>Documentation practice beyond Canonical</h2>
-        <p>We're working to establish patterns of excellence in documentation in Canonical, but not just for Canonical. The scale of operations at Canonical makes it an effective proving-ground for the models and ideas that we're developing &mdash; models and ideas that are being noticed and adopted more widely in the industry.</p>
+    <main class="col-9">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="encounters-and-dialogue" style="scroll-margin-top: 3.5rem;">Encounters and dialogue</h2>
+        <div class="col-6 col-medium-4">
+          <p>We actively seek new encounters with problems in documentation, in order that we may understand how our thinking can apply to them. We need to learn from experiences in other contexts.</p>
+          <p>We think, talk and write about the problems and practices of documentation, openly, and with whoever wants to take part part in that dialogue.</p>
+        </div>
       </div>
-      <div class="question-heading" id="encounters-and-dialogue" style="scroll-margin-top: 4.5rem;">
-        <h3>Encounters and dialogue</h3>
-        <p>We actively seek new encounters with problems in documentation, in order that we may understand how our thinking can apply to them. We need to learn from experiences in other contexts.</p>
-        <p>We think, talk and write about the problems and practices of documentation, openly, and with whoever wants to take part part in that dialogue.</p>
+      <hr class="p-rule">     
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="open-source-events" style="scroll-margin-top: 3.5rem;">Workshops and talks at open-source events</h2>
+        <div class="col-6 col-medium-4">
+          <p>We regularly attend events where the topic of documentation is firmly on the table. Recent examples of participation include <a href="https://2022.pyconuk.org/">PyCon UK 2022</a>, <a href="https://www.youtube.com/watch?v=R4O2WoFC-JQ">DjangoCon Europe 2022</a>, <a href="https://events.canonical.com/event/2/">Ubuntu Summit 2022</a>, <a href="https://www.python.org/events/python-events/1379/">PyCon Namibia 2023</a>.</p>
+          <figure>
+            <img class="p-image" src="https://assets.ubuntu.com/v1/a1630e44-working-at-canonical.jpeg" alt="Workshop participants sitting around a table analyse user needs in documentation situations" width="600" height="400">
+            <figcaption>Diátaxis workshop at the Ubuntu Summit, 2022</figcaption>
+          </figure>
+          <p>Documentation is important for open-source software in several ways. One that's sometimes not properly understood is the value it has as a pathway into open-source participation and contribution. </p>
+          <p>In turn, open-source software also has a lot of significance for documentation. That's because it's one of the great entry-points into documentation practice. Most people in documentation are not trained technical writers, but the barriers to writing documentation in open-source contexts are low, and the context makes first, hesitant steps easier.</p>
+        </div>
       </div>
-      <div class="question-heading" id="open-source-events" style="scroll-margin-top: 4.5rem;">
-        <h3>Workshops and talks at open-source events</h3>
-        <p>We regularly attend events where the topic of documentation is firmly on the table. Recent examples of participation include <a href="https://2022.pyconuk.org/">PyCon UK 2022</a>, <a href="https://www.youtube.com/watch?v=R4O2WoFC-JQ">DjangoCon Europe 2022</a>, <a href="https://events.canonical.com/event/2/">Ubuntu Summit 2022</a>, <a href="https://www.python.org/events/python-events/1379/">PyCon Namibia 2023</a>.</p>
-        <figure>
-          <img class="p-image" src="https://assets.ubuntu.com/v1/a1630e44-working-at-canonical.jpeg" alt="Workshop participants sitting around a table analyse user needs in documentation situations" width="600" height="400">
-          <figcaption>Diátaxis workshop at the Ubuntu Summit, 2022</figcaption>
-        </figure>
-        <p>Documentation is important for open-source software in several ways. One that's sometimes not properly understood is the value it has as a pathway into open-source participation and contribution. </p>
-        <p>In turn, open-source software also has a lot of significance for documentation. That's because it's one of the great entry-points into documentation practice. Most people in documentation are not trained technical writers, but the barriers to writing documentation in open-source contexts are low, and the context makes first, hesitant steps easier.</p>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="supporting-open-source-projects" style="scroll-margin-top: 3.5rem;">Supporting open-source projects</h2>
+        <div class="col-6 col-medium-4">
+          <p>Open-source projects inevitably find it easier to secure top-class programming contributions than they do to attract the same level of expertise in documentation.</p>
+          <p>We engage with a number of open-source projects, providing guidance, support as well as material documentation contributions. Recent examples include <a href="https://www.python.org/">Python</a> and <a href="https://www.djangoproject.com/">Django</a>.</p>
+        </div>
       </div>
-      <div class="question-heading" id="supporting-open-source-projects" style="scroll-margin-top: 4.5rem;">
-        <h3>Supporting open-source projects</h3>
-        <p>Open-source projects inevitably find it easier to secure top-class programming contributions than they do to attract the same level of expertise in documentation.</p>
-        <p>We engage with a number of open-source projects, providing guidance, support as well as material documentation contributions. Recent examples include <a href="https://www.python.org/">Python</a> and <a href="https://www.djangoproject.com/">Django</a>.</p>
+      <hr class="p-rule">         
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="collaboration-with-practitioners" style="scroll-margin-top: 3.5rem;">Collaboration with other practitioners</h2>
+        <div class="col-6 col-medium-4">
+          <p>We eagerly absorb insight from others in the discipline. The challenges faced by practitioners in other organisations serve to illuminate our own, and we value the exchange of ideas and expertise they offer.</p>
+          <p>In particular, we've benefited from the experiences that others have had implementing <a href="https://diataxis.fr/">Diátaxis</a> at scale, or in very different contexts, as a means to refining our own understanding.</p>
+        </div>
       </div>
-      <div class="question-heading" id="collaboration-with-practitioners" style="scroll-margin-top: 4.5rem;">
-        <h3>Collaboration with other practitioners</h3>
-        <p>We eagerly absorb insight from others in the discipline. The challenges faced by practitioners in other organisations serve to illuminate our own, and we value the exchange of ideas and expertise they offer.</p>
-        <p>In particular, we've benefited from the experiences that others have had implementing <a href="https://diataxis.fr/">Diátaxis</a> at scale, or in very different contexts, as a means to refining our own understanding.</p>
-      </div>
-      <div class="question-heading" id="scientific-research-community" style="scroll-margin-top: 4.5rem;">
-        <h3>Engagement with the scientific research community</h3>
-        <p>The scientific community faces a problem, that risks becoming a crisis, of <em>reproducibility</em>. Ever-more research relies on computation, and much of it is wholly dependent on it. Despite this fact, and despite the valiant effort of software research engineers, software practices in research in general fall very far behind the standards achieved in industry.</p>
-        <p>Documentation plays an important role in achieving and maintaining reproducibility. Members of our documentation team have held workshops dedicated to research software documentation, and explored the context in particular research institutions. Our Practice Lead for Documentation is <a href="https://software.ac.uk/about/fellows/daniele-procida">a Fellow of the Software Sustainability Institute</a>, running a long-term project to work with researchers, as much to understand the special problems faced in research as to share good practice that can be adopted.</p>
-      </div>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="scientific-research-community" style="scroll-margin-top: 3.5rem;">Engagement with the scientific research community</h2>
+        <div class="col-6 col-medium-4">
+          <p>The scientific community faces a problem, that risks becoming a crisis, of <em>reproducibility</em>. Ever-more research relies on computation, and much of it is wholly dependent on it. Despite this fact, and despite the valiant effort of software research engineers, software practices in research in general fall very far behind the standards achieved in industry.</p>
+          <p>Documentation plays an important role in achieving and maintaining reproducibility. Members of our documentation team have held workshops dedicated to research software documentation, and explored the context in particular research institutions. Our Practice Lead for Documentation is <a href="https://software.ac.uk/about/fellows/daniele-procida">a Fellow of the Software Sustainability Institute</a>, running a long-term project to work with researchers, as much to understand the special problems faced in research as to share good practice that can be adopted.</p>
+        </div>
+      </div>   
     </main>
   </div>
 </div>

--- a/templates/documentation/beyond-canonical.html
+++ b/templates/documentation/beyond-canonical.html
@@ -52,6 +52,7 @@
           <p>We're working to establish patterns of excellence in documentation in Canonical, but not just for Canonical. The scale of operations at Canonical makes it an effective proving-ground for the models and ideas that we're developing &mdash; models and ideas that are being noticed and adopted more widely in the industry.</p>
         </div>
       </div>
+      <hr class="p-rule">     
       <div class="row p-block">
         <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="encounters-and-dialogue" style="scroll-margin-top: 3.5rem;">Encounters and dialogue</h2>
         <div class="col-6 col-medium-4">

--- a/templates/documentation/index.html
+++ b/templates/documentation/index.html
@@ -111,6 +111,7 @@
                 <p>The tools and machinery we adopt to write, maintain and publish documentation, that serve our work best.</p>
               </div>
             </div>
+            <p><a href="https://ubuntu.com/blog/the-future-of-documentation-at-canonical">Read about our plan to put these pillars into place at Canonical&nbsp;&rsaquo;</a></p>
           </div>
         </div>
         <hr class="p-rule">

--- a/templates/documentation/index.html
+++ b/templates/documentation/index.html
@@ -11,7 +11,7 @@
 {% block meta_image %}https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg{% endblock %}
 
 {% block documentation_content %}
-<section class="p-strip u-no-padding--top">
+<section class="p-section">
   <div class="row" id="documentation">
     <aside class="col-3">
       <div class="p-side-navigation--raw-html is-sticky" id="drawer">
@@ -43,71 +43,109 @@
       </div>
     </aside>
     <main class="col-9">
-      <div class="row">
-        <div class="col-7">
-          <div id="introduction">
-            <p>For too long in our industry, documentation has been allowed to be a secondary aspect of software development. Our approach will make documentation a core engineering concern, governed by systematic principles and requiring conscious practice, whose values inform the work not just of technical authors, but of all our engineering and product teams.</p>
-          </div>
-          <div class="question-heading" id="documentation-as-practice" style="scroll-margin-top: 4.5rem;">
-            <h2>Documentation as practice</h2>
-            <p>A central principle we hold is that <strong>documentation is an engineering practice, rather than an engineering task.</strong></p>
-            <p>At Canonical, engineers and product managers make real and substantial contributions to documentation, as part of their everyday work. Documentation is not a siloed activity, it's a responsibility shared by everyone who works in engineering, product or support.</p>
-            <p>Everyone is expected to think and care about documentation, specialists and non-specialists alike, in just the same way that quality and security are shared concerns. If you're applying to Canonical for an engineering role, don't be surprised to be asked about your work in &mdash; or your thoughts on &mdash; documentation at a job interview.</p>
-          </div>
-          <div class="question-heading" id="documentation-with-rigour" style="scroll-margin-top: 4.5rem;">
-            <h2 >Documentation with rigour</h2>
-            <p>It's a key part of our project in documentation to understand and define documentation as a rigorous discipline in software engineering, one with rules that apply generally, are derived from sound principles, and are tested in action.</p>
-            <p>Documentation in software deserves &mdash; but has never enjoyed &mdash; <strong>a scientific approach</strong>. We need our ideas and models to be examined and challenged, not just by us and our colleagues, but beyond Canonical too. Our models are <em>working models</em>, not the last word on the subject.</p>
-            <p>Documentation practitioners at Canonical are not just in the business of producing documentation &mdash; not even just the business of producing excellent documentation. They have a responsibility to advance the state of the art of documentation, and to advance documentation practice itself.</p>
-            <p>We work together towards this end, to define the practice of documentation. Our approach is critical, exploratory, collaborative and iterative.</p>
-            <h3 class="u-no-margin--bottom">We're hiring</h3>
-            <p class="p-card__content u-sv1">We're hiring technical authors to join multiple engineering teams, working on products across Canonical's portfolio.</p>
-            <p><a href="/careers/all?search=%22Technical+Author%22" class="p-button--positive">Join our team</a></p>
-          </div>
+      <div class="row p-block">
+        <p class="col-6 col-start-large-4 col-medium-4 col-start-medium-3" id="introduction">For too long in our industry, documentation has been allowed to be a secondary aspect of software development. Our approach will make documentation a core engineering concern, governed by systematic principles and requiring conscious practice, whose values inform the work not just of technical authors, but of all our engineering and product teams.</p>
+      </div>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="documentation-as-practice" style="scroll-margin-top: 3.5rem;">Documentation as practice</h2>
+        <div class="col-6 col-medium-4">
+          <p>A central principle we hold is that documentation is an engineering practice, rather than an engineering task.</p>
+          <p>At Canonical, engineers and product managers make real and substantial contributions to documentation, as part of their everyday work. Documentation is not a siloed activity, it's a responsibility shared by everyone who works in engineering, product or support.</p>
+          <p>Everyone is expected to think and care about documentation, specialists and non-specialists alike, in just the same way that quality and security are shared concerns. If you're applying to Canonical for an engineering role, don't be surprised to be asked about your work in &mdash; or your thoughts on &mdash; documentation at a job interview.</p>
         </div>
       </div>
-      <div class="question-heading" id="pillars" style="scroll-margin-top: 4.5rem;">
-        <h2>Four pillars</h2>
-        <p>Our work identifies four pillars that support documentation success</p>
-        <div class="row">
-          <div class="col-4 p-card">
-            <h3>Direction</h3>
-            <p>Where we want to go &mdash; the standards and quality we seek, so that documentation meets its users' needs.</p>
-          </div>
-          <div class="col-4 p-card">
-            <h3>Care</h3>
-            <p>Our attitude towards documentation, and a culture of documentation discipline that makes it a living concern.</p>
-          </div>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="documentation-with-rigour" style="scroll-margin-top: 3.5rem;">Documentation with rigour</h2>
+        <div class="col-6 col-medium-4">
+          <p>It's a key part of our project in documentation to understand and define documentation as a rigorous discipline in software engineering, one with rules that apply generally, are derived from sound principles, and are tested in action.</p>
+          <p>Documentation in software deserves &mdash; but has never enjoyed &mdash; a scientific approach. We need our ideas and models to be examined and challenged, not just by us and our colleagues, but beyond Canonical too. Our models are <em>working models</em>, not the last word on the subject.</p>
+          <p>Documentation practitioners at Canonical are not just in the business of producing documentation &mdash; not even just the business of producing excellent documentation. They have a responsibility to advance the state of the art of documentation, and to advance documentation practice itself.</p>
+          <p>We work together towards this end, to define the practice of documentation. Our approach is critical, exploratory, collaborative and iterative.</p>
+          <h3 class="p-heading--4">We're hiring</h3>
+          <p>We're hiring technical authors to join multiple engineering teams, working on products across Canonical's portfolio.</p>
+          <p><a href="/careers/all?search=%22Technical+Author%22" class="p-button--positive">Join our team</a></p>
         </div>
-        <div class="row">
-          <div class="col-4 p-card">
-            <h3>Execution</h3>
-            <p>How we do our work, so that we consistently produce better output with less effort and more satisfaction.</p>
-          </div>
-          <div class="col-4 p-card">
-            <h3>Equipment</h3>
-            <p>The tools and machinery we adopt to write, maintain and publish documentation, that serve our work best.</p>
-          </div>
-        </div>
-        <p><a href="https://ubuntu.com/blog/the-future-of-documentation-at-canonical">Read about our plan to put these pillars into place at Canonical&nbsp;&rsaquo;</a></p>
       </div>
-      <div class="question-heading" id="readmore" style="scroll-margin-top: 4.5rem;">
-        <h2>Read more</h2>
-        <div class="row p-divider">
-          <div class="col-3 p-divider__block">
-            <h3 class="p-heading--4">Diátaxis Framework</h3>
-            <p>Read more about the Diátaxis authoring framework</p>
-            <p><a href="https://diataxis.fr/">Read more&nbsp;&rsaquo;</a></p>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="pillars" style="scroll-margin-top: 3.5rem;">Four pillars</h2>
+          <div class="col-6 col-medium-4">
+            <div class="p-block">
+              <p>Our work identifies four pillars that support documentation success:</p>
+            </div>
+            <hr class="p-rule">
+            <div class="row">
+              <div class="col-3">
+                <h3 class="p-heading--5">Direction</h3>
+              </div>
+              <div class="col-3">
+                <p>Where we want to go &mdash; the standards and quality we seek, so that documentation meets its users' needs.</p>
+              </div>
+            </div>
+            <hr class="p-rule">
+            <div class="row">
+              <div class="col-3">
+                <h3 class="p-heading--5">Care</h3>
+              </div>
+              <div class="col-3">
+                <p>Our attitude towards documentation, and a culture of documentation discipline that makes it a living concern.</p>
+              </div>
+            </div>
+            <hr class="p-rule">
+            <div class="row">
+              <div class="col-3">
+                <h3 class="p-heading--5">Execution</h3>
+              </div>
+              <div class="col-3">
+                <p>How we do our work, so that we consistently produce better output with less effort and more satisfaction.</p>
+              </div>
+            </div>
+            <hr class="p-rule">
+            <div class="row">
+              <div class="col-3">
+                <h3 class="p-heading--5">Equipment</h3>
+              </div>
+              <div class="col-3">
+                <p>The tools and machinery we adopt to write, maintain and publish documentation, that serve our work best.</p>
+              </div>
+            </div>
           </div>
-          <div class="col-3 p-divider__block">
-            <h3 class="p-heading--4">Documentation articles</h3>
-            <p>Read our documentation articles on the Ubuntu blog</p>
-            <p><a href="https://ubuntu.com/blog/tag/documentation">View blog&nbsp;&rsaquo;</a></p>
-          </div>
-          <div class="col-3 p-divider__block">
-            <h3 class="p-heading--4">Careers at Canonical</h3>
-            <p>Take a look at our open roles here at Canonical</p>
-            <p><a href="/careers/all?search=%22Technical+Author%22">See roles&nbsp;&rsaquo;</a></p>
+        </div>
+        <hr class="p-rule">
+        <div class="row p-block">
+          <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="readmore" style="scroll-margin-top: 3.5rem;">Read more</h2>
+          <div class="col-6 col-medium-4">
+            <div class="row">
+              <div class="col-3">
+                <h3 class="p-heading--5">Diátaxis Framework</h3>
+              </div>
+              <div class="col-3">
+                <p>Read more about the Diátaxis authoring framework</p>
+                <p><a href="https://diataxis.fr/">Read more&nbsp;&rsaquo;</a></p>
+              </div>
+            </div>
+            <hr class="p-rule">
+            <div class="row">
+              <div class="col-3">
+                <h3 class="p-heading--5">Documentation articles</h3>
+              </div>
+              <div class="col-3">
+                <p>Read our documentation articles on the Ubuntu blog</p>
+                <p><a href="https://ubuntu.com/blog/tag/documentation">View blog&nbsp;&rsaquo;</a></p>
+              </div>
+            </div>
+            <hr class="p-rule">
+            <div class="row">
+              <div class="col-3">
+                <h3 class="p-heading--5">Careers at Canonical</h3>
+              </div>
+              <div class="col-3">
+                <p>Take a look at our open roles here at Canonical</p>
+                <p><a href="/careers/all?search=%22Technical+Author%22">See roles&nbsp;&rsaquo;</a></p>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/templates/documentation/work-and-careers.html
+++ b/templates/documentation/work-and-careers.html
@@ -74,7 +74,7 @@
       </div>
       <hr class="p-rule">
       <div class="row p-block">
-        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="in-the-documentation-team">In the documentation team?</h2>
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="in-the-documentation-team">In the documentation team</h2>
         <div class="col-2 col-medium-1">
           <div class="p-image-wrapper">
             <img src="https://assets.ubuntu.com/v1/f75f5612-tmihoc-photo.jpg" alt="">

--- a/templates/documentation/work-and-careers.html
+++ b/templates/documentation/work-and-careers.html
@@ -39,82 +39,132 @@
         </nav>
       </div>
     </aside>
-    <main class="col-7">
-      <div id="introduction">
-        <h2>Working in documentation at Canonical</h2>
-        <p>We are hiring now for <a href="/careers/3798310/technical-author-ubuntu-and-canonical-products-remote">Technical Authors</a> and <a href="/careers/4752030">Senior Technical Authors</a> &mdash; individuals at various levels of experience and seniority. They will be placed in multiple different teams to work on software and products of all kinds.</p>
-        <p><a href="/careers/all?search=%22Technical+Author%22" class="p-button--positive">Join the team</a></p>
-      </div>
-      <h3 id="being-a-technical-author" style="scroll-margin-top: 4.5rem;">Being a Canonical Technical Author</h3>
-      <p>A candidate for a Canonical Technical author role:</p>
-      <div class="row">
-        <div class="col-7">
-          <ul>
-            <li>has and uses programming skills &mdash; they might not be an engineer, but programming is amongst the things they can do</li>
-            <li>creates documentation that's part of a product, whether it's a proprietary or open-source, professional or personal</li>
-            <li>engages with the software and the development process as part of their work</li>
-            <li>thinks about and puzzles over the problems of documentation </li>
-          </ul>
+    <main class="col-9">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="introduction" style="scroll-margin-top: 3.5rem;">Working in documentation at Canonical</h2>
+        <div class="col-6 col-medium-4">
+          <p>We are hiring now for <a href="/careers/3798310/technical-author-ubuntu-and-canonical-products-remote">Technical Authors</a> and <a href="/careers/4752030">Senior Technical Authors</a> &mdash; individuals at various levels of experience and seniority. They will be placed in multiple different teams to work on software and products of all kinds.</p>
+          <p><a href="/careers/all?search=%22Technical+Author%22" class="p-button--positive">Join the team</a></p>
         </div>
       </div>
-      <p>If that sounds like you &mdash; maybe you're ready to join our team.</p>
-      <h3>What is a Technical Author, exactly?</h3>
-      <p>In some software organisations, the work of documentation specialists &ndash; is to produce documentation. They receive explanations and descriptions of software from their engineering colleagues, and turn those into polished output. They are expert technical <em>writers</em>.</p>
-      <p>Our documentation specialists have a different role. They are technical <em>authors</em>, members of our engineering teams. They are called Technical Authors because they have  technical authority: they know their products in depth, and are part of the software development process.</p>
-      <p>A Technical Author's work shapes the way our products are conceived and presented. Amongst other things, it's reflective, critical, active and creative. It's work that feeds back into the product itself, and helps define what it is, and always seeks new and better ways to add to its value.</p>
-      <p>Our Technical Authors come from many backgrounds, including academic research, software engineering and journalism. What they have in common is that they are expert, effective communicators. They share an intense sense of technical curiosity, and a strong feeling for the perspective of a product's users. Their strength of imagination and qualities of empathy are crucial to their work.</p>
-      <p>Documentation is something that everyone contributes to; Technical Authors encourage and lead documentation work, and help guarantee its quality.</p>
-      <h3 id="in-the-documentation-team" style="scroll-margin-top: 4.5rem;">In the documentation team</h3>
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/f75f5612-tmihoc-photo.jpg" class="p-media-object__image is-round" alt="">
-        <div class="p-media-object__details">
-          <h4 class="p-media-object__title">Teodora Mihoc, Technical Author (Juju)</h4>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="being-a-technical-author" style="scroll-margin-top: 3.5rem;">Being a Canonical Technical Author</h2>
+        <div class="col-6 col-medium-4">
+          <p>A candidate for a Canonical Technical author role:</p>
+          <ul class="p-list--divided">
+            <li class="p-list__item has-bullet">has and uses programming skills &mdash; they might not be an engineer, but programming is amongst the things they can do</li>
+            <li class="p-list__item has-bullet">creates documentation that's part of a product, whether it's a proprietary or open-source, professional or personal</li>
+            <li class="p-list__item has-bullet">engages with the software and the development process as part of their work</li>
+            <li class="p-list__item has-bullet">thinks about and puzzles over the problems of documentation </li>
+          </ul>
+          <p>If that sounds like you &mdash; maybe you're ready to join our team.</p>
+        </div>
+      </div>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4">What is a Technical Author, exactly?</h2>
+        <div class="col-6 col-medium-4">
+          <p>In some software organisations, the work of documentation specialists &ndash; is to produce documentation. They receive explanations and descriptions of software from their engineering colleagues, and turn those into polished output. They are expert technical <em>writers</em>.</p>
+          <p>Our documentation specialists have a different role. They are technical <em>authors</em>, members of our engineering teams. They are called Technical Authors because they have  technical authority: they know their products in depth, and are part of the software development process.</p>
+          <p>A Technical Author's work shapes the way our products are conceived and presented. Amongst other things, it's reflective, critical, active and creative. It's work that feeds back into the product itself, and helps define what it is, and always seeks new and better ways to add to its value.</p>
+          <p>Our Technical Authors come from many backgrounds, including academic research, software engineering and journalism. What they have in common is that they are expert, effective communicators. They share an intense sense of technical curiosity, and a strong feeling for the perspective of a product's users. Their strength of imagination and qualities of empathy are crucial to their work.</p>
+          <p>Documentation is something that everyone contributes to; Technical Authors encourage and lead documentation work, and help guarantee its quality.</p>
+        </div>
+      </div>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="in-the-documentation-team">In the documentation team?</h2>
+        <div class="col-2 col-medium-1">
+          <div class="p-image-wrapper">
+            <img src="https://assets.ubuntu.com/v1/f75f5612-tmihoc-photo.jpg" alt="">
+          </div>
+          <p class="p-heading--5 u-no-margin--bottom">Teodora Mihoc</p>
+          <p class="p-muted-heading">Technical Author (Juju)</p>
+        </div>
+        <div class="col-4 col-medium-3">
           <p class="p-media-object__content">Before joining Canonical, I spent 10 years of my life doing linguistics.</p>
           <p class="p-media-object__content">My favourite thing about that was semantics and pragmatics, and my favourite thing about that was building unified theories, in a spirit of amiable free inquiry.</p>
           <p class="p-media-object__content">I get the same pleasure in creating new knowledge and systematically, collaboratively, pursuing order in my work as a technical author for <a href="https://juju.is/">Juju</a> at Canonical.</p>
           <p class="p-media-object__content">The subject matter is, of course, very different. But in every other way the challenge is delightfully the same: to understand the puzzle; find the solution; and repeat - until it all makes sense in an ever bigger scheme of things.</p>
         </div>
-      </div>
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/7e32a5b7-Daniele-Procida.png" class="p-media-object__image is-round" alt="">
-        <div class="p-media-object__details">
-          <h4 class="p-media-object__title">Daniele Procida, Director of Engineering</h4>
+        <div class="col-6 col-start-large-4 col-medium-4 col-start-medium-3">
+          <hr class="p-rule">
+        </div>
+        <div class="col-2 col-start-large-4 col-medium-1 col-start-medium-3">
+          <div class="p-image-wrapper">
+            <img src="https://assets.ubuntu.com/v1/7e32a5b7-Daniele-Procida.png" alt="">
+          </div>
+          <p class="p-heading--5 u-no-margin--bottom">Daniele Procida</p>
+          <p class="p-muted-heading">Director of Engineering</p>
+        </div>
+        <div class="col-4 col-medium-3">
           <p class="p-media-object__content">I lead Documentation Practice throughout Canonical, from long-term strategy to guiding our activities, processes and objectives along the way. </p>
           <p class="p-media-object__content">I get to work closely with a team of talented, thoughtful and disciplined authors, whose own leadership in documentation is helping transform the way the entire organisation thinks about process and the product.</p>
           <p class="p-media-object__content">I've been a long-term participant in open-source software projects and communities, notably Python and Django, and in the growing pan-African open-source software movement.</p>
           <p class="p-media-object__content">At Canonical, I have the privilege of working in an organisation that itself works right at the heart of open-source software, and is committed to attaining excellence in documentation.</p>
         </div>
       </div>
-      <h3 id="how-we-hire" style="scroll-margin-top: 4.5rem;">How we hire</h3>
-      <p>We have a rigorous hiring process for Technical Authors. Once your application is processed, you will be invited to complete a written interview, covering numerous aspects of your career, work in and thoughts on documentation and your education. Stages along the way include:</p>
-      <h4>Written interview</h4>
-      <p>The written interview is an important part of the process. It's reviewed - anonymously, in an effort to remove bias - by multiple members of the team.</p>
-      <p>This has several benefits. One is that in-person interviews are stressful experiences, while a written interview gives you all the time you need to gather your thoughts and put them together in a way that presents you at your best. It's a good opportunity to say things that might not not otherwise come up later.</p>
-      <p>It's also excellent preparation for the interviews that will come. We want to see your best, and for you to be prepared for them. And we want them to be a good experience for you too.</p>
-      <p>Our written interviews are used by all the future in-person interviewers you'll meet. When you do meet them, they'll already have had a good introduction to you, so that you don't need to repeat the same stories and explanations to multiple people.</p>
-      <h4>Peer interviews</h4>
-      <p>Candidates who progress will face up to three interviews with Technical Author peers, covering:</p>
-      <div class="row">
-        <div class="col-7">
-          <ul>
-            <li><em>Skills and experience</em>: What have you done? What do you know? What can you do?</li>
-            <li><em>Insight and understanding</em>: How do you think about documentation and its challenges? What ideas have you formed, about practice, process and product? How deep is your thinking?</li>
-            <li><em>Culture and value</em>: What drives you and what values underpin your work? How do you collaborate? How will you fit in with our values, and how will you challenge us to do better?</li>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="how-we-hire" style="scroll-margin-top: 3.5rem;">How we hire</h2>
+        <div class="col-6 col-medium-4">
+          <p>We have a rigorous hiring process for Technical Authors. Once your application is processed, you will be invited to complete a written interview, covering numerous aspects of your career, work in and thoughts on documentation and your education. Stages along the way include:</p>
+        </div>
+        <div class="col-9 col-medium-6">
+          <hr class="p-rule">
+        </div>
+        <h3 class="col-3 col-medium-2 p-heading--5">Written interview</h3>
+        <div class="col-6 col-medium-4">
+          <p>The written interview is an important part of the process. It's reviewed - anonymously, in an effort to remove bias - by multiple members of the team.</p>
+          <p>This has several benefits. One is that in-person interviews are stressful experiences, while a written interview gives you all the time you need to gather your thoughts and put them together in a way that presents you at your best. It's a good opportunity to say things that might not not otherwise come up later.</p>
+          <p>It's also excellent preparation for the interviews that will come. We want to see your best, and for you to be prepared for them. And we want them to be a good experience for you too.</p>
+          <p>Our written interviews are used by all the future in-person interviewers you'll meet. When you do meet them, they'll already have had a good introduction to you, so that you don't need to repeat the same stories and explanations to multiple people.</p>
+        </div>
+        <div class="col-9 col-medium-6">
+          <hr class="p-rule">
+        </div>
+        <h3 class="col-3 col-medium-2 p-heading--5">Peer interviews</h3>
+        <div class="col-6 col-medium-4">
+          <p>Candidates who progress will face up to three interviews with Technical Author peers, covering:</p>
+          <ul class="p-list--divided">
+            <li class="p-list__item has-bullet"><em>Skills and experience</em>: What have you done? What do you know? What can you do?</li>
+            <li class="p-list__item has-bullet"><em>Insight and understanding</em>: How do you think about documentation and its challenges? What ideas have you formed, about practice, process and product? How deep is your thinking?</li>
+            <li class="p-list__item has-bullet"><em>Culture and value</em>: What drives you and what values underpin your work? How do you collaborate? How will you fit in with our values, and how will you challenge us to do better?</li>
           </ul>
         </div>
+        <div class="col-9 col-medium-6">
+          <hr class="p-rule">
+        </div>
+        <h3 class="col-3 col-medium-2 p-heading--5">Talent interview</h3>
+        <div class="col-6 col-medium-4">
+         <p>Next is an interview with someone from our Talent Acquisition team, that looks back at your career, discusses how you work and want to work, and considers questions like salary, availability to start and so on.</p>
+        </div>
+        <div class="col-9 col-medium-6">
+          <hr class="p-rule">
+        </div>
+        <h3 class="col-3 col-medium-2 p-heading--5">Technical exercise</h3>
+        <div class="col-6 col-medium-4">
+          <p>Not strictly an interview, but an opportunity to demonstrate your ability to think through and solve documentation problems (and it's not a writing test; we already know you can write). We want to see how you approach issues such as meeting user needs and documentation structure, and your analytical and critical skills.</p>
+        </div>
+        <div class="col-9 col-medium-6">
+          <hr class="p-rule">
+        </div>
+        <h3 class="col-3 col-medium-2 p-heading--5">Documentation lead interview</h3>
+        <div class="col-6 col-medium-4">
+          <p>An interview to confirm our assessments and work out the next steps, based on your interests, skills and experience. This will help us arrange interviews with appropriate hiring managers in different teams.</p>
+        </div>
+        <div class="col-9 col-medium-6">
+          <hr class="p-rule">
+        </div>
+        <h3 class="col-3 col-medium-2 p-heading--5">Hiring manager interviews</h3>
+        <div class="col-6 col-medium-4">
+          <p>By this stage, we'd like to have you as a Technical Author at Canonical, and now it's a question of finding the right team or project for you, where both we and you feel that you'll be excited by the technology and in a strong position to make a valuable contribution.</p>
+          <p>That is indeed a lot of interviews. It's an in-depth process for an exacting role and we take it very seriously.</p>
+          <p>Don't forget that you are interviewing us as much as we are interviewing you. We want you to be an active participant in the process, not just someone who answers our questions.  </p>
+          <p>You will spend a large proportion of your life each day at work. We, as much as you, want to be sure that you're in the right place, one where you will be successful, fulfilled and happy. </p>
+        </div>
       </div>
-      <h4>Talent interview</h4>
-      <p>Next is an interview with someone from our Talent Acquisition team, that looks back at your career, discusses how you work and want to work, and considers questions like salary, availability to start and so on.</p>
-      <h4>Technical exercise</h4>
-      <p>Not strictly an interview, but an opportunity to demonstrate your ability to think through and solve documentation problems (and it's not a writing test; we already know you can write). We want to see how you approach issues such as meeting user needs and documentation structure, and your analytical and critical skills.</p>
-      <h4>Documentation lead interview</h4>
-      <p>An interview to confirm our assessments and work out the next steps, based on your interests, skills and experience. This will help us arrange interviews with appropriate hiring managers in different teams.</p>
-      <h4>Hiring manager interviews</h4>
-      <p>By this stage, we'd like to have you as a Technical Author at Canonical, and now it's a question of finding the right team or project for you, where both we and you feel that you'll be excited by the technology and in a strong position to make a valuable contribution.</p>
-      <hr>
-      <p>That is indeed a lot of interviews. It's an in-depth process for an exacting role and we take it very seriously.</p>
-      <p>Don't forget that you are interviewing us as much as we are interviewing you. We want you to be an active participant in the process, not just someone who answers our questions.  </p>
-      <p>You will spend a large proportion of your life each day at work. We, as much as you, want to be sure that you're in the right place, one where you will be successful, fulfilled and happy. </p>
     </main>
   </div>
 </section>

--- a/templates/documentation/work-and-careers.html
+++ b/templates/documentation/work-and-careers.html
@@ -41,11 +41,11 @@
     </aside>
     <main class="col-7">
       <div id="introduction">
-        <h1 class="p-heading--2">Working in documentation at Canonical</h1>
+        <h2>Working in documentation at Canonical</h2>
         <p>We are hiring now for <a href="/careers/3798310/technical-author-ubuntu-and-canonical-products-remote">Technical Authors</a> and <a href="/careers/4752030">Senior Technical Authors</a> &mdash; individuals at various levels of experience and seniority. They will be placed in multiple different teams to work on software and products of all kinds.</p>
         <p><a href="/careers/all?search=%22Technical+Author%22" class="p-button--positive">Join the team</a></p>
       </div>
-      <h2 class="question-heading p-heading--3" id="being-a-technical-author" style="scroll-margin-top: 4.5rem;">Being a Canonical Technical Author</h2>
+      <h3 id="being-a-technical-author" style="scroll-margin-top: 4.5rem;">Being a Canonical Technical Author</h3>
       <p>A candidate for a Canonical Technical author role:</p>
       <div class="row">
         <div class="col-7">
@@ -58,17 +58,17 @@
         </div>
       </div>
       <p>If that sounds like you &mdash; maybe you're ready to join our team.</p>
-      <h2 class="p-heading--3">What is a Technical Author, exactly?</h2>
+      <h3>What is a Technical Author, exactly?</h3>
       <p>In some software organisations, the work of documentation specialists &ndash; is to produce documentation. They receive explanations and descriptions of software from their engineering colleagues, and turn those into polished output. They are expert technical <em>writers</em>.</p>
       <p>Our documentation specialists have a different role. They are technical <em>authors</em>, members of our engineering teams. They are called Technical Authors because they have  technical authority: they know their products in depth, and are part of the software development process.</p>
       <p>A Technical Author's work shapes the way our products are conceived and presented. Amongst other things, it's reflective, critical, active and creative. It's work that feeds back into the product itself, and helps define what it is, and always seeks new and better ways to add to its value.</p>
       <p>Our Technical Authors come from many backgrounds, including academic research, software engineering and journalism. What they have in common is that they are expert, effective communicators. They share an intense sense of technical curiosity, and a strong feeling for the perspective of a product's users. Their strength of imagination and qualities of empathy are crucial to their work.</p>
       <p>Documentation is something that everyone contributes to; Technical Authors encourage and lead documentation work, and help guarantee its quality.</p>
-      <h2 class="question-heading p-heading--3" id="in-the-documentation-team" style="scroll-margin-top: 4.5rem;">In the documentation team</h2>
+      <h3 id="in-the-documentation-team" style="scroll-margin-top: 4.5rem;">In the documentation team</h3>
       <div class="p-media-object">
         <img src="https://assets.ubuntu.com/v1/f75f5612-tmihoc-photo.jpg" class="p-media-object__image is-round" alt="">
         <div class="p-media-object__details">
-          <h3 class="p-media-object__title">Teodora Mihoc, Technical Author (Juju)</h3>
+          <h4 class="p-media-object__title">Teodora Mihoc, Technical Author (Juju)</h4>
           <p class="p-media-object__content">Before joining Canonical, I spent 10 years of my life doing linguistics.</p>
           <p class="p-media-object__content">My favourite thing about that was semantics and pragmatics, and my favourite thing about that was building unified theories, in a spirit of amiable free inquiry.</p>
           <p class="p-media-object__content">I get the same pleasure in creating new knowledge and systematically, collaboratively, pursuing order in my work as a technical author for <a href="https://juju.is/">Juju</a> at Canonical.</p>
@@ -78,21 +78,21 @@
       <div class="p-media-object">
         <img src="https://assets.ubuntu.com/v1/7e32a5b7-Daniele-Procida.png" class="p-media-object__image is-round" alt="">
         <div class="p-media-object__details">
-          <h3 class="p-media-object__title">Daniele Procida, Director of Engineering</h3>
+          <h4 class="p-media-object__title">Daniele Procida, Director of Engineering</h4>
           <p class="p-media-object__content">I lead Documentation Practice throughout Canonical, from long-term strategy to guiding our activities, processes and objectives along the way. </p>
           <p class="p-media-object__content">I get to work closely with a team of talented, thoughtful and disciplined authors, whose own leadership in documentation is helping transform the way the entire organisation thinks about process and the product.</p>
           <p class="p-media-object__content">I've been a long-term participant in open-source software projects and communities, notably Python and Django, and in the growing pan-African open-source software movement.</p>
           <p class="p-media-object__content">At Canonical, I have the privilege of working in an organisation that itself works right at the heart of open-source software, and is committed to attaining excellence in documentation.</p>
         </div>
       </div>
-      <h2 class="question-heading p-heading--3" id="how-we-hire" style="scroll-margin-top: 4.5rem;">How we hire</h2>
+      <h3 id="how-we-hire" style="scroll-margin-top: 4.5rem;">How we hire</h3>
       <p>We have a rigorous hiring process for Technical Authors. Once your application is processed, you will be invited to complete a written interview, covering numerous aspects of your career, work in and thoughts on documentation and your education. Stages along the way include:</p>
-      <h3 class="u-no-margin--bottom p-heading--4">Written interview</h3>
+      <h4>Written interview</h4>
       <p>The written interview is an important part of the process. It's reviewed - anonymously, in an effort to remove bias - by multiple members of the team.</p>
       <p>This has several benefits. One is that in-person interviews are stressful experiences, while a written interview gives you all the time you need to gather your thoughts and put them together in a way that presents you at your best. It's a good opportunity to say things that might not not otherwise come up later.</p>
       <p>It's also excellent preparation for the interviews that will come. We want to see your best, and for you to be prepared for them. And we want them to be a good experience for you too.</p>
       <p>Our written interviews are used by all the future in-person interviewers you'll meet. When you do meet them, they'll already have had a good introduction to you, so that you don't need to repeat the same stories and explanations to multiple people.</p>
-      <h3 class="u-no-margin--bottom p-heading--4">Peer interviews</h3>
+      <h4>Peer interviews</h4>
       <p>Candidates who progress will face up to three interviews with Technical Author peers, covering:</p>
       <div class="row">
         <div class="col-7">
@@ -103,13 +103,13 @@
           </ul>
         </div>
       </div>
-      <h3 class="u-no-margin--bottom p-heading--4">Talent interview</h3>
+      <h4>Talent interview</h4>
       <p>Next is an interview with someone from our Talent Acquisition team, that looks back at your career, discusses how you work and want to work, and considers questions like salary, availability to start and so on.</p>
-      <h3 class="u-no-margin--bottom p-heading--4">Technical exercise</h3>
+      <h4>Technical exercise</h4>
       <p>Not strictly an interview, but an opportunity to demonstrate your ability to think through and solve documentation problems (and it's not a writing test; we already know you can write). We want to see how you approach issues such as meeting user needs and documentation structure, and your analytical and critical skills.</p>
-      <h3 class="u-no-margin--bottom p-heading--4">Documentation lead interview</h3>
+      <h4>Documentation lead interview</h4>
       <p>An interview to confirm our assessments and work out the next steps, based on your interests, skills and experience. This will help us arrange interviews with appropriate hiring managers in different teams.</p>
-      <h3 class="u-no-margin--bottom p-heading--4">Hiring manager interviews</h3>
+      <h4>Hiring manager interviews</h4>
       <p>By this stage, we'd like to have you as a Technical Author at Canonical, and now it's a question of finding the right team or project for you, where both we and you feel that you'll be excited by the technology and in a strong position to make a valuable contribution.</p>
       <hr>
       <p>That is indeed a lot of interviews. It's an in-depth process for an exacting role and we take it very seriously.</p>

--- a/templates/documentation/work-and-careers.html
+++ b/templates/documentation/work-and-careers.html
@@ -160,11 +160,11 @@
         <h3 class="col-3 col-medium-2 p-heading--5">Hiring manager interviews</h3>
         <div class="col-6 col-medium-4">
           <p>By this stage, we'd like to have you as a Technical Author at Canonical, and now it's a question of finding the right team or project for you, where both we and you feel that you'll be excited by the technology and in a strong position to make a valuable contribution.</p>
-          <p>That is indeed a lot of interviews. It's an in-depth process for an exacting role and we take it very seriously.</p>
-          <p>Don't forget that you are interviewing us as much as we are interviewing you. We want you to be an active participant in the process, not just someone who answers our questions.  </p>
-          <p>You will spend a large proportion of your life each day at work. We, as much as you, want to be sure that you're in the right place, one where you will be successful, fulfilled and happy. </p>
         </div>
       </div>
+      <p>That is indeed a lot of interviews. It's an in-depth process for an exacting role and we take it very seriously.</p>
+      <p>Don't forget that you are interviewing us as much as we are interviewing you. We want you to be an active participant in the process, not just someone who answers our questions.  </p>
+      <p>You will spend a large proportion of your life each day at work. We, as much as you, want to be sure that you're in the right place, one where you will be successful, fulfilled and happy. </p>
     </main>
   </div>
 </section>


### PR DESCRIPTION
## Done

Based on @mtruj013's [pr](https://github.com/canonical/canonical.com/pull/905). I changed a few things so pushing to a separate pr so as to not break anything.

This is a bit different from the design, as I talked to Daniele since we did the pages and he expressed a preference for a denser treatment on documentation pages, and liked placing headings on the side and clamping the heading hierarchy to h4. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check tab functionality on all 3 tabs

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-3737
