### PR TITLE
Wd 4674 visual update partners pages footer

### DIFF
--- a/templates/partners/iot-device.html
+++ b/templates/partners/iot-device.html
@@ -126,6 +126,6 @@
   </div>
 </section>
 
-{% include 'partial/_partners-footer.html' %}
+{% include '/partners/partial/_footer.html' %}
 
 {% endblock %}

--- a/templates/partners/partial/_footer.html
+++ b/templates/partners/partial/_footer.html
@@ -1,34 +1,30 @@
-  <section class="p-section">
-    <div class="row">
-      <hr class="p-rule">
-      <div class="col-6 col-medium-3">
-        <h3 class="p-heading--2">
-          Find a partner
-        </h3>
-      </div>
-      <div class="col-6 col-medium-3">
-        <p>Looking for a supplier with Ubuntu expertise? Select from the complete list of our partners.</p>
-        <hr class="p-rule">
-        <p>
-          <a href="/partners/find-a-partner">Find a partner&nbsp;&rsaquo;</a>
-        </p>
-      </div>
+<section class="p-section">
+  <div class="row">
+    <hr class="p-rule">
+    <div class="col-6 col-medium-3">
+      <h3 class="p-heading--2">Find a partner</h3>
     </div>
-  </section>
-  <section class="p-strip is-deep u-no-padding--top">
-    <div class="row">
+    <div class="col-6 col-medium-3">
+      <p>Looking for a supplier with Ubuntu expertise? Select from the complete list of our partners.</p>
       <hr class="p-rule">
-      <div class="col-6 col-medium-3">
-        <h3 class="p-heading--2">
-          Become a partner
-        </h3>
-      </div>
-      <div class="col-6 col-medium-3">
-        <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
-        <hr class="p-rule">
-        <p>
-          <a href="/partners/become-a-partner">Become a partner&nbsp;&rsaquo;</a>
-        </p>
-      </div>
+      <p>
+        <a href="/partners/find-a-partner">Find a partner&nbsp;&rsaquo;</a>
+      </p>
     </div>
-  </section>
+  </div>
+</section>
+<section class="p-strip is-deep u-no-padding--top">
+  <div class="row">
+    <hr class="p-rule">
+    <div class="col-6 col-medium-3">
+      <h3 class="p-heading--2">Become a partner</h3>
+    </div>
+    <div class="col-6 col-medium-3">
+      <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
+      <hr class="p-rule">
+      <p>
+        <a href="/partners/become-a-partner">Become a partner&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </div>
+</section>

--- a/templates/partners/partial/_footer.html
+++ b/templates/partners/partial/_footer.html
@@ -1,9 +1,34 @@
-<section class="p-strip--white is-deep">
-  <div class="row">
-    <h3 class="p-heading--2">
-    <a href="/partners/find-a-partner">Find a partner&nbsp;&rsaquo;</a>
-    <br>
-    <a href="/partners/become-a-partner">Become a partner&nbsp;&rsaquo;</a>
-    </h3>
-  </div>
-</section>
+  <section class="p-section">
+    <div class="row">
+      <hr class="p-rule">
+      <div class="col-6 col-medium-3">
+        <h3 class="p-heading--2">
+          Find a partner
+        </h3>
+      </div>
+      <div class="col-6 col-medium-3">
+        <p>Looking for a supplier with Ubuntu expertise? Select from the complete list of our partners.</p>
+        <hr class="p-rule">
+        <p>
+          <a href="/partners/find-a-partner">Find a partner&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </section>
+  <section class="p-strip is-deep u-no-padding--top">
+    <div class="row">
+      <hr class="p-rule">
+      <div class="col-6 col-medium-3">
+        <h3 class="p-heading--2">
+          Become a partner
+        </h3>
+      </div>
+      <div class="col-6 col-medium-3">
+        <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
+        <hr class="p-rule">
+        <p>
+          <a href="/partners/become-a-partner">Become a partner&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </section>


### PR DESCRIPTION
## Done

Revert to previous design as per discussion with @juanruitina 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the partners footer is in a 2 6-col layout, check links go to the correct places

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4674

## Screenshots
![image](https://github.com/canonical/canonical.com/assets/2741678/a5a34a20-4600-40cf-ab85-776ec3a3ab21)

