### PR TITLE
Update error pages

### DIFF
--- a/templates/401.html
+++ b/templates/401.html
@@ -1,21 +1,11 @@
-{% extends 'base_index.html' %}
+{% extends '/_error.tmpl' %}
 
-{% block title %}401: Unauthorised{% endblock %}
+{% set error_code = "401" %}
 
-{% block meta_description %}Something&rsquo;s gone wrong.{% endblock %}
+{% set error_message = "Unauthorised" %}
 
-{% block content %}
-<div class="p-strip is-deep u-extra-space">
-  <div class="row">
-    <div class="col-6 col-medium-3 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Error owl" width="400" height="400" />
-    </div>
-    <div class="col-6 col-medium-3">
-      <h1>401: Unauthorised</h1>
-      <p>Sorry you are not allowed to access this page.</p>
-      {% if message %}<p></p><blockquote><code>{{ message }}</code></blockquote></p>{% endif %}
-      <p>If you believe this is an error, please <a href="https://github.com/canonical/canonical.com/issues/new">file an issue</a>.</p>
-    </div>
-  </div>
-</div>
-{% endblock content %}
+{% block error_content %}
+  Sorry you are not allowed to access this page.
+  <br>
+  <a href="https://github.com/canonical/canonical.com/issues/new">File a bug</a> if you think this might be an error.
+{% endblock error_content %}

--- a/templates/401.html
+++ b/templates/401.html
@@ -5,7 +5,6 @@
 {% set error_message = "Unauthorised" %}
 
 {% block error_content %}
-  Sorry you are not allowed to access this page.
-  <br>
-  <a href="https://github.com/canonical/canonical.com/issues/new">File a bug</a> if you think this might be an error.
+  You do not have access to this page.<br>
+  You can <a href="https://github.com/canonical/canonical.com/issues/new">File a bug</a> if this is an error.
 {% endblock error_content %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,20 +1,11 @@
-{% extends 'base_index.html' %}
+{% extends '/_error.tmpl' %}
 
-{% block title %}404: Page not found{% endblock %}
+{% set error_code = "404" %}
 
-{% block meta_description %}Sorry, we can't find the page you're looking for.{% endblock %}
+{% set error_message = "Page not found" %}
 
-{% block content %}
-<div class="p-strip is-deep u-extra-space">
-  <div class="row">
-    <div class="col-6 col-medium-3 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Error owl" width="400" height="400" />
-    </div>
-    <div class="col-6 col-medium-3">
-      <h1>404: Page not found</h1>
-      <p>Sorry, we can't find the page you're looking for.</p>
-      <p>If you think this is an error on our site, please <a href="https://github.com/canonical-web-and-design/canonical.com/issues/new"  >file a bug</a>.</p>
-    </div>
-  </div>
-</div>
-{% endblock content %}
+{% block error_content %}
+  We can't find the page you're looking for.
+  <br>
+  <a href="https://github.com/canonical/canonical.com/issues/new">File a bug</a> if you think this might be an error.
+{% endblock error_content %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -5,7 +5,7 @@
 {% set error_message = "Server error" %}
 
 {% block error_content %}
-  Try reloading the page.<br>
-  If the error persists, please note that it may be a <a href="https://github.com/canonical-web-and-design/canonical.com/issues">known issue</a>.<br>
-  If not, please <a href="https://github.com/canonical/canonical.com/issues/new">file a new issue</a>.
+  We couldn't load this page.<br>
+  Try reloading or <a href="https://github.com/canonical/canonical.com/issues/new">file an issue</a>.<br>
+  Please note, this may be a <a href="https://github.com/canonical/canonical.com/issues">known issue</a> that we are working on.
 {% endblock error_content %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,25 +1,11 @@
-{% extends 'base_index.html' %}
+{% extends '/_error.tmpl' %}
 
-{% block title %}500: Server error{% endblock %}
+{% set error_code = "500" %}
 
-{% block meta_description %}Something&rsquo;s gone wrong.{% endblock %}
+{% set error_message = "Server error" %}
 
-{% block content %}
-<div class="p-strip is-deep u-extra-space">
-  <div class="row">
-    <div class="col-6 col-medium-3 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Error owl" width="400" height="400" />
-    </div>
-    <div class="col-6 col-medium-3">
-      <h1>500: Server error</h1>
-      <p class="p-heading--4">Something&rsquo;s gone wrong.</p>
-      {% if message %}<blockquote><code>{{ message }}</code></blockquote>{% endif %}
-      <p>
-        Try reloading the page.
-        If the error persists, please note that it may be a <a href="https://github.com/canonical-web-and-design/canonical.com/issues">known issue</a>.
-        If not, please <a href="https://github.com/canonical-web-and-design/canonical.com/issues/new">file a new issue</a>.
-      </p>
-    </div>
-  </div>
-</div>
-{% endblock content %}
+{% block error_content %}
+  Try reloading the page.<br>
+  If the error persists, please note that it may be a <a href="https://github.com/canonical-web-and-design/canonical.com/issues">known issue</a>.<br>
+  If not, please <a href="https://github.com/canonical/canonical.com/issues/new">file a new issue</a>.
+{% endblock error_content %}

--- a/templates/502.html
+++ b/templates/502.html
@@ -1,24 +1,10 @@
-{% extends 'base_index.html' %}
+{% extends '/_error.tmpl' %}
 
-{% block title %}502: Bad gateway{% endblock %}
+{% set error_code = "502" %}
 
-{% block meta_description %}Sorry, we can't find the page you're looking for.{% endblock %}
+{% set error_message = "Bad gateway" %}
 
-{% block content %}
-<div class="p-strip is-deep u-extra-space">
-  <div class="row">
-    <div class="col-6 col-medium-3 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Error owl" width="400" height="400" />
-    </div>
-    <div class="col-6 col-medium-3">
-      <h1>502: Bad gateway</h1>
-      {% if message %}
-				<p>{{ message }}</p>
-			{% else %}
-				<p>Sorry, The proxy server received an invalid response from an upstream server.</p>
-			{% endif %}
-      <p>If you think this is an error on our site, please <a href="https://github.com/canonical-web-and-design/canonical.com/issues/new">file a bug</a>.</p>
-    </div>
-  </div>
-</div>
-{% endblock content %}
+{% block error_content %}
+  Sorry, The proxy server received an invalid response from an upstream server.<br>
+  <a href="https://github.com/canonical/canonical.com/issues/new">File a bug</a> if you think this might be an error.
+{% endblock error_content %}

--- a/templates/502.html
+++ b/templates/502.html
@@ -5,6 +5,6 @@
 {% set error_message = "Bad gateway" %}
 
 {% block error_content %}
-  Sorry, The proxy server received an invalid response from an upstream server.<br>
-  <a href="https://github.com/canonical/canonical.com/issues/new">File a bug</a> if you think this might be an error.
+  The proxy server did not get a valid response from an upstream server.<br>
+  You can <a href="https://github.com/canonical/canonical.com/issues/new">File a bug</a> to report this issue.
 {% endblock error_content %}

--- a/templates/_error.tmpl
+++ b/templates/_error.tmpl
@@ -7,8 +7,8 @@
 {% set is_paper = True %}
 
 {% block content %}
-  <div class="p-strip">
-    <div class="row p-section">
+  <div class="p-strip is-deep">
+    <div class="row">
       <hr class="p-rule">
       <div class="col-3 col-medium-2 col-medium-3 u-hide--small">
         <p class="p-heading--1">{{error_code}}</p>

--- a/templates/_error.tmpl
+++ b/templates/_error.tmpl
@@ -1,0 +1,25 @@
+{% extends 'base_index.html' %}
+
+{% block title %}{{error_code}}: {{error_message}}{% endblock %}
+
+{% block meta_description %}{{error_message}}{% endblock %}
+
+{% set is_paper = True %}
+
+{% block content %}
+  <div class="p-strip">
+    <div class="row p-section">
+      <hr class="p-rule">
+      <div class="col-3 col-medium-2 col-medium-3 u-hide--small">
+        <p class="p-heading--1">{{error_code}}</p>
+      </div>
+      <div class="col-9 col-medium-4">
+        <h1><span class="u-hide--medium u-hide--large">{{error_code}}: </span>{{error_message}}</h1>
+        <p class="p-heading--2">
+          {% block error_content %}
+          {% endblock error_content %}
+        </p>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -80,7 +80,7 @@
     <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}" />
   </head>
 
-  <body {% if is_paper %} class="is-paper" {% endif %}>
+  <body {% if is_paper %} class="is-paper l-site" {% else %} class="l-site" {% endif %} >
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M5BPGQ6"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -22,7 +22,7 @@
         {% if "/careers" in current_path %}
           <li class="p-list__item--condensed"><a href="https://ubuntu.com/legal/equal-employment-opportunity-commitment">Equal Employment Opportunity Commitment</a></li>
         {% endif %}
-        <li class="p-list__item--condensed"><a href="https://github.com/canonical-web-and-design/canonical.com/issues/new">Improve this site</a></li>
+        <li class="p-list__item--condensed"><a href="https://github.com/canonical/canonical.com/issues/new">Improve this site</a></li>
         <li class="p-list__item--condensed"><a href="/projects" >Projects</a></li>
         <li class="p-list__item--condensed"><a class="js-revoke-cookie-manager" href="">Manage your tracker settings</a></li>
       </ul>

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -1,5 +1,5 @@
 {% set current_path =  url_for(request.endpoint, **request.view_args)  %}
-<footer class="p-strip--dark p-footer">
+<footer class="p-strip--dark p-footer l-footer--sticky">
   <div class="row u-position">
     <div class="col-medium-2 col-3">
       <p>&copy; {{ current_year }} Canonical Ltd.</p>

--- a/templates/partners/partial/_footer.html
+++ b/templates/partners/partial/_footer.html
@@ -1,4 +1,4 @@
-<section class="p-strip--white is-deep">
+<section class="p-strip--white is-deep l-footer--sticky">
   <div class="row">
     <h3 class="p-heading--2">
     <a href="/partners/find-a-partner">Find a partner&nbsp;&rsaquo;</a>


### PR DESCRIPTION
## Done

Rebuiuld the 404 page as per teh design (sans thge enrichment isometric illustration).
Driveby: Make  footer stick to the bottom of the window.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check against hthe design

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-3807

## Screenshots

![image](https://github.com/canonical/canonical.com/assets/2741678/d4f8d1a0-8264-44d8-9008-dd24644c39c5)
