### PR TITLE
Update favicons, take 2

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -54,9 +54,9 @@
 
     {% block extra_metatags %}{% endblock %}
 
-    <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/0843d517-favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/e6b1c303-COF%20favicon.ico" type="image/x-icon" />
     <link rel="apple-touch-icon-precomposed" sizes="144x144"
-      href="https://assets.ubuntu.com/v1/9864667f-apple-touch-icon-144x144-precomposed.png">
+      href="https://assets.ubuntu.com/v1/f38b9c7e-COF%20apple-touch-icon.png">
     <link rel="apple-touch-icon-precomposed" sizes="114x114"
       href="https://assets.ubuntu.com/v1/f2ddbdc6-apple-touch-icon-114x114-precomposed.png">
     <link rel="apple-touch-icon-precomposed" sizes="72x72"


### PR DESCRIPTION
## Done

- Follow up of [this pr](https://github.com/canonical/canonical.com/pull/923). Has the exact same changes (updates 2 of the favicons), minus the rouge commits 

Note: These assets will likely have to be reworked, see jira ticket

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- See that the assets were updated 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4615
