### PR TITLE
WD-4941 - Add FAQ section about WI anonymously

### DIFF
--- a/templates/careers/application/faq.html
+++ b/templates/careers/application/faq.html
@@ -105,6 +105,14 @@
             </li>
             <li class="p-accordion__group">
               <div role="heading" aria-level="3" class="p-accordion__heading">
+                <button type="button" class="p-accordion__tab" id="written-interview-wi-anon" aria-controls="written-interview-wi-anon-section" aria-expanded="false"><span class="u-default-max-width">Why is there a requirement for the Written Interview to be submitted anonymously?</span></button>
+              </div>
+              <section class="p-accordion__panel" id="written-interview-wi-anon-section" aria-hidden="true" aria-labelledby="written-interview-wi-anon">
+                <p>One initiative that we have in place to reduce bias in our selection process is to protect the identity of your Written Interview submission. This means that the reviewer of the submission will not be able to locate your candidate record or resume submission. We therefore ask for you to omit any information or links that make you personally identifiable i.e. GitHub, LinkedIn links, etc. We assume you have included this information in your application set questions or on your resume, so we will already hold this separately. Our Written Interview assessment will be based purely on the skills you possess and display in this document.</p>
+              </section>
+            </li>
+            <li class="p-accordion__group">
+              <div role="heading" aria-level="3" class="p-accordion__heading">
                 <button type="button" class="p-accordion__tab" id="written-interview-tab5" aria-controls="written-interview-tab5-section" aria-expanded="false"><span class="u-default-max-width">How do I submit my Written Interview?</span></button>
               </div>
               <section class="p-accordion__panel" id="written-interview-tab5-section" aria-hidden="true" aria-labelledby="written-interview-tab5">


### PR DESCRIPTION
## Done

Add the "Why is there a requirement for the Written Interview to be submitted anonymously?" section to the FAQ page.

## QA

- Go to /career/application/faq in the demo
- Check the content matches the [copy doc](https://docs.google.com/document/d/12_O_QtPqfv9p7kaDFdiP8Xq-kY5xa1XB-C-CRbXjDew/edit)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4941