### PR TITLE
WD-4982 - Make the navigation tag orange

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -513,7 +513,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
   background-size: contain;
 }
 
-.p-department-cards__container {  
+.p-department-cards__container {
   aspect-ratio: auto;
   background-color: #fff;
 
@@ -546,7 +546,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
 
     .p-department-cards__link {
       color: $color-link;
-      
+
       &:hover {
         text-decoration: underline;
       }
@@ -558,7 +558,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
       top: 0.4375rem;
       width: 2rem;
     }
-    
+
     .p-department-cards__image-container {
       align-items: center;
       display: flex;
@@ -637,7 +637,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
 
     @media screen and (max-width: 688px) {
       height: 181px;
-      width: 121px;  
+      width: 121px;
     }
   }
 }
@@ -699,4 +699,10 @@ $p-small-lh-diff: map-get($line-heights, default-text) - map-get($line-heights, 
 
 #latest-articles article:first-child hr {
   display: none;
+}
+
+// XXX: 05.06.23 - This can be removed once this project is using Vanilla 4.0
+// Upstream fix: https://github.com/canonical/vanilla-framework/pull/4821
+.p-navigation__tagged-logo .p-navigation__logo-tag {
+  background-color: #E95420;
 }


### PR DESCRIPTION
## Done

Update the accent color on the site which is used for the navigation tag by Vanilla.

## QA

- Open the demo and see the logo is orange and not aubergine anymore

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4982

## Screenshots

![image](https://github.com/canonical/canonical.com/assets/1413534/6e1aad86-2578-456e-b38b-47bb3f712c36)

