### PR TITLE
Update careers nav

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -77,15 +77,12 @@
               <a href="/careers/career-explorer" class="p-navigation__dropdown-item">Career finder</a>
             </li>
             <li>
-              <a href="/careers/progression" class="p-navigation__dropdown-item">Career progression</a>
-            </li>
-            <li>
               <a href="/careers/company-culture" class="p-navigation__dropdown-item">Company culture</a>
               <ul class="p-navigation__sub-list">
-                <li><a href="/careers/company-culture/diversity" class="p-navigation__dropdown-item">Diversity</a></li>
                 <li><a href="/careers/company-culture/remote-work" class="p-navigation__dropdown-item">Remote work</a></li>
-                <li><a href="/careers/company-culture/sustainability" class="p-navigation__dropdown-item">Sustainability</a></li>
+                <li><a href="/careers/company-culture/diversity" class="p-navigation__dropdown-item">Diversity</a></li>
                 <li><a href="/careers/company-culture/progression" class="p-navigation__dropdown-item">Progression</a></li>
+                <li><a href="/careers/company-culture/sustainability" class="p-navigation__dropdown-item">Sustainability</a></li>
               </ul>
             </li>
           </ul>


### PR DESCRIPTION
## Rationale

During demo review I realized that there are repeated links to the documentation page on the careers nav. UX has requested that the first one be removed that the "company culture" children be ordered as follows: Remote work, Diversity, Progression, Sustainability

## Done

- Updated careers nav according to above specification 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://canonical-com-933.demos.haus/
- See that the updates have been made

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4990
