### PR TITLE
Update partners nav and /partners copy

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -43,7 +43,7 @@
               <ul class="p-navigation__sub-list">
                 <li><a href="/partners/desktop" class="p-navigation__dropdown-item">Desktop</a></li>
                 <li><a href="/partners/channel-and-reseller" class="p-navigation__dropdown-item">Channel/reseller</a></li>
-                <li><a href="/partners/iot-device" class="p-navigation__dropdown-item">Internet of Things device</a></li>
+                <li><a href="/partners/iot-device" class="p-navigation__dropdown-item">IoT devices</a></li>
                 <li><a href="/partners/ihv-and-oem" class="p-navigation__dropdown-item">IHV/OEM</a></li>
                 <li><a href="/partners/gsi" class="p-navigation__dropdown-item">Global Seller Initiative</a></li>
                 <li><a href="/partners/public-cloud" class="p-navigation__dropdown-item">Public cloud</a></li>

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -82,7 +82,7 @@
       <div class="row">
         <div class="col-3">
           <p class="p-heading--5">
-            <a href="/partners/iot-device">IoT Device&nbsp;&rsaquo;</a>
+            <a href="/partners/iot-device">IoT Devices&nbsp;&rsaquo;</a>
           </p>
         </div>
         <div class="col-6">


### PR DESCRIPTION
## Done

- Updated partners nav and /partners copy as per request:
  - Navigation: under “Partners”, rename “Internet of Things device” to “IoT devices”
  - Programmes page: rename “IoT Device” as “IoT devices”.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- See that the changes have been made

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4998
