### PR TITLE
WD-5009 - Improve the withdrawal email to include current stage

### DIFF
--- a/templates/careers/application/_withdrawal_notification-email.html
+++ b/templates/careers/application/_withdrawal_notification-email.html
@@ -1,7 +1,7 @@
 <div>
   <p>Dear {{ hiring_lead_name }},</p>
   <p>This is an automated email is to inform you that {{ applicant_name }} has withdrawn their application for the {{ position }} position.</p>
+  <p>The candidate was in {{ current_stage["name"] }} stage.</p>
   <p><a href="{{application_url}}">Click here to access the candidate's application.</a></p>
-  <br>
-  <p>Regards,</p>
+  <p>Regards,<br>Talent Science Engineering</p>
 </div>

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -486,16 +486,17 @@ def application_withdrawal(token):
         "careers/application/_withdrawal_notification-email.html",
         applicant_name=application["candidate"]["first_name"],
         hiring_lead_name=hiring_lead_name,
-        position=application["jobs"][0]["name"],
+        position=application["role_name"],
         hiring_lead=application["hiring_lead"],
         application_url=application_url,
+        current_stage=application["current_stage"],
     )
 
     debug_skip_sending = flask.current_app.debug
     if not debug_skip_sending:
         _send_mail(
             hiring_lead_email,
-            "Candidate Withdrawal",
+            "Candidate Withdrawal for " + application["role_name"],
             email_message,
         )
 


### PR DESCRIPTION
## Done

- Improved the messaging by using the parsed job title value. Therefore if they apply to Engineering Manager - Web they see that job role title instead of just Web Developer which is the Job title.
- Added information to the hiring lead email to include the current stage name of the candidate to speed up actions.

## QA

- Create a job (or reopen a closed application) on the test position
- Run this branch locally and visit the application page
- Withdraw and see the email sent to the candidate
- Click the link to confirm
- See the email sent to the hiring lead contains the current stage

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5009
