### PR TITLE
Fix careers bugs/styling issues

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -387,13 +387,13 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 
   &:nth-child(2) {
     background-position: -1104px 49px;
-
+    
     @media screen and (max-width: $breakpoint-small) {
       background-position: -1055px 49px;
     }
   }
-
-  &:nth-child(3) {
+  
+  &.is-last-pillar {
     background-position: -1300px 65px;
 
     @media screen and (max-width: $breakpoint-small) {

--- a/templates/careers/_careers-pagination.html
+++ b/templates/careers/_careers-pagination.html
@@ -3,7 +3,7 @@
       <ol class="p-pagination__items u-align--right">
         <li class="p-pagination__item">
             <p id="total-results"></p>
-          </li>
+        </li>
         <li class="p-pagination__item">
           <button class="p-pagination__link--next" id="show-all" title="Next page"><span>Show all</span><i class="p-icon--chevron-down"></i></button>
           <button class="p-pagination__link--next" id="show-20-more"  title="Next page"><span>Show 20 more</span><i class="p-icon--chevron-down"></i></button>

--- a/templates/careers/_search.html
+++ b/templates/careers/_search.html
@@ -13,7 +13,7 @@
         </div>
       </div>
     </div>
-    <button type="submit"  alt="search roles" class="p-button--positive" style="white-space: nowrap">Search roles</button>
+    <button type="submit"  alt="search roles" class="p-button--positive" style="white-space: nowrap; border: none;">Search roles</button>
   </form>
 </div>
 <script src="{{ versioned_static('js/modules/fuse/fuse.js') }}"></script>
@@ -44,6 +44,7 @@
 
   function showJobList(containerDiv, searchTerm, vacancies) {
     let searchResult = searchTerm ? fuse.search(searchTerm).map( a => a.item ) : vacancies
+    console.log(searchTerm)
     let jobs = vacancies.filter( a => searchResult.includes(a) )
     containerDiv.innerHTML = ''
     jobs.forEach( job => { 

--- a/templates/careers/_search.html
+++ b/templates/careers/_search.html
@@ -44,7 +44,6 @@
 
   function showJobList(containerDiv, searchTerm, vacancies) {
     let searchResult = searchTerm ? fuse.search(searchTerm).map( a => a.item ) : vacancies
-    console.log(searchTerm)
     let jobs = vacancies.filter( a => searchResult.includes(a) )
     containerDiv.innerHTML = ''
     jobs.forEach( job => { 

--- a/templates/careers/company-culture/sustainability.html
+++ b/templates/careers/company-culture/sustainability.html
@@ -76,9 +76,11 @@
           <div class="col-3 col-medium-2">
             <hr class="u-no-margin--bottom">
             <p class="p-text--small-caps">Carbon sinks development</p>
-            <div class="p-card--pillar">
-              <h4 class="p-heading--5">Pillar C</h4>
-              <p>Remove and store <br class="u-hide--small">carbon with carbon sinks</p>
+            <div class="row">
+              <div class="p-card--pillar is-last-pillar col-3 col-medium-2">
+                <h4 class="p-heading--5">Pillar C</h4>
+                <p>Remove and store <br class="u-hide--small">carbon with carbon sinks</p>
+              </div>
             </div>
           </div>
         </div>

--- a/templates/shared/_featured_jobs.html
+++ b/templates/shared/_featured_jobs.html
@@ -6,9 +6,11 @@
   <div class="p-featured row u-sv2">
     {% for job in featured_jobs %}
       {% if loop.index < 7 %}
-        <div class="p-featured__item col-small-4 col-medium-3 col-4 u-no-padding--left">
-          <div class="p-card p-featured__role u-no-margin--bottom">
-            <p><a class="p-featured__url p-card--content" href="/careers/{{job.id}}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Featured job', 'eventAction' : 'Click', 'eventLabel' : '{{ job.title }}', 'eventValue' : undefined });">{{ job.title }}</a></p>
+        <div class="col-small-4 col-medium-3 col-4">
+          <div class="p-featured__item u-no-padding--left u-no-padding--right">
+            <div class="p-card p-featured__role u-no-margin--bottom">
+              <p><a class="p-featured__url p-card--content" href="/careers/{{job.id}}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Featured job', 'eventAction' : 'Click', 'eventLabel' : '{{ job.title }}', 'eventValue' : undefined });">{{ job.title }}</a></p>
+            </div>
           </div>
         </div>
       {% endif %}


### PR DESCRIPTION
## Done

- Fixed alignment for careers search 
- Fixed third pillar card position on /sustainability
- Fixed featured roles alignment on mobile

All other bugs mentioned in linked ticket were already resolved on this branch.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://canonical-com-947.demos.haus/careers/company-culture/remote-work
  - See that the alignment of the input field relative to the button has been fixed
  - Note: this is a shared partial and can also be checked under /careers and /careers/all
- View the site locally in your web browser at: https://canonical-com-947.demos.haus/careers/company-culture/sustainability
  - See that third key pillar is now correctly aligned
- View the site locally in your web browser at: https://canonical-com-947.demos.haus/careers/engineering (or any other dept page with featured roles)
  - Change to mobile view and see that each card is correctly aligned 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5026
