### PR TITLE
Fix rules showing on top of side navigation

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -347,7 +347,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 .p-side-navigation {
   &--raw-html.is-sticky {
     top: 4.5rem;
-    z-index: 1;
+    z-index: 5; // make sure it's higher than 2, that is used by some components (like the rules)
   }
 
   &__drawer {


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical/vanilla-framework/issues/4816

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Go to /documentation
- Make screen small as mobile view
- Open side navigation
- Scroll the page, make sure horizontal rules from content don't overflow the side navigation

