### PR TITLE
candidate page: add executive review to late stage

### DIFF
--- a/templates/careers/application/partial/_late-stage.html
+++ b/templates/careers/application/partial/_late-stage.html
@@ -9,14 +9,14 @@
     <div class="progress-detail-late-stage">
     {% endif %}
     {% for interview in application["scheduled_interviews"]|reverse %}
-        {% if interview["stage_name"]  == "Late Stage Interviews" and now("%Y%m%d") > interview["start"]["datetime"].strftime('%Y%m%d') %}
+        {% if interview["stage_name"] in ["Late Stage Interviews", "Executive Review"] and now("%Y%m%d") > interview["start"]["datetime"].strftime('%Y%m%d') %}
             <hr />
             <h4 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Past Interviews</h4>
             {% include 'careers/application/_interview-card-done.html' %}
         {% endif %}
     {% endfor %}
     {% for interview in application["scheduled_interviews"] %}
-        {% if interview["stage_name"] == "Late Stage Interviews" and now("%Y%m%d") <= interview["start"]["datetime"].strftime('%Y%m%d') %}
+        {% if interview["stage_name"] in ["Late Stage Interviews", "Executive Review"] and now("%Y%m%d") <= interview["start"]["datetime"].strftime('%Y%m%d') %}
             <hr />
             <h4 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Next interview</h4>
             {% include 'careers/application/_interview-card.html' %}


### PR DESCRIPTION
## Done

- Include executive review in the late stage so interviews show up on the page

## QA
- Open demo
- Visit the candidate page included in the ticket below 
- If you do it before the 17th you should see an interview with the CEO with the label "next interviews" on top
- If you do it after, it will appear as a "past interview"

## Issue / Card

https://warthogs.atlassian.net/browse/WD-5063
