### PR TITLE
Filter out nec logo

### DIFF
--- a/templates/partners/partial/_partners-logos.html
+++ b/templates/partners/partial/_partners-logos.html
@@ -8,12 +8,12 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items"> 
           {% for partner in partners %}
-            <div class="p-logo-section__item">
-              <!-- Temporarily filter out nec logo until properly replaced -->
-              {% if partner.slug != "nec" %} 
-              <img class="p-logo-section__logo" src="{{ partner.logo }}" alt="{{ partner.slug }}">
-              {% endif %}
-            </div>
+          <!-- Temporarily filter out nec logo until properly replaced -->
+            {% if partner.slug != "nec" %} 
+              <div class="p-logo-section__item">
+                <img class="p-logo-section__logo" src="{{ partner.logo }}" alt="{{ partner.slug }}">
+              </div>
+            {% endif %}
           {% endfor %}
         </div>  
       </div>

--- a/templates/partners/partial/_partners-logos.html
+++ b/templates/partners/partial/_partners-logos.html
@@ -9,7 +9,10 @@
         <div class="p-logo-section__items"> 
           {% for partner in partners %}
             <div class="p-logo-section__item">
+              <!-- Temporarily filter out nec logo until properly replaced -->
+              {% if partner.slug != "nec" %} 
               <img class="p-logo-section__logo" src="{{ partner.logo }}" alt="{{ partner.slug }}">
+              {% endif %}
             </div>
           {% endfor %}
         </div>  


### PR DESCRIPTION
## Done

- Filter out Nec logo


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://canonical-com-964.demos.haus/partners/ihv-and-oem
- See that the logo no longer appears

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5138

## Screenshots

Before: 
![image](https://github.com/canonical/canonical.com/assets/17607612/fce94b77-0831-4339-832b-ee6303680732)

After: 
![image](https://github.com/canonical/canonical.com/assets/17607612/f93cf521-4d15-472e-a4ef-4260ed2ad2db)

