### PR TITLE
Visual fixes

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -387,12 +387,12 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 
   &:nth-child(2) {
     background-position: -1104px 49px;
-    
+
     @media screen and (max-width: $breakpoint-small) {
       background-position: -1055px 49px;
     }
   }
-  
+
   &.is-last-pillar {
     background-position: -1300px 65px;
 
@@ -487,7 +487,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 .p-image-wrapper {
   margin-top: $spv--medium;
   padding-top: $spv--small;
-  
+
   &.is-partner {
     background-color: #fff;
   }
@@ -909,13 +909,12 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
     margin-left: 0;
   }
 
-  &__item {
-    margin-left: 3rem;
-    width: auto;
-  }
+  &__item,
+  [class^=col] &__item {
 
-  &__item:first-child {
     margin-left: 0;
+    margin-right: 3rem;
+    width: auto;
   }
 
   &__logo {

--- a/templates/careers/company-culture.html
+++ b/templates/careers/company-culture.html
@@ -7,10 +7,10 @@
 
 
 {% block content %}
-<div class="p-strip is-deep">
+<div class="p-strip">
   <div class="row">
     <div class="col-start-large-4 col-8">
-      <h1 class="p-heading--2"><strong>Company culture</strong></h1>
+      <h1 class="p-heading--2 u-no-margin--bottom"><strong>Company culture</strong></h1>
       <p class="p-heading--2">We believe that talent is evenly distributed around the world.  Diversity is part of our strength. What unifies us isn’t our background,  it’s our mission to amplify open source.</p>
     </div>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,7 @@
       <div class="col-medium-6 col-9 col-start-large-4">
         <div class="p-block">
           <h1 class="p-heading--display">Build at speed. <br>Operate at scale.</h1>
-          <p class="p-heading--2">The Canonical way to open source in the enterprise starts with Ubuntu and reaches every part of the stack.</p>
+          <p class="p-heading--2">The Canonical way to open source in the enterprise starts with Ubuntu and reaches every part of&nbsp;the&nbsp;stack.</p>
         </div>
         <a class="p-button--positive u-no-margin--bottom" href="https://ubuntu.com/contact-us/form?product=generic-contact-us">Contact us</a>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@
   <img src='https://pubads.g.doubleclick.net/activity;xsp=4822915;ord=1?' width=1 height=1 border=0>
 </noscript>
 <div class=" p-navigation__overlay">
-  <section class="p-strip u-no-padding--bottom">
+  <section class="p-strip">
     <div class="row">
       <div class="col-medium-6 col-9 col-start-large-4">
         <div class="p-block">
@@ -36,15 +36,15 @@
   </section>
   <section class="p-section" id="products">
     <div class="u-fixed-width">
-      <hr class="p-rule is-dark is-bold">
-      <h2><strong>A broad portfolio</strong></h2>
+      <hr class="p-rule is-dark">
+      <h2 class="u-no-margin--bottom"><strong>A broad portfolio</strong></h2>
       <p class="p-heading--2">Made for reliability. <br class="u-hide--medium u-hide--small">Designed to drive down infrastructure costs.</p>
     </div>
   </section>
   <section class="p-section">
     <div class="row">
       <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-        <hr class="p-rule is-dark is-bold">
+        <hr class="p-rule is-dark">
         <div class="row">
           <div class="col-6">
             <h3 class="p-heading--2">One stable platform <br>for everything open source</h3>
@@ -62,7 +62,7 @@
   <section class="p-section">
     <div class="row">
       <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-        <hr class="p-rule is-dark is-bold">
+        <hr class="p-rule is-dark">
         <div class="row">
           <div class="col-6">
             <h3 class="p-heading--2">Infrastructure, <br class="u-hide--medium u-hide--small">your way</h3>
@@ -84,7 +84,7 @@
   <section class="p-section">
     <div class="row">
       <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-        <hr class="p-rule is-dark is-bold">
+        <hr class="p-rule is-dark">
         <div class="row">
           <div class="col-6">
             <h3 class="p-heading--2">Hybrid, multi-cloud<br class="u-hide--medium u-hide--small">experience</h3>
@@ -104,7 +104,7 @@
   <section class="p-section">
     <div class="row">
       <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-        <hr class="p-rule is-dark is-bold">
+        <hr class="p-rule is-dark">
         <div class="row">
           <div class="col-6">
             <h3 class="p-heading--2">Optimised<br class="u-hide--medium u-hide--small">for IoT and edge</h3>
@@ -122,7 +122,7 @@
   <section class="p-section">
     <div class="row">
       <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-        <hr class="p-rule is-dark is-bold">
+        <hr class="p-rule is-dark">
         <div class="row">
           <div class="col-6">
             <h3 class="p-heading--2">Support, security <br class="u-hide--medium u-hide--small">and compliance</h3>
@@ -137,7 +137,7 @@
   </section>
   <section class="p-section">
     <div class="u-fixed-width">
-      <hr class="p-rule is-dark is-bold">
+      <hr class="p-rule is-dark">
       <h2>
         <strong>
           Trusted in every industry
@@ -353,8 +353,8 @@
   </section>
   <section class="p-section">
     <div class="u-fixed-width">
-      <hr class="p-rule is-dark is-bold">
-      <h2><strong>Accelerating innovation</strong></h2>
+      <hr class="p-rule is-dark">
+      <h2 class="u-no-margin--bottom"><strong>Accelerating innovation</strong></h2>
       <p class="p-heading--2">We partner with the biggest names in tech <br class="u-hide--small">to amplify the impact of open source.</p>
     </div>
   </section>
@@ -367,38 +367,51 @@
       <div class="col-9 col-medium-4">
         <p class="p-heading--2">Streamline your workflows and get the scalability you need with <a href="/partners/public-cloud">Ubuntu across clouds</a>.</p>
         <div class="row">
-          <div class="col-2 col-medium-1 col-small-1">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/08d2774c-google-cloud-logo.png",
-            alt="",
-            width="474",
-            height="474",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-            }}
-          </div>
-          <div class="col-2 col-medium-1 col-small-1">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/ef1abcf8-aws-logo.png",
-            alt="",
-            width="474",
-            height="474",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-            }}
-          </div>
-          <div class="col-2 col-medium-1 col-small-1">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/414962ea-microsoft-logo.png",
-            alt="",
-            width="474",
-            height="474",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-            }}
+          <div class="p-logo-section">
+            <div class="p-logo-section__items">
+              <div class="p-logo-section__item">
+                <div class="p-logo-section__logo">
+                  {{ image (
+                    url="https://assets.ubuntu.com/v1/5afa90c1-google-cloud-logo.png",
+                    alt="",
+                    width="696",
+                    height="474",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-logo-section__logo"}
+                    ) | safe
+                  }}
+                </div>
+              </div>
+              <div class="p-logo-section__item">
+                <div class="p-logo-section__logo">
+                  {{ image (
+                    url="https://assets.ubuntu.com/v1/0b9f0328-aws-logo.png",
+                    alt="",
+                    width="177",
+                    height="474",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-logo-section__logo"}
+                    ) | safe
+                  }}
+                </div>
+              </div>
+              <div class="p-logo-section__item">
+                <div class="p-logo-section__logo">
+                  {{ image (
+                    url="https://assets.ubuntu.com/v1/bb183d2b-Group 3359.png",
+                    alt="",
+                    width="474",
+                    height="474",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-logo-section__logo"}
+                    ) | safe
+                  }}
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -411,49 +424,65 @@
       <div class="col-9 col-medium-4">
         <p class="p-heading--2">Go to market faster with <a href="/partners/silicon">Canonical's silicon ecosystem</a>.</p>
         <div class="row">
-          <div class="col-2 col-medium-1 col-small-1">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/2e6c37cc-nvidia-logo.png",
-            alt="",
-            width="474",
-            height="475",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-            }}
-          </div>
-          <div class="col-2 col-medium-1 col-small-1">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/e11a4602-arm-logo.png",
-            alt="",
-            width="474",
-            height="475",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-            }}
-          </div>
-          <div class="col-2 col-medium-1 col-small-1">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/5358eff7-intel-new-logo.png",
-            alt="",
-            width="474",
-            height="475",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-            }}
-          </div>
-          <div class="col-2 col-medium-1 col-small-1">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/ce9d6423-amd-logo1.png",
-            alt="",
-            width="474",
-            height="475",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-            }}
+          <div class="p-logo-section">
+            <div class="p-logo-section__items">
+              <div class="p-logo-section__item">
+                <div class="p-logo-section__logo">
+                {{ image (
+                  url="https://assets.ubuntu.com/v1/3267d9f8-nvidia-logo.png",
+                  alt="",
+                  width="525",
+                  height="474",
+                  hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}
+                  ) | safe
+                }}
+              </div>
+              </div>
+              <div class="p-logo-section__item">
+                <div class="p-logo-section__logo">
+                  {{ image (
+                    url="https://assets.ubuntu.com/v1/560da749-arm-logo.png",
+                    alt="",
+                    width="183",
+                    height="474",
+                    hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}
+                    ) | safe
+                  }}
+                </div>
+              </div>
+              <div class="p-logo-section__item">
+                <div class="p-logo-section__logo">
+                  {{ image (
+                    url="https://assets.ubuntu.com/v1/eedd1cbe-intel-new-logo.png",
+                    alt="",
+                    width="207",
+                    height="474",
+                    hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}
+                    ) | safe
+                  }}
+                </div>
+              </div>
+              <div class="p-logo-section__item">
+                <div class="p-logo-section__logo">
+                  {{ image (
+                    url="https://assets.ubuntu.com/v1/74705d48-amd-logo.png",
+                    alt="",
+                    width="336",
+                    height="474",
+                    hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}
+                    ) | safe
+                  }}
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -465,54 +494,64 @@
       </div>
       <div class="col-9 col-medium-4">
         <p class="p-heading--2">Get optimal performance and a seamless user experience with <a href="https://ubuntu.com/certified">Ubuntu certified hardware</a>.</p>
-        <div class="row">
-          <div class="col-2 col-medium-1 col-small-1">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/d187826f-hp-logo.png",
-            alt="",
-            width="474",
-            height="475",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-            }}
+        <div class="p-logo-section">
+          <div class="p-logo-section__items">
+            <div class="p-logo-section__item">
+              <div class="p-logo-section__logo">
+                {{ image (
+                  url="https://assets.ubuntu.com/v1/59392278-hp-logo.png",
+                  alt="",
+                  width="195",
+                  height="474",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "p-logo-section__logo"}
+                  ) | safe
+                }}
+              </div>
+            </div>
+            <div class="p-logo-section__item">
+              <div class="p-logo-section__logo">
+                {{ image (
+                  url="https://assets.ubuntu.com/v1/33e9a7bd-dell-logo.png",
+                  alt="",
+                  width="231",
+                  height="474",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "p-logo-section__logo"}
+                  ) | safe
+                }}
+              </div>
+            </div>
+            <div class="p-logo-section__item">
+                <div class="p-logo-section__logo">
+                {{ image (
+                  url="https://assets.ubuntu.com/v1/77ee3313-lenovo-logo.png",
+                  alt="",
+                  width="318",
+                  height="474",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "p-logo-section__logo"}
+                  ) | safe
+                }}
+              </div>
+            </div>
           </div>
-          <div class="col-2 col-medium-1 col-small-1">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/9c2f21e7-dell-logo.png",
-            alt="",
-            width="474",
-            height="475",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-            }}
-          </div>
-          <div class="col-2 col-medium-1 col-small-1">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/4c1992f8-lenovo-logo.png",
-            alt="",
-            width="474",
-            height="475",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-            }}
-          </div>
-        </div>
       </div>
     </div>
   </section>
   <section class="p-section">
     <div class="u-fixed-width">
-      <hr class="p-rule is-dark is-bold">
+      <hr class="p-rule is-dark">
       <h2><strong>Get to know Canonical</strong></h2>
     </div>
   </section>
   <section class="p-section">
     <div class="row">
       <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-        <hr class="p-rule is-dark is-bold">
+        <hr class="p-rule is-dark">
         <div class="row">
           <div class="col-9">
             <div class="p-block">
@@ -528,7 +567,7 @@
   <section class="p-section">
     <div class="row">
       <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-        <hr class="p-rule is-dark is-bold">
+        <hr class="p-rule is-dark">
         <div class="row">
           <div class="col-9">
             <div class="p-block">
@@ -544,7 +583,7 @@
   <section class="p-strip is-deep u-no-padding--top">
     <div class="row">
       <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-        <hr class="p-rule is-dark is-bold">
+        <hr class="p-rule is-dark">
         <div class="row">
           <div class="col-9">
             <div class="p-block">

--- a/templates/index.html
+++ b/templates/index.html
@@ -434,8 +434,8 @@
                   width="525",
                   height="474",
                   hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}
+                  loading="lazy",
+                  attrs={"class": "p-logo-section__logo"}
                   ) | safe
                 }}
               </div>
@@ -448,8 +448,8 @@
                     width="183",
                     height="474",
                     hi_def=True,
-                          loading="lazy",
-                          attrs={"class": "p-logo-section__logo"}
+                    loading="lazy",
+                    attrs={"class": "p-logo-section__logo"}
                     ) | safe
                   }}
                 </div>
@@ -462,8 +462,8 @@
                     width="207",
                     height="474",
                     hi_def=True,
-                          loading="lazy",
-                          attrs={"class": "p-logo-section__logo"}
+                    loading="lazy",
+                    attrs={"class": "p-logo-section__logo"}
                     ) | safe
                   }}
                 </div>
@@ -476,8 +476,8 @@
                     width="336",
                     height="474",
                     hi_def=True,
-                          loading="lazy",
-                          attrs={"class": "p-logo-section__logo"}
+                    loading="lazy",
+                    attrs={"class": "p-logo-section__logo"}
                     ) | safe
                   }}
                 </div>


### PR DESCRIPTION
## Done

- Fix spacing between headings as [per design](https://www.figma.com/file/KQSCmTqOjY4gfKvJPyvzj2/Canonical.com-latest-only?type=design&node-id=11270%3A26788&mode=design&t=r71PtO3zN3fjUZBA-1):

before:
<img width="918" alt="image" src="https://github.com/canonical/canonical.com/assets/2741678/5d05c1f6-f774-409b-bd90-8cc01a30976d">

after:
<img width="929" alt="image" src="https://github.com/canonical/canonical.com/assets/2741678/9286dabf-5bbc-436a-9ad7-fd5c04e2f1d2">

- refactor: remove old is-bold class from hrs, it doesn't do anything
- fix logos on homepage to be variable width, equally spaced
- fix local css so wrapping logos are not indented:
before: 
<img width="645" alt="image" src="https://github.com/canonical/canonical.com/assets/2741678/0341be8c-34f5-4a90-bdd3-10e9559eb7a6">

after:
<img width="561" alt="image" src="https://github.com/canonical/canonical.com/assets/2741678/931bb45f-c320-492c-8731-12839e54e09e">

- remove spacing between two headings (pointed out by @marcushas)
before: 
<img width="784" alt="image" src="https://github.com/canonical/canonical.com/assets/2741678/cac5814c-ea72-486a-8f15-5dc8edc01ad6">
after:
<img width="1278" alt="image" src="https://github.com/canonical/canonical.com/assets/2741678/cacc79a6-7d84-4a7a-97c1-20f3d389d8fa">

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- verify the above list of fixes


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
