### PR TITLE
Fix #976 .p-logo-section__items width

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -723,6 +723,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   &__items {
     justify-content: flex-start;
     margin-left: 0;
+    width: 100%;
   }
 
   &__item,


### PR DESCRIPTION
Resolves a minor horizontal scrolling bug by introducing `width: 100%` on `.p-logo-section__items`.

## Done
Added a single line to override the injected `width` calculation on the element. Instead of `calc(100% + 2rem)`, which is rendered ineffective due to `margin-left: 0` on the element (it required `margin-left: -2rem`, we have `100%`:

https://github.com/johnlettman/canonical.com/blob/3888f0ec9b38fecac804f6b9e82d19d9f59bada1/static/sass/styles.scss#L726

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Visual inspection of the logo sections on each page

## Issue / Card

Fixes #976 

## Screenshots

### Pre Fix
![Screenshot_20230719_124641](https://github.com/canonical/canonical.com/assets/20583294/697eaad2-61e8-4c94-ba81-847993761cbe)

### Post Fix
![Screenshot_20230719_154838](https://github.com/canonical/canonical.com/assets/20583294/b2e217fd-85c3-4f51-bc79-acd102b58887)

