### PR TITLE
Update link

### DIFF
--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -62,7 +62,7 @@
       <div class="row">
         <div class="col-3">
           <p class="p-heading--5">
-            <a href="https://ubuntu.com/silicon">Silicon&nbsp;&rsaquo;</a>
+            <a href="/partners/silicon">Silicon&nbsp;&rsaquo;</a>
           </p>
         </div>
         <div class="col-6">


### PR DESCRIPTION
## Done

- Updated link ubuntu.com/silicon -> /partners/silicon as per ticket

## Notes

Follow up PR to come which removes silicon page from u.com altogether 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/
- Click on the silicon link and see that you are taken to the correct partner page

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5209