### PR TITLE
Fix typos in interview-done card

### DIFF
--- a/templates/careers/application/_interview-card-done.html
+++ b/templates/careers/application/_interview-card-done.html
@@ -6,7 +6,7 @@
   {% endif %}
   <p class="p-card__content u-sv2">{{ interview["start"]["datetime"].strftime('%d %B') }}, with {% for interviewer in interview["interviewers"] %}{% if loop.index > 1 %}, {% endif %}{{ interviewer["name"] }}{% endfor %}</p>
   {% if interview["stage_name"]  == "Talent Interview" %}
-  <p class="p-card__content u-sv1">Once completed, your behavioural assement will be avaiable in the <a href="#assessment" onclick="showProgressDetail('assessment');">Assessment</a> section.</p>
+  <p class="p-card__content u-sv1">Once completed, your behavioural assessment will be available in the <a href="#assessment" onclick="showProgressDetail('assessment');">Assessment</a> section.</p>
   {% endif %}
 
 </div>


### PR DESCRIPTION
## Done

- Multiple typos in `_interview-card-done.html` fixed.

I didn't think that filing an issue would be appropriate for such a small change, but I can do so if that would be helpful. 🙂