### PR TITLE
Fix 404 Redirect enterprise services to Ubuntu Pro

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -25,3 +25,4 @@ enterprise-services/ubuntu-advantage/landscape/dedicated-edition/?: "https://ubu
 intellectual-property-rights-policy/?: "https://ubuntu.com/legal/intellectual-property-policy"
 legal/?: "https://ubuntu.com/legal"
 intellectual-property-policy/?: "https://ubuntu.com/legal/intellectual-property-policy"
+enterprise-services/ubuntu-advantage?: "https://ubuntu.com/pro"


### PR DESCRIPTION
## QA

- Check https://canonical-com-986.demos.haus/enterprise-services/ubuntu-advantage goes to https://ubuntu.com/pro now

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5279
Fixes https://github.com/canonical/canonical.com/issues/885
