### PR TITLE
Update partners nav item

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -48,7 +48,7 @@
                 <li><a href="/partners/channel-and-reseller" class="p-navigation__dropdown-item">Channel/reseller</a></li>
                 <li><a href="/partners/iot-device" class="p-navigation__dropdown-item">IoT devices</a></li>
                 <li><a href="/partners/ihv-and-oem" class="p-navigation__dropdown-item">IHV/OEM</a></li>
-                <li><a href="/partners/gsi" class="p-navigation__dropdown-item">Global Seller Initiative</a></li>
+                <li><a href="/partners/gsi" class="p-navigation__dropdown-item">Global System Integrators</a></li>
                 <li><a href="/partners/public-cloud" class="p-navigation__dropdown-item">Public cloud</a></li>
                 <li><a href="/partners/silicon" class="p-navigation__dropdown-item">Silicon</a></li>
               </ul>


### PR DESCRIPTION
## Done

- Change nav item from "Global Seller Initiative" to "Global System Integrators" as per ticket 

## QA

- Visit the demo: https://canonical-com-990.demos.haus/
- Toggle the partners drop down and see that the change was made

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5252


## Screenshots
![image](https://github.com/canonical/canonical.com/assets/17607612/9ad78def-72b7-46f0-b4f7-14c36f8abfd6)
