### PR TITLE
[copy update] WD-5286 update on footer privacy policy link

### DIFF
--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -35,7 +35,11 @@
       <hr class="is-dark"/>
       <p>
         For further information on data collection,<br>
-        please refer to our <a href="https://ubuntu.com/legal/data-privacy/recruitment">recruitment privacy notice</a> and <a href="https://ubuntu.com/legal/data-privacy">privacy policy</a>.
+        please refer to our 
+        {% if "/careers" in current_path %}
+          <a href="https://ubuntu.com/legal/data-privacy/recruitment">recruitment privacy notice</a> and 
+        {% endif %}
+        <a href="https://ubuntu.com/legal/data-privacy">privacy policy</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Update privacy policy text

## QA

- Check out [the demo here](https://canonical-com-992.demos.haus/) and compare it to the work specified in the [task](https://warthogs.atlassian.net/browse/WD-5286).
- Make the privacy policy notice says **"For further information on data collection, please refer to our [privacy policy](https://ubuntu.com/legal/data-privacy)."** for all pages except `/careers` pages.
  - For `/careers` pages it should say **"For further information on data collection, please refer to our [recruitment privacy notice](https://ubuntu.com/legal/data-privacy/recruitment) and [privacy policy](https://ubuntu.com/legal/data-privacy)."**

## Issue / Card

- [WD-5286](https://warthogs.atlassian.net/browse/WD-5286)

[WD-5286]: https://warthogs.atlassian.net/browse/WD-5286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ