### PR TITLE
Fix documentation typo

### DIFF
--- a/templates/documentation/work-and-careers.html
+++ b/templates/documentation/work-and-careers.html
@@ -117,7 +117,7 @@
         <h3 class="col-3 col-medium-2 p-heading--5">Written interview</h3>
         <div class="col-6 col-medium-4">
           <p>The written interview is an important part of the process. It's reviewed - anonymously, in an effort to remove bias - by multiple members of the team.</p>
-          <p>This has several benefits. One is that in-person interviews are stressful experiences, while a written interview gives you all the time you need to gather your thoughts and put them together in a way that presents you at your best. It's a good opportunity to say things that might not not otherwise come up later.</p>
+          <p>This has several benefits. One is that in-person interviews are stressful experiences, while a written interview gives you all the time you need to gather your thoughts and put them together in a way that presents you at your best. It's a good opportunity to say things that might not otherwise come up later.</p>
           <p>It's also excellent preparation for the interviews that will come. We want to see your best, and for you to be prepared for them. And we want them to be a good experience for you too.</p>
           <p>Our written interviews are used by all the future in-person interviewers you'll meet. When you do meet them, they'll already have had a good introduction to you, so that you don't need to repeat the same stories and explanations to multiple people.</p>
         </div>


### PR DESCRIPTION
## Done

- Removed the second "not" in the copy per the [doc](https://docs.google.com/document/d/1U-IkZOMzQlfV0zAAmM0PRVUBoZNBeOa-Qrso3i4rDVU/edit)

## QA

- View the site locally in your web browser at: https://canonical-com-1000.demos.haus/documentation/work-and-careers
- See that the typo is fixed

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5526