### PR TITLE
[copy update] WD-5625 Update executive summit events

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -300,7 +300,6 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 
 .p-image-wrapper {
   margin-top: $spv--medium;
-  padding-top: $spv--small;
 
   &.is-partner {
     background-color: #fff;

--- a/templates/partners/executive-summit.html
+++ b/templates/partners/executive-summit.html
@@ -96,7 +96,7 @@
               </p>
             </div>
             <div class="col-3 col-medium-2 u-hide--small p-image-wrapper">
-              <img src="https://assets.ubuntu.com/v1/26aa2680-executive-summit-california.png" alt="" />
+              <img src="https://assets.ubuntu.com/v1/b1bf6c63-photo-1580536793208-117fdb20ffc1-(1).jpg" alt="" />
             </div>
           </div>
         </div>

--- a/templates/partners/executive-summit.html
+++ b/templates/partners/executive-summit.html
@@ -64,33 +64,14 @@
         <div class="p-block">
           <div class="row">
             <div class="col-3 col-medium-2 col-small-2">
-              <h3 class="p-heading--2"><a href="https://ubuntu.com/engage/canonical-executive-summit-paris-2023">Paris</a></h3>
-            </div>
-            <div class="col-3 col-medium-2 col-small-2">
-              <p>14 June 2023</p>
-              <p>Join our partners in France to explore the advantages of open source for their customers.</p>
-              <p>
-                <a href="https://ubuntu.com/engage/canonical-executive-summit-paris-2023" class="p-button">Register <span class="u-off-screen"> for Executive Summit Paris</span></a>
-              </p>
-            </div>
-            <div class="col-3 col-medium-2 u-hide--small p-image-wrapper">
-              <img src="https://assets.ubuntu.com/v1/9c147658-executive-summit-paris.png" alt="" />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-9 col-start-large-4">
-        <div class="p-block">
-          <hr class="p-rule" />
-          <div class="row">
-            <div class="col-3 col-medium-2 col-small-2">
               <h3 class="p-heading--2">Bangalore</h3>
             </div>
             <div class="col-3 col-medium-2 col-small-2">
-              <p>September 2023</p>
+              <p>05 October 2023</p>
               <p>Learn about how many of the largest System Integrators are using open source for large-scale digital transformation projects.</p>
+              <p>
+                <a href="https://ubuntu.com/engage/canonical-partner-summit-bangalore-2023" class="p-button">Register <span class="u-off-screen"> for Executive Summit Bangalore</span></a>
+              </p>
             </div>
             <div class="col-3 col-medium-2 u-hide--small p-image-wrapper">
               <img src="https://assets.ubuntu.com/v1/938a3f0e-executive-summit-bangalore.png" alt="" />
@@ -105,11 +86,14 @@
           <hr class="p-rule" />
           <div class="row">
             <div class="col-3 col-medium-2 col-small-2">
-              <h3 class="p-heading--2">California</h3>
+              <h3 class="p-heading--2">Dallas</h3>
             </div>
             <div class="col-3 col-medium-2 col-small-2">
-              <p>October 2023</p>
+              <p>19 October 2023</p>
               <p>Join Canonical&rsquo;s US partners&rsquo; business leaders and technology innovators to explore open source opportunities.</p>
+              <p>
+                <a href="https://ubuntu.com/engage/canonical-partner-summit-dallas-2023" class="p-button">Register <span class="u-off-screen"> for Executive Summit Dallas</span></a>
+              </p>
             </div>
             <div class="col-3 col-medium-2 u-hide--small p-image-wrapper">
               <img src="https://assets.ubuntu.com/v1/26aa2680-executive-summit-california.png" alt="" />
@@ -141,6 +125,25 @@
             </div>
             <div class="col-3 col-medium-2 u-hide--small p-image-wrapper">
               <img src="https://assets.ubuntu.com/v1/3027d899-executive-summit-london.png" alt="" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <div class="p-block">
+          <hr class="p-rule" />
+          <div class="row">
+            <div class="col-3 col-medium-2 col-small-2">
+              <h3 class="p-heading--2"><a href="https://ubuntu.com/engage/canonical-executive-summit-paris-2023">Paris</a></h3>
+            </div>
+            <div class="col-3 col-medium-2 col-small-2">
+              <p>14 June 2023</p>
+              <p>Join our partners in France to explore the advantages of open source for their customers.</p>
+            </div>
+            <div class="col-3 col-medium-2 u-hide--small p-image-wrapper">
+              <img src="https://assets.ubuntu.com/v1/9c147658-executive-summit-paris.png" alt="" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Update summit even dates and links
- Move the Paris Summit to the past events section

## QA

- Check out [the demo here](https://canonical-com-1009.demos.haus/partners/executive-summit) and compare it with the changes requested in [the copy doc](https://docs.google.com/document/d/15C3k-htvapwp-WTrYQ2SdHBW20Lp9IinpY9mkvo6q3U/edit).

## Issue / Card

- [WD-5625](https://warthogs.atlassian.net/browse/WD-5625)


[WD-5625]: https://warthogs.atlassian.net/browse/WD-5625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ