### PR TITLE
Remove unnecessary div from logo sections

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -370,7 +370,6 @@
           <div class="p-logo-section">
             <div class="p-logo-section__items">
               <div class="p-logo-section__item">
-                <div class="p-logo-section__logo">
                   {{ image (
                     url="https://assets.ubuntu.com/v1/5afa90c1-google-cloud-logo.png",
                     alt="",
@@ -381,10 +380,8 @@
                     attrs={"class": "p-logo-section__logo"}
                     ) | safe
                   }}
-                </div>
               </div>
               <div class="p-logo-section__item">
-                <div class="p-logo-section__logo">
                   {{ image (
                     url="https://assets.ubuntu.com/v1/0b9f0328-aws-logo.png",
                     alt="",
@@ -395,10 +392,8 @@
                     attrs={"class": "p-logo-section__logo"}
                     ) | safe
                   }}
-                </div>
               </div>
               <div class="p-logo-section__item">
-                <div class="p-logo-section__logo">
                   {{ image (
                     url="https://assets.ubuntu.com/v1/bb183d2b-Group%203359.png",
                     alt="",
@@ -409,7 +404,6 @@
                     attrs={"class": "p-logo-section__logo"}
                     ) | safe
                   }}
-                </div>
               </div>
             </div>
           </div>
@@ -427,7 +421,6 @@
           <div class="p-logo-section">
             <div class="p-logo-section__items">
               <div class="p-logo-section__item">
-                <div class="p-logo-section__logo">
                 {{ image (
                   url="https://assets.ubuntu.com/v1/3267d9f8-nvidia-logo.png",
                   alt="",
@@ -439,9 +432,7 @@
                   ) | safe
                 }}
               </div>
-              </div>
               <div class="p-logo-section__item">
-                <div class="p-logo-section__logo">
                   {{ image (
                     url="https://assets.ubuntu.com/v1/560da749-arm-logo.png",
                     alt="",
@@ -452,10 +443,8 @@
                     attrs={"class": "p-logo-section__logo"}
                     ) | safe
                   }}
-                </div>
               </div>
               <div class="p-logo-section__item">
-                <div class="p-logo-section__logo">
                   {{ image (
                     url="https://assets.ubuntu.com/v1/eedd1cbe-intel-new-logo.png",
                     alt="",
@@ -466,10 +455,8 @@
                     attrs={"class": "p-logo-section__logo"}
                     ) | safe
                   }}
-                </div>
               </div>
               <div class="p-logo-section__item">
-                <div class="p-logo-section__logo">
                   {{ image (
                     url="https://assets.ubuntu.com/v1/74705d48-amd-logo.png",
                     alt="",
@@ -480,7 +467,6 @@
                     attrs={"class": "p-logo-section__logo"}
                     ) | safe
                   }}
-                </div>
               </div>
             </div>
           </div>
@@ -497,7 +483,6 @@
         <div class="p-logo-section">
           <div class="p-logo-section__items">
             <div class="p-logo-section__item">
-              <div class="p-logo-section__logo">
                 {{ image (
                   url="https://assets.ubuntu.com/v1/59392278-hp-logo.png",
                   alt="",
@@ -508,10 +493,8 @@
                   attrs={"class": "p-logo-section__logo"}
                   ) | safe
                 }}
-              </div>
             </div>
             <div class="p-logo-section__item">
-              <div class="p-logo-section__logo">
                 {{ image (
                   url="https://assets.ubuntu.com/v1/33e9a7bd-dell-logo.png",
                   alt="",
@@ -522,10 +505,8 @@
                   attrs={"class": "p-logo-section__logo"}
                   ) | safe
                 }}
-              </div>
             </div>
             <div class="p-logo-section__item">
-                <div class="p-logo-section__logo">
                 {{ image (
                   url="https://assets.ubuntu.com/v1/77ee3313-lenovo-logo.png",
                   alt="",
@@ -536,7 +517,6 @@
                   attrs={"class": "p-logo-section__logo"}
                   ) | safe
                 }}
-              </div>
             </div>
           </div>
 	</div>


### PR DESCRIPTION
## Done

The `.p-logo-section__logo` is meant to be put on the logo image element. On home page it's set both on the image and on wrapping div which can lead to some unexpected bugs.

This removes unnecessary wrapping divs from logos.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Go to home page, find logo sections, make sure there is no div with `p-logo-section__logo` class around the images.


## Screenshots

<img width="1270" alt="image" src="https://github.com/canonical/canonical.com/assets/83575/a31f5463-fb8f-4f9f-a13a-de0327ddc653">
