### PR TITLE
Update careers pages meta-image

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -51,6 +51,12 @@
     <meta name="twitter:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
     <meta property="og:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
     {% endif %}
+    
+    {% set current_path =  url_for(request.endpoint, **request.view_args)  %}
+    {% if "/careers" in current_path %}
+    <meta name="twitter:image" content="https://assets.ubuntu.com/v1/c17ef7b4-careers-meta-image-resized.png">
+    <meta property="og:image" content="https://assets.ubuntu.com/v1/c17ef7b4-careers-meta-image-resized.png">
+    {% endif %}
 
     {% block extra_metatags %}{% endblock %}
 

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -6,8 +6,6 @@
 
 {% block meta_keywords %}{{ job.skills | join(', ') }}{% endblock %}
 
-{% block meta_image %}https://assets.ubuntu.com/v1/c17ef7b4-careers-meta-image-resized.png{% endblock %}
-
 {% block canonical_url %}{{request.host_url}}careers/{{job.id}}{% endblock %}
 
 {% block extra_metatags %}

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -6,7 +6,7 @@
 
 {% block meta_keywords %}{{ job.skills | join(', ') }}{% endblock %}
 
-{% block meta_image %}ceed7655-Canonical-Careers-image.jpg{% endblock %}
+{% block meta_image %}https://assets.ubuntu.com/v1/c17ef7b4-careers-meta-image-resized.png{% endblock %}
 
 {% block canonical_url %}{{request.host_url}}careers/{{job.id}}{% endblock %}
 

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -1,4 +1,3 @@
-{% set current_path =  url_for(request.endpoint, **request.view_args)  %}
 <footer class="p-footer l-footer--sticky">
   <div class="row u-position">
     <div class="col-medium-2 col-3">


### PR DESCRIPTION
## Done

- Updated careers pages meta-image

Originally this ticket only covered the individual job posts, but Camille rightly flagged that the meta-image for the careers index page is currently showing up as the suru when she goes to post it on linkedin so I implemented the change on all careers pages

## QA

- View the site locally in your web browser at: https://canonical-com-1012.demos.haus/careers/5243483 (or any other job opening)
- View the page source and check that the image is the correct one
- Do the same for the careers pages (don't need to check all of them, this should cover anything with /careers in the path)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5637

## Screenshots
Before:
![image](https://github.com/canonical/canonical.com/assets/17607612/da1294f0-95f8-4c66-b17f-0a4845864b02)

After:
![image](https://github.com/canonical/canonical.com/assets/17607612/86c92023-4592-4b83-a9f4-5c0e339d9ad6)

Before:
![image](https://github.com/canonical/canonical.com/assets/17607612/c632abf3-bc74-4a7d-95f9-25ba4a465878)

After:
![image](https://github.com/canonical/canonical.com/assets/17607612/e8b06e72-5dce-4b2d-902a-47b849087e78)


