### PR TITLE
Update careers index meta data

### DIFF
--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -2,9 +2,9 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1o8ind3Zav-kwrUDWgiMJnkw2QLpniKgdlWrw9byIvlE/edit#heading=h.ov7lrxgwh2dv{% endblock meta_copydoc %}
 
-{% block title %}Careers{% endblock %}
+{% block title %}Canonical Careers{% endblock %}
 
-{% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public clouds to certify Ubuntu.{% endblock %}
+{% block meta_description %}Looking for a career in open source? Be where the cutting edge is established and amplify the impact of open source. Browse careers at Canonical.{% endblock %}
 
 {% block body_class %}is-paper{% endblock body_class %}
 


### PR DESCRIPTION
## Done

- Updated page title and description as per [doc](https://docs.google.com/document/d/1o8ind3Zav-kwrUDWgiMJnkw2QLpniKgdlWrw9byIvlE/edit)

## QA

- View the site locally in your web browser at: https://canonical-com-1015.demos.haus/careers
- View source and see that the change shows up correctly 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5729
