### PR TITLE
WD-5430 - Replace the broken favicon with a PNG version

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -51,7 +51,7 @@
     <meta name="twitter:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
     <meta property="og:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
     {% endif %}
-    
+
     {% set current_path =  url_for(request.endpoint, **request.view_args)  %}
     {% if "/careers" in current_path %}
     <meta name="twitter:image" content="https://assets.ubuntu.com/v1/c17ef7b4-careers-meta-image-resized.png">
@@ -60,7 +60,7 @@
 
     {% block extra_metatags %}{% endblock %}
 
-    <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/e6b1c303-COF%20favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png" type="image/png" sizes="32x32">
     <link rel="apple-touch-icon-precomposed" sizes="144x144"
       href="https://assets.ubuntu.com/v1/f38b9c7e-COF%20apple-touch-icon.png">
     <link rel="apple-touch-icon-precomposed" sizes="114x114"


### PR DESCRIPTION
## Done

Replace the broken favicon with a PNG version

## QA

- Check the favicon loads in the tab when opening the demo
- Check the demo URL with https://realfavicongenerator.net/favicon_checker

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5430
