### PR TITLE
WD-6197 - Update the canonical URL for articles authored by Canonical

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -5,7 +5,20 @@
 {% block body_class %}is-paper blog-article{% endblock body_class %}
 {% block meta_image %}{{ article.image.source_url }}{% endblock %}
 
-{% block canonical_url %}{% if 2996 in article.tags %}https://snapcraft.io/blog/{{ article.slug }}{% elif 4059 in article.tags %}https://juju.is/blog/{{ article.slug }}{% elif 1304 in article.tags or 3681 in article.tags -%}https://maas.io/blog/{{ article.slug }}{% else %}{{ super() }}{% endif %}{% endblock canonical_url %}
+{%- block canonical_url -%}
+  {%- if article.author and article.author.id == 217 -%}
+    https://canonical.com/blog/{{ article.slug }}
+  {%- elif 2996 in article.tags -%}
+    https://snapcraft.io/blog/{{ article.slug }}
+  {%- elif 4059 in article.tags -%}
+    https://juju.is/blog/{{ article.slug }}
+  {%- elif 1304 in article.tags or 3681 in article.tags -%}
+    https://maas.io/blog/{{ article.slug }}
+  {%- else -%}
+    https://ubuntu.com/blog/{{ article.slug }}
+  {%- endif -%}
+{%- endblock canonical_url -%}
+
 {% block extra_metatags %}
 
 <script type="application/ld+json">
@@ -49,7 +62,7 @@
             <img src="{{ article.author.avatar_urls['96'] }}" class="p-media-object__image is-round" alt="" style="align-self: center;">
           {% endif %}
         {% endif %}
-      
+
         <div class="p-media-object__details">
           <p class="u-no-margin--bottom">
           {% if article.author %}
@@ -195,5 +208,5 @@
     {% endfor %}
   </section>
 {% endif %}
-  
+
 {% endblock %}


### PR DESCRIPTION
## Done
Update the canonical URL for articles authored by Canonical

## QA

- Open the demo
- Go to /blog
- Open an article by someone else then Canonical and view-source
- See that the `rel="canonical"` points to ubuntu.com/blog
- Go back and open an article from Canonical and view-source
- See that the `rel="canonical"` points to canonical.com/blog

There are some tags which might mix this up a little.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6197