### PR TITLE
WD-5751 - Add redirect for /enterprise-services

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -30,3 +30,4 @@ intellectual-property-rights-policy/?: "https://ubuntu.com/legal/intellectual-pr
 legal/?: "https://ubuntu.com/legal"
 intellectual-property-policy/?: "https://ubuntu.com/legal/intellectual-property-policy"
 enterprise-services/ubuntu-advantage?: "https://ubuntu.com/pro"
+enterprise-services?: "https://ubuntu.com/support"


### PR DESCRIPTION
## Done

Add redirect for /enterprise-services to ubuntu.com/support

## QA

- Open the demo
- Go to /enterprise-services
- See that it redirects to ubuntu.com/support

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5751
Fixes https://github.com/canonical/canonical.com/issues/1004
