### PR TITLE
Add modal form for Canonical /contact-us

### DIFF
--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -126,7 +126,7 @@
       <h2 class="p-muted-heading">Online</h2>
     </div>
     <div class="col-9 col-medium-4">
-      <p><a href="https://ubuntu.com/contact-us/form?product=generic-contact-us">Get in touch</a> about open source infrastructure, applications, development and operations. We are proud to deliver the world's best pathway to open source success.</p>
+      <p><a href="/contact-us#get-in-touch" aria-controls="homepage-modal">Get in touch</a> about open source infrastructure, applications, development and operations. We are proud to deliver the world's best pathway to open source success.</p>
     </div>
   </div>
   <div class="row p-block">
@@ -263,4 +263,11 @@
     </div>
   </div>
 </section>
+
+{% with %}
+  {% set formid = "5311" %}
+  {% set returnURL = "https://canonical.com#success" %}
+  {% include "partners/partial/_homepage-form.html" %}
+{% endwith %}
+
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
           <p class="p-heading--2">The Canonical way to open source in the enterprise starts with Ubuntu and reaches every part of&nbsp;the&nbsp;stack.</p>
         </div>
         <p>
-          <a class="p-button--positive u-no-margin--bottom" href="/contact-us" id="showModal" aria-controls="executive-summit-modal">Contact us</a>
+          <a class="p-button--positive u-no-margin--bottom" href="/contact-us" id="showModal" aria-controls="homepage-modal">Contact us</a>
         </p>
       </div>
     </div>

--- a/templates/partners/partial/_homepage-form.html
+++ b/templates/partners/partial/_homepage-form.html
@@ -1,7 +1,7 @@
-<div class="p-modal" style="display: none;" id="executive-summit-modal">
+<div class="p-modal" style="display: none;" id="homepage-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
-      <button class="p-modal__close" aria-controls="executive-summit-modal" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <button class="p-modal__close" aria-controls="homepage-modal" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
       <h2 class="p-modal__title u-sv1" id="modal-title">Contact Canonical</h2>
     </header>
     <div class="js-pagination js-pagination--1">


### PR DESCRIPTION
## Done

Added modal form for contact-us page and update aria-controls identifer

## QA

- Check https://canonical-com-1039.demos.haus/contact-us with [copy doc](https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit) comment
- Open the modal and fill up the form

- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6223

## Screenshots

[if relevant, include a screenshot]
