### PR TITLE
WD-6068 Fix navigation on application page

### DIFF
--- a/templates/careers/application/_withdrawal-form.html
+++ b/templates/careers/application/_withdrawal-form.html
@@ -1,4 +1,4 @@
-<div class="p-withdrawal-modal p-modal" id="withdrawal-modal">
+<div class="p-withdrawal-modal p-modal" style="display: none;" id="withdrawal-modal">
   <section class="p-withdrawal-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
     <div class="row">
       <header class="col-6 p-withdrawal-modal__header">
@@ -19,6 +19,7 @@
               <option value="{{ reason_id }}">{{ reason_message }}</option>
             {% endfor %}
           </select>
+
           <div class="other-input" style="display:none;">
             <input type="text" id="withdrawal-reason-other" name="withdrawal-reason-other" placeholder="Please write your reason here">
           </div>

--- a/templates/careers/application/index.html
+++ b/templates/careers/application/index.html
@@ -38,7 +38,7 @@
   </script>
   {% if application["status"] == "active" or ( application["status"] != "active" and application["to_be_rejected"] == True ) %}
     <!-- Start of thank you for applying section -->
-    <section class="p-strip--image is-dark is-deep" style="background-position: 100% 0; background-size: 150vw; background-image:url('https://assets.ubuntu.com/v1/78c0cbe3-05_suru2_dark_2K.jpg')">
+    <section id="application-page" class="p-strip--image is-dark is-deep" style="background-position: 100% 0; background-size: 150vw; background-image:url('https://assets.ubuntu.com/v1/78c0cbe3-05_suru2_dark_2K.jpg')">
       {% if withdrawal_requested %}
         <div class="u-fixed-width">
           <div class="p-notification--caution">
@@ -282,123 +282,8 @@
     }
   }
 
-  (function () {
-
-    var currentDialog = null;
-    var lastFocus = null;
-    var ignoreFocusChanges = false;
-    var focusAfterClose = null;
-
-    // Traps the focus within the currently open modal dialog
-    function trapFocus(event) {
-      if (ignoreFocusChanges) return;
-
-      if (currentDialog.contains(event.target)) {
-        lastFocus = event.target;
-      } else {
-        focusFirstDescendant(currentDialog);
-        if (lastFocus == document.activeElement) {
-          focusLastDescendant(currentDialog);
-        }
-        lastFocus = document.activeElement;
-      }
-    }
-
-    // Attempts to focus given element
-    function attemptFocus(child) {
-      if (child.focus) {
-        ignoreFocusChanges = true;
-        child.focus();
-        ignoreFocusChanges = false;
-        return document.activeElement === child;
-      }
-
-      return false;
-    }
-
-    // Focuses first child element
-    function focusFirstDescendant(element) {
-      for (var i = 0; i < element.childNodes.length; i++) {
-        var child = element.childNodes[i];
-        if (attemptFocus(child) || focusFirstDescendant(child)) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    // Focuses last child element
-    function focusLastDescendant(element) {
-      for (var i = element.childNodes.length - 1; i >= 0; i--) {
-        var child = element.childNodes[i];
-        if (attemptFocus(child) || focusLastDescendant(child)) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    /**
-      Toggles visibility of modal dialog.
-      @param {HTMLElement} modal Modal dialog to show or hide.
-      @param {HTMLElement} sourceEl Element that triggered toggling modal
-      @param {Boolean} open If defined as `true` modal will be opened, if `false` modal will be closed, undefined toggles current visibility.
-    */
-    function toggleModal(modal, sourceEl, open) {
-      if (modal) {
-        if (typeof open === 'undefined') {
-          open = modal.style.display === 'none';
-        }
-
-        if (open) {
-          currentDialog = modal;
-          modal.style.display = 'flex';
-          focusFirstDescendant(modal);
-          focusAfterClose = sourceEl;
-          document.addEventListener('focus', trapFocus, true);
-        } else {
-          modal.style.display = 'none';
-          if (focusAfterClose && focusAfterClose.focus) {
-            focusAfterClose.focus();
-          }
-          document.removeEventListener('focus', trapFocus, true);
-          currentDialog = null;
-        }
-      }
-    }
-
-    // Find and hide all modals on the page
-    function closeModals() {
-      var modals = [].slice.apply(document.querySelectorAll('.p-withdrawal-modal'));
-      modals.forEach(function (modal) {
-        toggleModal(modal, false, false);
-      });
-    }
-
-    // Add click handler for clicks on elements with aria-controls
-    document.addEventListener('click', function (event) {
-      var targetControls = event.target.getAttribute('aria-controls');
-      if (targetControls) {
-        toggleModal(document.getElementById(targetControls), event.target);
-      }
-    });
-
-    // Add handler for closing modals using ESC key.
-    document.addEventListener('keydown', function (e) {
-      e = e || window.event;
-
-      if (e.code === 'Escape') {
-        closeModals();
-      } else if (e.keyCode === 27) {
-        closeModals();
-      }
-    });
-
-    // init the dialog that is initially opened in the example
-    const modals = document.querySelectorAll(".p-modal");
-    modals.forEach(modal => {
-      toggleModal(modal, document.querySelector(`[aria-controls=${modal.id}]`), false);
-    });
-  })();
+  
   </script>
+
+  <script async src="{{ versioned_static('js/modals.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Done

Navigation on application page was broken. This was because there is a duplication of modal functionality, which already exists on /js/modals.js.


## QA

- Go to an application page e.g. https://canonical-com-1040.demos.haus/careers/application/gAAAAABjX6OTC4h0nMj9zgQbSR4AeKZ4rLasVjmZKhoSbNCYqO8tNAilVS75NKwArileTUXZV72MI08EcukQokHOP0ZUp0gthw== and check navigation is no longer broken
- Check that application withdrawal modal opens

- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6068
Close https://github.com/canonical/canonical.com/issues/1024


## Screenshots

[if relevant, include a screenshot]
