### PR TITLE
Null check the UTM search field

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -124,7 +124,9 @@
         const utm_names = ["campaign", "source", "medium", "content", "term"];
         for (let i = 0; i < utm_names.length; i++) {
           var utm_fields = document.getElementsByName("utm_" + utm_names[i]);
-          utm_fields[0].value = params.get("utm_" + utm_names[i]);
+          if (utm_fields.length > 0) {
+            utm_fields[0].value = params.get("utm_" + utm_names[i]);
+          }
         }
       })()
     </script>


### PR DESCRIPTION
## Done
Null check the query selector as this does not always return results on all pages.

## QA

- Follow the steps in the issue and see that it's gone in the demo.

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/998