### PR TITLE
Replace wrong filter in mobile 'Find a Partner' section

### DIFF
--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -75,7 +75,7 @@
                     </div>
                     <hr class="p-rule">
                     <section class="p-accordion__panel is-dense" id="tab1-section" aria-hidden="false" aria-labelledby="tab1">
-                      {% include '/partners/partial/_partner-filters/_programme-filters.html' %}
+                      {% include '/partners/partial/_partner-filters/_services-filters.html' %}
                     </section>
                   </li>
                 </ul>


### PR DESCRIPTION
## Done

- Replaced the duplicate inclusion of '_programme-filters.html' with '_services-filters.html' in the mobile filters section of the '[Find a Partner](https://canonical.com/partners/find-a-partner)' page to align with the desktop version.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card
None

## Screenshots
Screenshots from the canonical website.
On desktop:
![Find a Canonical partner | Partners 2023-10-19 15-39-34](https://github.com/canonical/canonical.com/assets/92396581/1a7612c0-0451-4997-b168-a91e368eee9a)

On mobile:
![Find a Canonical partner | Partners 2023-10-19 15-39-56](https://github.com/canonical/canonical.com/assets/92396581/8dd8b332-2d37-4170-886a-86b4780214f0)

Screenshot from my localhost after fix:
![Find a Canonical partner | Partners 2023-10-19 15-41-10](https://github.com/canonical/canonical.com/assets/92396581/fe2f8312-1283-496e-9ee3-ffb0e34f2899)


[if relevant, include a screenshot]
