### PR TITLE
Bump canonicalwebteam.discourse to 5.4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.blog==6.4.0
 canonicalwebteam.http==1.0.4
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.discourse==5.2.4
+canonicalwebteam.discourse==5.4.3
 canonicalwebteam.search==1.3.0
 bleach==5.0.1
 markdown==3.4.1


### PR DESCRIPTION
## Done

Bump canonicalwebteam.discourse to 5.4.3

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Browse the discourse powered sections in the demo environment and check they work.