### PR TITLE
Update Kubernetes logos

### DIFF
--- a/templates/data/mongodb.html
+++ b/templates/data/mongodb.html
@@ -53,9 +53,10 @@
     <div class="p-logo-section">
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
-          {{ image (
+          {{
+            image (
             url="https://assets.ubuntu.com/v1/0c00d440-microsoft-azure-2021.png",
-            alt="",
+            alt="Microsoft Azure",
             width="116",
             height="384",
             hi_def=True,
@@ -65,10 +66,11 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/f7a0c5ff-kubernetes-logomark-logo.png",
-            alt="",
-            width="105",
+          {{
+            image (
+            url="https://assets.ubuntu.com/v1/cd1a01d0-kubernetes-logomark-logo.png",
+            alt="Kubernetes",
+            width="606",
             height="384",
             hi_def=True,
             loading="lazy",
@@ -78,20 +80,20 @@
         </div>
         <div class="p-logo-section__item">
           {{ image (
-							url="https://assets.ubuntu.com/v1/165fa040-openstack-logo.png",
-							alt="",
-							width="426",
-							height="256",
-							hi_def=True,
-							loading="lazy",
-							attrs={"class": "p-logo-section__logo"}
-							) | safe
-						}}
+            url="https://assets.ubuntu.com/v1/165fa040-openstack-logo.png",
+            alt="OpenStack",
+            width="426",
+            height="256",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
         </div>
         <div class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/4aa11bb2-vmware-logo.png",
-            alt="",
+            alt="VMWare",
             width="265",
             height="384",
             hi_def=True,
@@ -102,10 +104,10 @@
         </div>
         <div class="p-logo-section__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/854a6441-google-cloud-logomark.png",
-            alt="",
-            width="141",
-            height="384",
+            url="https://assets.ubuntu.com/v1/497cabc1-google-cloud-logo.png",
+            alt="Google Cloud",
+            width="397",
+            height="256",
             hi_def=True,
             loading="lazy",
             attrs={"class": "p-logo-section__logo"}
@@ -115,7 +117,7 @@
         <div class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/5e627a00-aws-logo.png",
-            alt="",
+            alt="AWS",
             width="187",
             height="384",
             hi_def=True,

--- a/templates/data/opensearch.html
+++ b/templates/data/opensearch.html
@@ -76,11 +76,12 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/8fb612cd-kubernetes-logomark-logo.png",
+          {{
+            image (
+            url="https://assets.ubuntu.com/v1/cd1a01d0-kubernetes-logomark-logo.png",
             alt="Kubernetes",
-            width="68",
-            height="256",
+            width="606",
+            height="384",
             hi_def=True,
             loading="lazy",
             attrs={"class": "p-logo-section__logo"}

--- a/templates/data/spark.html
+++ b/templates/data/spark.html
@@ -89,16 +89,17 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/8fb612cd-kubernetes-logomark-logo.png",
-              alt="Kubernetes",
-              width="68",
-              height="256",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"},
-              ) | safe
-            }}
+            {{
+							image (
+							url="https://assets.ubuntu.com/v1/cd1a01d0-kubernetes-logomark-logo.png",
+							alt="Kubernetes",
+							width="606",
+              height="384",
+							hi_def=True,
+							loading="lazy",
+							attrs={"class": "p-logo-section__logo"}
+							) | safe
+						}}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

Update Kubernetes logos.

## QA

- Go to 

https://canonical-com-1089.demos.haus/data/mongodb
https://canonical-com-1089.demos.haus/data/opensearch
https://canonical-com-1089.demos.haus/data/spark

and check that kubernetes logos have been replaced by the https://assets.ubuntu.com/v1/cd1a01d0-kubernetes-logomark-logo.png

- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6862
