### PR TITLE
[WD-6796] modify sections in /careers/engineering

### DIFF
--- a/templates/careers/_base-department.html
+++ b/templates/careers/_base-department.html
@@ -15,7 +15,9 @@
     </div>
     <div class="col-6 col-medium-3">
       <p class="u-sv2">{{ claim | safe }}</p>
-      {% if not fast_track_jobs %}
+      {% if fast_track_jobs %}
+        <div class="u-sv-3"></div>
+      {% else %}
         <a class="p-button--positive" href="/careers/all?filter={{ department.name | safe | urlencode }}">See all {{ department.name }} roles</a>
         <a class="p-button" href="/careers/career-explorer">Career explorer</a>
       {% endif %}

--- a/templates/careers/_base-department.html
+++ b/templates/careers/_base-department.html
@@ -15,20 +15,19 @@
     </div>
     <div class="col-6 col-medium-3">
       <p class="u-sv2">{{ claim | safe }}</p>
-      <a class="p-button--positive" href="/careers/all?filter={{ department.name | safe | urlencode }}">See all {{ department.name }} roles</a>
-      <a class="p-button" href="/careers/career-explorer">Career explorer</a>
+      {% if not fast_track_jobs %}
+        <a class="p-button--positive" href="/careers/all?filter={{ department.name | safe | urlencode }}">See all {{ department.name }} roles</a>
+        <a class="p-button" href="/careers/career-explorer">Career explorer</a>
+      {% endif %}
     </div>
   </div>
-  <!-- <div class="u-fixed-width p-block">
-    <hr class="p-rule">
-    <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Fast track roles</h2>
-  </div>
-  <div class="row">
-    {% include 'shared/_engineering-fast-track.html' %}
-  </div> -->
 </section>
 
-{% if fast_track_jobs or featured_jobs %}
+{% if fast_track_jobs %}
+    {% include 'shared/_engineering-fast-track.html' %}
+{% endif %}
+
+{% if featured_jobs and not fast_track_jobs %}
     {% include "shared/_promoted_roles.html" %}
 {% endif %}
 

--- a/templates/careers/_base-department.html
+++ b/templates/careers/_base-department.html
@@ -1,5 +1,5 @@
 <div class="u-fixed-width">
-  <nav class="p-breadcrumbs u-sv1" aria-label="Breadcrumbs">
+  <nav class="p-breadcrumbs" aria-label="Breadcrumbs">
     <ol class="p-breadcrumbs__items p-text--x-small-capitalised">
         <li class="p-breadcrumbs__item "><a href="/careers/">Careers</a></li>
         <li class="p-breadcrumbs__item ">{{ department.name }}</li>
@@ -7,6 +7,7 @@
   </nav>
   <h1 class="p-text--x-small-capitalised u-hide">Careers</h1>
 </div>
+{% if not fast_track_jobs %}
 <section class="p-section u-no-padding--top">
   <hr class="is-fixed-width p-rule">
   <div class="row p-section">
@@ -15,15 +16,12 @@
     </div>
     <div class="col-6 col-medium-3">
       <p class="u-sv2">{{ claim | safe }}</p>
-      {% if fast_track_jobs %}
-        <div class="u-sv-3"></div>
-      {% else %}
-        <a class="p-button--positive" href="/careers/all?filter={{ department.name | safe | urlencode }}">See all {{ department.name }} roles</a>
-        <a class="p-button" href="/careers/career-explorer">Career explorer</a>
-      {% endif %}
+      <a class="p-button--positive" href="/careers/all?filter={{ department.name | safe | urlencode }}">See all {{ department.name }} roles</a>
+      <a class="p-button" href="/careers/career-explorer">Career explorer</a>
     </div>
   </div>
 </section>
+{% endif %}
 
 {% if fast_track_jobs %}
     {% include 'shared/_engineering-fast-track.html' %}

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -9,8 +9,8 @@
 {% block content %}
 {% with 
     department=department,
-    claim="Open source is transforming the entire stack. This is your chance to be right at the centre of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud and high performance computing, from AI and big data to the web and connected devices, open source is a key ingredient for success. Canonical offers the opportunity to work across the entire spectrum.",
-    fast_track_jobs=fast_track_jobs,
+    claim="Join our engineering team and shape the future of open source.<br/><br/>Apply based on your field or position level and we'll find the right role for you. You can also explore specific roles.",
+    fast_track_jobs=True,
     block_1_subheading="Projects you'll work on",
     block_1_text=["We publish Ubuntu, the leanest and most efficient open source platform. We care about developer access to the very best of open source, and make it easy to innovate and publish on the cloud, on desktops, and on smart connected devices for the internet of things. We work across the full range of open source &ndash; from the kernel, to applications, from deep system services to the GUI and the web. We care about security, correctness, reliability, performance and efficiency. If you share those values and you have a track record of exceptional software development, this is the place for you."],
     image_url='https://assets.ubuntu.com/v1/f540ae09-more-real-travel-image.png',

--- a/templates/shared/_engineering-fast-track.html
+++ b/templates/shared/_engineering-fast-track.html
@@ -13,62 +13,62 @@
 				</div>
 				<div class="col-3">
 					<a href="/careers/5191982">Microservices</a>
-					<p class="u-no-padding--top">REST API design in Go and Python</p>
+					<p class="u-no-padding--top"><small>REST API design in Go and Python</small></p>
 				</div>
 				<div class="col-3">
 					<a href="/careers/5151903">Kernel</a>
-					<p class="u-no-padding--top">Low-level system engineering</p>
+					<p class="u-no-padding--top"><small>Low-level system engineering</small></p>
 				</div>
 			</div>
 			<div class="row">
 				<div class="col-3">
 					<a href="/careers/5143074">Python</a>
-					<p class="u-no-padding--top">Develop for open source</p>
+					<p class="u-no-padding--top"><small>Develop for open source</small></p>
 				</div>
 				<div class="col-3">
 					<a href="/careers/5140562">Embedded Linux</a>
-					<p class="u-no-padding--top">ARM & x86, SoC, ACPI</p>
+					<p class="u-no-padding--top"><small>ARM & x86, SoC, ACPI</small></p>
 				</div>
 			</div>
 			<div class="row">
 				<div class="col-3">
 					<a href="/careers/5146709">Golang</a>
-					<p class="u-no-padding--top">Develop for open source</p>
+					<p class="u-no-padding--top"><small>Develop for open source</small></p>
 				</div>
 				<div class="col-3">
 					<a href="/careers/5172247">Containers & Virtualisation</a>
-					<p class="u-no-padding--top">LXD, Rust VMM, Docker</p>
+					<p class="u-no-padding--top"><small>LXD, Rust VMM, Docker</small></p>
 				</div>
 			</div>
 			<div class="row">
 				<div class="col-3">
 					<a href="/careers/5150422">Web Frontend</a>
-					<p class="u-no-padding--top">JS, CSS, React & Flutter</p>
+					<p class="u-no-padding--top"><small>JS, CSS, React & Flutter</small></p>
 				</div>
 				<div class="col-3">
 					<a href="/careers/5146620">Security</a>
-					<p class="u-no-padding--top">Keep Linux secure</p>
+					<p class="u-no-padding--top"><small>Keep Linux secure</small></p>
 				</div>
 			</div>
 			<div class="row">
 				<div class="col-3">
 					<a href="/careers/5163397">Networking</a>
-					<p class="u-no-padding--top">Data centres, SDN/NFV tech</p>
+					<p class="u-no-padding--top"><small>Data centres, SDN/NFV tech</small></p>
 				</div>
 				<div class="col-3">
-					<a href="/careers/3655681">DevRel</a>
-					<p class="u-no-padding--top">Engage with community and devs</p>
+					<a href="/careers/5143011">DevRel</a>
+					<p class="u-no-padding--top"><small>Engage with community and devs</small></p>
 				</div>
 			</div>
 		</div>
 		<div class="col-3 col-medium-3 col-start-medium-4">
 			<h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Position Level</h2>
 			<a href="/careers/5211861">Director</a>
-			<p class="u-no-padding--top">Define strategy and assist teams</p>
+			<p class="u-no-padding--top"><small>Define strategy and assist teams</small></p>
 			<a href="/careers/5188002">Manager</a>
-			<p class="u-no-padding--top">Lead globally-distributed teams</p>
+			<p class="u-no-padding--top"><small>Lead globally-distributed teams</small></p>
 			<a href="/careers/5142887">Senior Engineer</a>
-			<p class="u-no-padding--top">Solve open source challenges</p>
+			<p class="u-no-padding--top"><small>Solve open source challenges</small></p>
 		</div>
 	</div>
 </section>
@@ -93,6 +93,7 @@
 			{% endfor %}
 		</div>
 		<div class="col-3 col-medium-3 col-start-medium-4">
+			<hr class="u-hide--large" />
 			<p class="u-sv-1">
 				{% if formatted_slug %}
 				<a href="/careers/all?filter={{formatted_slug}}">Explore all {{ department.name }} roles</a>

--- a/templates/shared/_engineering-fast-track.html
+++ b/templates/shared/_engineering-fast-track.html
@@ -84,12 +84,13 @@
 		</div>
 		<div class="col-6 col-medium-3">
 			{% for job in featured_jobs %}
-			<p>
+				{% if loop.index < 10 %} <p>
 				<a class="p-featured__url p-card--content" href="/careers/{{job.id}}"
 					onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Featured job', 'eventAction' : 'Click', 'eventLabel' : '{{ job.title }}', 'eventValue' : undefined });">
 					{{job.title }}
 				</a>
-			</p>
+				</p>
+				{% endif %}
 			{% endfor %}
 		</div>
 		<div class="col-3 col-medium-3 col-start-medium-4">

--- a/templates/shared/_engineering-fast-track.html
+++ b/templates/shared/_engineering-fast-track.html
@@ -1,131 +1,108 @@
-<div class="col-3 col-medium-3 p-engineering-fast-track">
-	<a class="p-engineering-fast-track__url p-card--content" aria-disabled="true" href="" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Fast track roles', 'eventAction' : 'Click', 'eventLabel' : 'Micro services', 'eventValue' : undefined });">
-	<div class="p-engineering-fast-track__container col-small-4 col-medium-3 col-4 u-no-padding--left">
-		<div class="p-engineering-fast-track__item">
-			<p><span class="p-engineering-fast-track__text">Micro services</span></p>
+<section class="p-section">
+	<div class="u-fixed-width">
+		<hr class="p-rule">
+	</div>
+	<div class="row">
+		<div class="col-3 col-medium-3">
+			<h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Apply based on</h2>
 		</div>
-		<div class="p-engineering-fast-track__chevron">
-			<i class="p-icon--chevron-right"></i>
+		<div class="col-6 col-medium-3">
+			<div class="row">
+				<div class="col-6">
+					<h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Technology & Field</h2>
+				</div>
+				<div class="col-3">
+					<a href="/careers/5191982">Microservices</a>
+					<p class="u-no-padding--top">REST API design in Go and Python</p>
+				</div>
+				<div class="col-3">
+					<a href="/careers/5151903">Kernel</a>
+					<p class="u-no-padding--top">Low-level system engineering</p>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-3">
+					<a href="/careers/5143074">Python</a>
+					<p class="u-no-padding--top">Develop for open source</p>
+				</div>
+				<div class="col-3">
+					<a href="/careers/5140562">Embedded Linux</a>
+					<p class="u-no-padding--top">ARM & x86, SoC, ACPI</p>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-3">
+					<a href="/careers/5146709">Golang</a>
+					<p class="u-no-padding--top">Develop for open source</p>
+				</div>
+				<div class="col-3">
+					<a href="/careers/5172247">Containers & Virtualisation</a>
+					<p class="u-no-padding--top">LXD, Rust VMM, Docker</p>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-3">
+					<a href="/careers/5150422">Web Frontend</a>
+					<p class="u-no-padding--top">JS, CSS, React & Flutter</p>
+				</div>
+				<div class="col-3">
+					<a href="/careers/5146620">Security</a>
+					<p class="u-no-padding--top">Keep Linux secure</p>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-3">
+					<a href="/careers/5163397">Networking</a>
+					<p class="u-no-padding--top">Data centres, SDN/NFV tech</p>
+				</div>
+				<div class="col-3">
+					<a href="/careers/3655681">DevRel</a>
+					<p class="u-no-padding--top">Engage with community and devs</p>
+				</div>
+			</div>
+		</div>
+		<div class="col-3 col-medium-3 col-start-medium-4">
+			<h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Position Level</h2>
+			<a href="/careers/5211861">Director</a>
+			<p class="u-no-padding--top">Define strategy and assist teams</p>
+			<a href="/careers/5188002">Manager</a>
+			<p class="u-no-padding--top">Lead globally-distributed teams</p>
+			<a href="/careers/5142887">Senior Engineer</a>
+			<p class="u-no-padding--top">Solve open source challenges</p>
 		</div>
 	</div>
-	</a>
-</div>
+</section>
 
-<div class="col-3 col-medium-3 p-engineering-fast-track">
-	<a class="p-engineering-fast-track__url p-card--content" aria-disabled="true" href="" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Fast track roles', 'eventAction' : 'Click', 'eventLabel' : 'Python', 'eventValue' : undefined });">
-		<div class="p-engineering-fast-track__container col-small-4 col-medium-3 col-4 u-no-padding--left">
-			<div class="p-engineering-fast-track__item">
-				<p><span class="p-engineering-fast-track__text">Python</span></p>
-			</div>
-			<div class="p-engineering-fast-track__chevron">
-				<i class="p-icon--chevron-right"></i>
-			</div>
+<section class="p-section">
+	{% if featured_jobs %}
+	<div class="u-fixed-width">
+		<hr class="p-rule">
+	</div>
+	<div class="row">
+		<div class="col-3 col-medium-3">
+			<h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Featured Roles</h2>
 		</div>
-	</a>
-</div>
-
-<div class="col-3 col-medium-3 p-engineering-fast-track">
-	<a class="p-engineering-fast-track__url p-card--content" aria-disabled="true" href="" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Fast track roles', 'eventAction' : 'Click', 'eventLabel' : 'Golang', 'eventValue' : undefined });">
-		<div class="p-engineering-fast-track__container col-small-4 col-medium-3 col-4 u-no-padding--left">
-			<div class="p-engineering-fast-track__item">
-				<p><span class="p-engineering-fast-track__text">Golang</span></p>
-			</div>
-			<div class="p-engineering-fast-track__chevron">
-				<i class="p-icon--chevron-right"></i>
-			</div>
+		<div class="col-6 col-medium-3">
+			{% for job in featured_jobs %}
+			<p>
+				<a class="p-featured__url p-card--content" href="/careers/{{job.id}}"
+					onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Featured job', 'eventAction' : 'Click', 'eventLabel' : '{{ job.title }}', 'eventValue' : undefined });">
+					{{job.title }}
+				</a>
+			</p>
+			{% endfor %}
 		</div>
-	</a>
-</div>
-
-
-<div class="col-3 col-medium-3 p-engineering-fast-track">
-	<a class="p-engineering-fast-track__url p-card--content" aria-disabled="true" href="" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Fast track roles', 'eventAction' : 'Click', 'eventLabel' : 'Distro', 'eventValue' : undefined });">
-		<div class="p-engineering-fast-track__container col-small-4 col-medium-3 col-4 u-no-padding--left">
-			<div class="p-engineering-fast-track__item">
-				<p><span class="p-engineering-fast-track__text">Distro</span></p>
-			</div>
-			<div class="p-engineering-fast-track__chevron">
-				<i class="p-icon--chevron-right"></i>
-			</div>
+		<div class="col-3 col-medium-3 col-start-medium-4">
+			<p class="u-sv-1">
+				{% if formatted_slug %}
+				<a href="/careers/all?filter={{formatted_slug}}">Explore all {{ department.name }} roles</a>
+				{% else %}
+				<a href="/careers/all?filter={{department.slug.capitalize()}}">Explore all {{ department.name }} roles</a>
+				{% endif %}
+			</p>
+			<hr />
+			<a href="/careers/career-explorer">Career explorer</a>
 		</div>
-	</a>
-</div>
-
-
-<div class="col-3 col-medium-3 p-engineering-fast-track">
-	<a class="p-engineering-fast-track__url p-card--content" aria-disabled="true" href="" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Fast track roles', 'eventAction' : 'Click', 'eventLabel' : 'Embedded', 'eventValue' : undefined });">
-		<div class="p-engineering-fast-track__container col-small-4 col-medium-3 col-4 u-no-padding--left">
-			<div class="p-engineering-fast-track__item">
-				<p><span class="p-engineering-fast-track__text">Embedded</span></p>
-			</div>
-			<div class="p-engineering-fast-track__chevron">
-				<i class="p-icon--chevron-right"></i>
-			</div>
-		</div>
-	</a>
-</div>
-
-<div class="col-3 col-medium-3 p-engineering-fast-track">
-	<a class="p-engineering-fast-track__url p-card--content" aria-disabled="true" href="" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Fast track roles', 'eventAction' : 'Click', 'eventLabel' : 'Performance', 'eventValue' : undefined });">
-		<div class="p-engineering-fast-track__container col-small-4 col-medium-3 col-4 u-no-padding--left">
-			<div class="p-engineering-fast-track__item">
-				<p><span class="p-engineering-fast-track__text">Performance</span></p>
-			</div>
-			<div class="p-engineering-fast-track__chevron">
-				<i class="p-icon--chevron-right"></i>
-			</div>
-		</div>
-	</a>
-</div>
-
-<div class="col-3 col-medium-3 p-engineering-fast-track">
-	<a class="p-engineering-fast-track__url p-card--content" aria-disabled="true" href="" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Fast track roles', 'eventAction' : 'Click', 'eventLabel' : 'Performance', 'eventValue' : undefined });">
-		<div class="p-engineering-fast-track__container col-small-4 col-medium-3 col-4 u-no-padding--left">
-			<div class="p-engineering-fast-track__item">
-				<p><span class="p-engineering-fast-track__text">Performance</span></p>
-			</div>
-			<div class="p-engineering-fast-track__chevron">
-				<i class="p-icon--chevron-right"></i>
-			</div>
-		</div>
-	</a>
-</div>
-
-<div class="col-3 col-medium-3 p-engineering-fast-track">
-	<a class="p-engineering-fast-track__url p-card--content" aria-disabled="true" href="" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Fast track roles', 'eventAction' : 'Click', 'eventLabel' : 'Web - JS, CSS, Flutter', 'eventValue' : undefined });">
-		<div class="p-engineering-fast-track__container col-small-4 col-medium-3 col-4 u-no-padding--left">
-			<div class="p-engineering-fast-track__item">
-				<p><span class="p-engineering-fast-track__text">Web - JS, CSS, Flutter</span></p>
-			</div>
-			<div class="p-engineering-fast-track__chevron">
-				<i class="p-icon--chevron-right"></i>
-			</div>
-		</div>
-	</a>
-</div>
-
-<div class="col-3 col-medium-3 p-engineering-fast-track">
-	<a class="p-engineering-fast-track__url p-card--content" aria-disabled="true" href="" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Fast track roles', 'eventAction' : 'Click', 'eventLabel' : 'Data Scientist', 'eventValue' : undefined });">
-		<div class="p-engineering-fast-track__container col-small-4 col-medium-3 col-4 u-no-padding--left">
-			<div class="p-engineering-fast-track__item">
-				<p><span class="p-engineering-fast-track__text">Data Scientist</span></p>
-			</div>
-			<div class="p-engineering-fast-track__chevron">
-				<i class="p-icon--chevron-right"></i>
-			</div>
-		</div>
-	</a>
-</div>
-
-<div class="col-3 col-medium-3 p-engineering-fast-track">
-	<a class="p-engineering-fast-track__url p-card--content" aria-disabled="true" href="/careers/3798310" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Fast track roles', 'eventAction' : 'Click', 'eventLabel' : 'Dev Rel', 'eventValue' : undefined });">
-		<div class="p-engineering-fast-track__container col-small-4 col-medium-3 col-4 u-no-padding--left">
-			<div class="p-engineering-fast-track__item">
-				<p><span class="p-engineering-fast-track__text">Dev Rel</span></p>
-			</div>
-			<div class="p-engineering-fast-track__chevron">
-				<i class="p-icon--chevron-right"></i>
-			</div>
-		</div>
-	</a>
-</div>
+	</div>
+	{% endif %}
+</section>

--- a/templates/shared/_engineering-fast-track.html
+++ b/templates/shared/_engineering-fast-track.html
@@ -1,15 +1,28 @@
+<section class="p-section u-no-padding--top">
+  <hr class="is-fixed-width p-rule">
+  <div class="row p-section">
+    <div class="col-6 col-medium-2">
+      <h1 class="p-heading--2"><strong>{{ department.name }}</strong></h1>
+    </div>
+    <div class="col-6 col-medium-4">
+      <p>{{ claim | safe }}</p>
+      <div class="u-sv-3"></div>
+    </div>
+  </div>
+</section>
+
 <section class="p-section">
 	<div class="u-fixed-width">
 		<hr class="p-rule">
 	</div>
 	<div class="row">
-		<div class="col-3 col-medium-3">
+		<div class="col-3 col-medium-2">
 			<h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Apply based on</h2>
 		</div>
-		<div class="col-6 col-medium-3">
+		<div class="col-6 col-medium-2">
 			<div class="row">
 				<div class="col-6">
-					<h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Technology & Field</h2>
+					<h5 class="p-text--large">Technology & Field</h5>
 				</div>
 				<div class="col-3">
 					<a href="/careers/5191982">Microservices</a>
@@ -61,8 +74,8 @@
 				</div>
 			</div>
 		</div>
-		<div class="col-3 col-medium-3 col-start-medium-4">
-			<h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Position Level</h2>
+		<div class="col-3 col-medium-2">
+			<h5 class="p-text--large">Position Level</h5>
 			<a href="/careers/5211861">Director</a>
 			<p class="u-no-padding--top"><small>Define strategy and assist teams</small></p>
 			<a href="/careers/5188002">Manager</a>
@@ -79,10 +92,10 @@
 		<hr class="p-rule">
 	</div>
 	<div class="row">
-		<div class="col-3 col-medium-3">
+		<div class="col-3 col-medium-2">
 			<h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Featured Roles</h2>
 		</div>
-		<div class="col-6 col-medium-3">
+		<div class="col-6 col-medium-2">
 			{% for job in featured_jobs %}
 				{% if loop.index < 10 %} <p>
 				<a class="p-featured__url p-card--content" href="/careers/{{job.id}}"
@@ -93,8 +106,8 @@
 				{% endif %}
 			{% endfor %}
 		</div>
-		<div class="col-3 col-medium-3 col-start-medium-4">
-			<hr class="u-hide--large" />
+		<div class="col-3 col-medium-2">
+			<hr class="u-hide--medium u-hide--large" />
 			<p class="u-sv-1">
 				{% if formatted_slug %}
 				<a href="/careers/all?filter={{formatted_slug}}">Explore all {{ department.name }} roles</a>


### PR DESCRIPTION
## Done

- create 'Apply based on' section for "fast-track" positions in `/careers/engineering`
- modify 'Featured roles' section in `/careers/engineering` according to [Figma designs](https://www.figma.com/file/c4QYGBPZl5hxr5XrziIVZA/23.10-C.com---%2Fcareers%2Fengineering-(Fast-tracks)?type=design&node-id=98-5748&mode=design&t=LRqU0MZl4Xk191vG-4)
- edit the first section in `/careers/engineering` also according to design

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Open /careers/engineering and check the changes in first three sections
- Open other /careers pages and check that nothing changed

## Issue / Card

Closes https://warthogs.atlassian.net/browse/WD-6796
