### PR TITLE
WD-6868 - Add the Open Documentation Academy page

### DIFF
--- a/templates/documentation/_documentation-tab-navigation.html
+++ b/templates/documentation/_documentation-tab-navigation.html
@@ -11,6 +11,9 @@
         <li class="p-tabs__item" role="presentation">
           <a href="/documentation/beyond-canonical" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'beyond-canonical' or current_tab == 'docs' %}aria-selected="true" {% endif %}>Beyond Canonical</a>
         </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="/documentation/open-documentation-academy" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'open-documentation-academy' or current_tab == 'docs' %}aria-selected="true" {% endif %}>Open Documentation Academy</a>
+        </li>
       </ul>
     </nav>
   </div>

--- a/templates/documentation/open-documentation-academy.html
+++ b/templates/documentation/open-documentation-academy.html
@@ -98,7 +98,7 @@
         <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="stay-in-touch" style="scroll-margin-top: 3.5rem;">Stay in touch</h2>
         <div class="col-6 col-medium-4">
           <ul class="p-list--divided">
-            <li class="p-list__item">Subscribe to our calendar:  Open Documentation Academy events</li>
+            <li class="p-list__item">Subscribe to our calendar: <a href="https://calendar.google.com/calendar/u/0?cid=Y19mYTY4YzE5YWEwY2Y4YWE1ZWNkNzMyNjZmNmM0ZDllOTRhNTIwNTNjODc1ZjM2ZmQ3Y2MwNTQ0MzliOTIzZjMzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20">Open Documentation Academy events</a></li>
             <li class="p-list__item"><a href="https://discourse.ubuntu.com/c/open-documentation-academy">Join our discussion forum on the Ubuntu Community Hub</a></li>
             <li class="p-list__item"><a href="https://fosstodon.org/@CanonicalDocumentation">Follow our progress online through Mastodon</a></li>
             <li class="p-list__item">Email our academy leadership team directly: <a href="mailto:opendocsacademy@canonical.com">opendocsacademy@canonical.com</a></li>

--- a/templates/documentation/open-documentation-academy.html
+++ b/templates/documentation/open-documentation-academy.html
@@ -1,0 +1,113 @@
+{% set current_tab = "open-documentation-academy" %}
+
+{% extends 'documentation/documentation-layout.html' %}
+
+{% block title %}Documentation Practice - Open Documentation Academy{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1nhy653-SOfTmGCIiSZHuGBCrwZlzEZJaA4kFBsw-5dc/edit{% endblock %}
+
+{% block meta_description %}At Canonical, we aim to set a standard of excellence in technical documentation, by treating it as a professional discipline within our engineering practice.{% endblock %}
+
+{% block meta_image %}https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg{% endblock %}
+
+{% block documentation_content %}
+<div class="p-strip u-no-padding--top">
+  <div class="row" id="documentation">
+    <aside class="col-3">
+      <div class="p-side-navigation--raw-html is-sticky" id="drawer">
+        <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+          Toggle side navigation
+        </button>
+        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
+        <nav class="p-side-navigation__drawer" aria-label="documentation side navigation">
+          <div class="p-side-navigation__drawer-header">
+            <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+              Toggle table of contents
+            </button>
+          </div>
+          <ul>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#get-out-of-it">What you'll get out of it</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#what-we-offer">What we offer</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#what-you-will-do">What you will do</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#activities">Activities</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#stay-in-touch">Stay in touch</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </aside>
+    <main class="col-9">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4" style="scroll-margin-top: 3.5rem;">Open Documentation Academy</h2>
+        <div class="col-6 col-medium-4">
+          <p class="p-heading--5">Learn open-source software documentation skills with Canonical</p>
+          <p>The Open Documentation Academy combines Canonical's documentation team with documentation newcomers, experts, and those in-between, to help us all improve documentation practice and become better writers.</p>
+          <p>If you're a newcomer, we can provide help, advice, mentorship, and a hundred different tasks to get started on. If you're an expert, we want to create a place to share knowledge, a place to get involved with new developments, and somewhere you can ask for help on your own projects.</p>
+          <p>A key aim of this initiative is to help lower the barrier into successful open-source software contribution, by making documentation into the gateway.</p>
+        </div>
+      </div>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="get-out-of-it" style="scroll-margin-top: 3.5rem;">What you'll get out of it</h2>
+        <div class="col-6 col-medium-4">
+          <p><strong>Real experience, real skills, real discipline</strong>: Open-source products in the Canonical/Ubuntu industry are highly-respected and used by millions of people. Standards for contributions are high. You'll have a chance to contribute to prestigious projects, and acquire the skills to take part in the development of world-class software.</p>
+          <p><strong>Structured support</strong>: The Open Documentation Academy will include a structured programme of support and development for serious participants, taking them from their first steps to having the confidence to lead their own documentation initiatives.</p>
+          <p><strong>Recognition</strong>: Your contributions will speak for themselves, but we'll vouch for you too. Participants who complete our programme will receive certification from Canonical.</p>
+        </div>
+      </div>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="what-we-offer" style="scroll-margin-top: 3.5rem;">What we offer</h2>
+        <div class="col-6 col-medium-4">
+          <p><strong>Mentoring</strong>: You are not alone. Regardless of whether you're writing your first document, or editing your hundredth, we're here to help. Our 1:1 mentorship can help you through your first contributions, provide advice on approaches, and help you build your confidence.</p>
+          <p><strong>Guided contributions</strong>: Help us identify gaps, nominate solutions, and propose documentation of your own. We curate tasks across a variety of different open source projects. Choose a task you're interested in, at a level you're comfortable with, and make a contribution. Research. Write. Commit. Fill blanks in your resume and colour your GitHub Activity tracker golden.</p>
+          <p><strong>Community</strong>: Through our forum and communication channels, you can directly interact with documentation teams and co-conspirators across the globe. We want our community to be friendly, inclusive and always supremely approachable, in accordance with the Ubuntu Code of Conduct.</p>
+        </div>
+      </div>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="what-you-will-do" style="scroll-margin-top: 3.5rem;">What you will do</h2>
+        <div class="col-6 col-medium-4">
+          <ul class="p-list--divided">
+            <li class="p-list__item">Participate in our forum, and join our Office Hours discussions</li>
+            <li class="p-list__item">Reach out to our team of mentors, let them know you're interested</li>
+            <li class="p-list__item">Find a project that excites you, and make your first contributions</li>
+          </ul>
+        </div>
+      </div>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="activities" style="scroll-margin-top: 3.5rem;">Activities</h2>
+        <div class="col-6 col-medium-4">
+          <p><strong>Podcast</strong> Take a well-earned tea-break and join our virtual documentation chatter. We record and publish the Open Documentation Academy podcast every other week. Each episode is a fun and fanatical chat about documentation, from process and personas to publishing and personality conflicts.</p>
+          <p><strong>Weekly Office Hours</strong> Every Thursday, join us for interactive discussions about tricky documentation problems and help us to improve documents together. This is the place to solicit feedback from the team, and to share your docs struggles and accomplishments. Everyone is welcome, whether you participate or prefer to listen.</p>
+          <p><strong>Events</strong> We're planning to host both online and in-person events enabling us all to target specific objectives together. These targets may include improving sets of documentation, creating guides and tutorials, or just discussing and agreeing on a style guide.</p>
+        </div>
+      </div>
+      <hr class="p-rule">
+      <div class="row p-block">
+        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="stay-in-touch" style="scroll-margin-top: 3.5rem;">Stay in touch</h2>
+        <div class="col-6 col-medium-4">
+          <ul class="p-list--divided">
+            <li class="p-list__item">Subscribe to our calendar:  Open Documentation Academy events</li>
+            <li class="p-list__item"><a href="https://discourse.ubuntu.com/c/open-documentation-academy">Join our discussion forum on the Ubuntu Community Hub</a></li>
+            <li class="p-list__item"><a href="https://fosstodon.org/@CanonicalDocumentation">Follow our progress online through Mastodon</a></li>
+            <li class="p-list__item">Email our academy leadership team directly: <a href="mailto:opendocsacademy@canonical.com">opendocsacademy@canonical.com</a></li>
+          </ul>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+{% endblock documentation_content %}
+

--- a/templates/documentation/open-documentation-academy.html
+++ b/templates/documentation/open-documentation-academy.html
@@ -88,9 +88,9 @@
       <div class="row p-block">
         <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="activities" style="scroll-margin-top: 3.5rem;">Activities</h2>
         <div class="col-6 col-medium-4">
-          <p><strong>Podcast</strong> Take a well-earned tea-break and join our virtual documentation chatter. We record and publish the Open Documentation Academy podcast every other week. Each episode is a fun and fanatical chat about documentation, from process and personas to publishing and personality conflicts.</p>
-          <p><strong>Weekly Office Hours</strong> Every Thursday, join us for interactive discussions about tricky documentation problems and help us to improve documents together. This is the place to solicit feedback from the team, and to share your docs struggles and accomplishments. Everyone is welcome, whether you participate or prefer to listen.</p>
-          <p><strong>Events</strong> We're planning to host both online and in-person events enabling us all to target specific objectives together. These targets may include improving sets of documentation, creating guides and tutorials, or just discussing and agreeing on a style guide.</p>
+          <p><strong>Podcast</strong>: Take a well-earned tea-break and join our virtual documentation chatter. We record and publish the Open Documentation Academy podcast every other week. Each episode is a fun and fanatical chat about documentation, from process and personas to publishing and personality conflicts.</p>
+          <p><strong>Weekly Office Hours</strong>: Every Thursday, join us for interactive discussions about tricky documentation problems and help us to improve documents together. This is the place to solicit feedback from the team, and to share your docs struggles and accomplishments. Everyone is welcome, whether you participate or prefer to listen.</p>
+          <p><strong>Events</strong>: We're planning to host both online and in-person events enabling us all to target specific objectives together. These targets may include improving sets of documentation, creating guides and tutorials, or just discussing and agreeing on a style guide.</p>
         </div>
       </div>
       <hr class="p-rule">


### PR DESCRIPTION
## Done

Add the Open Documentation Academy page

## QA

- Open the demo
- Go to /documentation/open-documentation-academy
- Ensure the content matches [the copy doc](https://docs.google.com/document/d/1nhy653-SOfTmGCIiSZHuGBCrwZlzEZJaA4kFBsw-5dc/edit)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6868

