### PR TITLE
Fix application job post id

### DIFF
--- a/templates/careers/base_job-details.html
+++ b/templates/careers/base_job-details.html
@@ -10,7 +10,7 @@
     <div class="col-6" style="position: relative">
       <div style="position: sticky; top: 65px">
         <h1 class="p-heading--2">{{ job.title }}</h1>
-        <p class="p-muted-heading">{{ job.location }}</p>
+        <p class="p-muted-heading">{{ job.location.name }}</p>
       </div>
     </div>
     <div class="col-6">
@@ -21,7 +21,7 @@
     <div class="col-6 col-start-large-4 p-strip u-no-padding--top">
       <div class="p-strip u-no-padding--top">
         <h1 class="p-heading--2">{{ job.title }}</h1>
-        <p class="p-muted-heading">{{ job.location }}</p>
+        <p class="p-muted-heading">{{ job.location.name }}</p>
       </div>
       {% block application_content %}{% endblock %}
     </div>

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -28,7 +28,7 @@
     {% endif %}
     {% if job.is_remote %}
     "jobLocationType": "TELECOMMUTE",
-    "applicantLocationRequirements": {{ job.location | job_location_countries | tojson}},
+    "applicantLocationRequirements": {{ job.location | job_location_countries | tojson }},
     {% else %}
     "jobLocation": {
       "@type": "Place",
@@ -65,7 +65,11 @@
     <div class="job-desc">
       {{ job.content | filtered_html_tags | safe }}
     </div>
-    <p class="p-button--positive" id="apply-button">Apply</p>
+    {% if job.active %}
+      <button class="p-button--positive" id="apply-button">Apply</button>
+    {% else %}
+      <button class="p-button--positive" disabled="">No longer accepting applications</button>
+    {% endif %}
   </div>
 </div>
 {% endblock %}
@@ -86,32 +90,32 @@
         <input type="hidden" name="id" value="{{ job.id }}" />
         {% if job.questions %}
           {% for question in job.questions %}
-          <label for="{{ question.fields[0].name }}" class="{% if question.required %}is-required{% endif %}">{{ question.label }}</label>
-            {% if question.fields[0].type == "input_text" %}
-            <input id="{{ question.fields[0].name }}" name="{{ question.fields[0].name }}" {% if question.description %}aria-describedby="{{ question.fields[0].name }}_help"{% endif %} type="text" {% if question.required %}required{% endif %} maxlength="255">
-            {% if question.description %}<p class="p-form-help-text" id="{{ question.fields[0].name }}_help">{{ question.description | safe }}</p>{% endif %}
-            {% elif question.fields[0].type == "input_file" %}
-            <input id="{{ question.fields[0].name }}" name="{{ question.fields[0].name }}" {% if question.description %}aria-describedby="{{ question.fields[0].name }}_help"{% endif %} type="file" {% if question.required %}required{% endif %} accept=".pdf, .doc, .docx, .txt, .rtf">
-            {% if question.description %}<p class="p-form-help-text" id="{{ question.fields[0].name }}_help">{{ question.description | safe }}</p>{% endif %}
-            {% elif question.fields[0].type == "textarea" %}
-            <textarea id="{{ question.fields[0].name }}" name="{{ question.fields[0].name }}" {% if question.description %}aria-describedby="{{ question.fields[0].name }}_help"{% endif %} type="textarea" {% if question.required %}required{% endif %}></textarea>
-            {% if question.description %}<p class="p-form-help-text" id="{{ question.fields[0].name }}_help">{{ question.description | safe }}</p>{% endif %}
-            {% elif question.fields[0].type == "multi_value_single_select" %}
-            <select name="{{ question.fields[0].name }}" id="{{ question.fields[0].name }}" {% if question.description %}aria-describedby="{{ question.fields[0].name }}_help"{% endif %} {% if question.required %}required{% endif %}>
+          <label for="{{ question.name }}" class="{% if question.required %}is-required{% endif %}">{{ question.label }}</label>
+            {% if question.type == "short_text" %}
+            <input id="{{ question.name }}" name="{{ question.name }}" {% if question.description %}aria-describedby="{{ question.name }}_help"{% endif %} type="text" {% if question.required %}required{% endif %} maxlength="255">
+            {% if question.description %}<p class="p-form-help-text" id="{{ question.name }}_help">{{ question.description | safe }}</p>{% endif %}
+            {% elif question.type == "attachment" %}
+            <input id="{{ question.name }}" name="{{ question.name }}" {% if question.description %}aria-describedby="{{ question.name }}_help"{% endif %} type="file" {% if question.required %}required{% endif %} accept=".pdf, .doc, .docx, .txt, .rtf">
+            {% if question.description %}<p class="p-form-help-text" id="{{ question.name }}_help">{{ question.description | safe }}</p>{% endif %}
+            {% elif question.type == "long_text" %}
+            <textarea id="{{ question.name }}" name="{{ question.name }}" {% if question.description %}aria-describedby="{{ question.name }}_help"{% endif %} type="textarea" {% if question.required %}required{% endif %}></textarea>
+            {% if question.description %}<p class="p-form-help-text" id="{{ question.name }}_help">{{ question.description | safe }}</p>{% endif %}
+            {% elif question.type == "single_select" or question.type == "boolean" %}
+            <select name="{{ question.name }}" id="{{ question.name }}" {% if question.description %}aria-describedby="{{ question.name }}_help"{% endif %} {% if question.required %}required{% endif %}>
               <option value="" disabled="disabled" selected="">Select an option</option>
-              {% for answer_option in question.fields[0].get("values",[])|reverse %}
+              {% for answer_option in question.get("values",[])|reverse %}
               <option value="{{ answer_option.value }}">{{ answer_option.label }}</option>
               {% endfor %}
             </select>
-            {% if question.description %}<p class="p-form-help-text" id="{{ question.fields[0].name }}_help">{{ question.description | safe }}</p>{% endif %}
-            {% elif question.fields[0].type == "multi_value_multi_select" %}
-            <select name="{{ question.fields[0].name }}" id="{{ question.fields[0].name }}" {% if question.description %}aria-describedby="{{ question.fields[0].name }}_help"{% endif %} multiple="" {% if question.required %}required{% endif %}>
+            {% if question.description %}<p class="p-form-help-text" id="{{ question.name }}_help">{{ question.description | safe }}</p>{% endif %}
+            {% elif question.type == "multi_value_multi_select" %}
+            <select name="{{ question.name }}" id="{{ question.name }}" {% if question.description %}aria-describedby="{{ question.name }}_help"{% endif %} multiple="" {% if question.required %}required{% endif %}>
               <option value="" disabled="disabled">Select...</option>
-              {% for answer_option in question.fields[0].get("values",[]) %}
+              {% for answer_option in question.get("values",[]) %}
               <option value="{{ answer_option.value }}">{{ answer_option.label }}</option>
               {% endfor %}
             </select>
-            {% if question.description %}<p class="p-form-help-text" id="{{ question.fields[0].name }}_help">{{ question.description | safe }}</p>{% endif %}
+            {% if question.description %}<p class="p-form-help-text" id="{{ question.name }}_help">{{ question.description | safe }}</p>{% endif %}
             {% endif %}
           {% endfor %}
         {% endif %}

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -107,7 +107,7 @@
               <option value="{{ answer_option.value }}">{{ answer_option.label }}</option>
               {% endfor %}
             </select>
-            {% if question.description %}<p class="p-form-help-text" id="{{ question.name }}_help">{{ question.description | safe }}</p>{% endif %}
+            {% if question.description %}<p class="p-form-help-text" id="{{ question.name }}_help">{{ question.description | striptags }}</p>{% endif %}
             {% elif question.type == "multi_value_multi_select" %}
             <select name="{{ question.name }}" id="{{ question.name }}" {% if question.description %}aria-describedby="{{ question.name }}_help"{% endif %} multiple="" {% if question.required %}required{% endif %}>
               <option value="" disabled="disabled">Select...</option>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -263,15 +263,16 @@ def job_details(job_id, job_title):
     context = {"bleach": bleach}
 
     try:
-        context["job"] = greenhouse.get_vacancy(job_id)
+        # Greenhouse job board API (get_vacancy) doesn't show inactive roles
+        context["job"] = harvest.get_job_post(job_id)
     except HTTPError as error:
         if error.response.status_code == 404:
             flask.abort(404)
         else:
             raise error
 
-    if not context["job"]:
-        flask.abort(404)
+    if "job" not in context:
+        return flask.abort(404)
 
     if flask.request.method == "POST":
         response = greenhouse.submit_application(


### PR DESCRIPTION
## Done

Fix [Jira ticket](https://warthogs.atlassian.net/browse/WD-6775) /careers/5172749

Swapped the Greenhouse job-boards API endpoint with Harvest API job post endpoint. The GH job boards API doesn't return job posts that have been flagged `inactive` or `not live`

Most of the files changed are due to the different data structure that this API returns, but the data seems to match.

## QA

- Go to https://canonical-com-1100.demos.haus/careers/5172749 should work now
- Button to apply should not show on the page (the harvest endpoint will return 401 upon submission of application)

Regression check:

- Go to e.g. https://canonical-com-1100.demos.haus/careers/4417916
- Click "Apply now" and fill out the application
- Go to Greenhouse and check that the application submitted successfully and correctly (check for missing fields, content submitted in the wrong fields etc, it's a bit hard for me to map the data without seeing the final result in greenhouse).

- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6775
