### PR TITLE
Add microcloud subnav and form

### DIFF
--- a/static/sass/_pattern_global-nav.scss
+++ b/static/sass/_pattern_global-nav.scss
@@ -95,7 +95,7 @@
     padding-bottom: 0.5rem;
   }
 
-  .microsite-menu {
+  .data-fabric-menu {
     padding-left: 0;
     padding-right: 0;
 
@@ -111,5 +111,9 @@
 
   #all-canonical-desktop {
     background-color: $color-dark;
+  }
+
+  .microcloud-menu {
+    padding-left: 0;
   }
 }

--- a/static/sass/_pattern_global-nav.scss
+++ b/static/sass/_pattern_global-nav.scss
@@ -95,7 +95,7 @@
     padding-bottom: 0.5rem;
   }
 
-  .data-fabric-menu {
+  .microsite-menu {
     padding-left: 0;
     padding-right: 0;
 

--- a/templates/microcloud/contact-us.html
+++ b/templates/microcloud/contact-us.html
@@ -140,7 +140,8 @@
 
             <!-- hidden fields -->
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="4271" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical.com/microcloud" />
+            <!-- This return URL link is temporary, will be updated once demo is approved -->
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical-com-1102.demos.haus/microcloud/thank-you" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="acquisition_url" id="acquisition_url" value="{{ request.url }}" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="acquisition_url" id="acquisition_url" value="{{ request.url }}" />

--- a/templates/microcloud/contact-us.html
+++ b/templates/microcloud/contact-us.html
@@ -124,7 +124,7 @@
               </li>
               <li class="p-list__item">
                 <label for="phone" class="is-required">Phone number</label>
-                <input class="p-form-validation__input" required="" id="phone" name="phone" maxlength="255" type="tel" />
+                <input class="p-form-validation__input" required="" id="phone" name="phone" maxlength="255" type="tel" pattern="[0-9\s]+" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/microcloud/contact-us.html
+++ b/templates/microcloud/contact-us.html
@@ -144,7 +144,6 @@
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical-com-1102.demos.haus/microcloud/thank-you" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="acquisition_url" id="acquisition_url" value="{{ request.url }}" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="acquisition_url" id="acquisition_url" value="{{ request.url }}" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/microcloud/contact-us.html
+++ b/templates/microcloud/contact-us.html
@@ -131,9 +131,9 @@
                   <input type="checkbox" aria-labelledby="canonicalUpdatesOptIn" class="p-checkbox__input" value="yes">
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
-                <p style="padding-left: 2rem;">By submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.</p>
               </li>
             </ul>
+            <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.</p>
             
             <hr />
             <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit form</button>

--- a/templates/microcloud/contact-us.html
+++ b/templates/microcloud/contact-us.html
@@ -1,10 +1,8 @@
 {% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1gIqyGENG6YQm0OH7WIS893stAzWZukfCtFD05bHr4pY/edit{% endblock %}
 
 {% block title %}Contact us{% endblock %}
-
-{% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
 
 {% block body_class %}is-paper{% endblock body_class %}
 

--- a/templates/microcloud/contact-us.html
+++ b/templates/microcloud/contact-us.html
@@ -104,7 +104,7 @@
     <div class="col">
       <div class="row">
         <div class="col-6">
-          <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_5364">
+          <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_4271">
             <p>Tell us about your MicroCloud use case</p>
             <ul class="p-list">
               <li class="p-list__item">
@@ -140,8 +140,16 @@
 
             <!-- hidden fields -->
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="4271" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://microk8s.io/thank-you" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical.com/microcloud" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="acquisition_url" id="acquisition_url" value="{{ request.url }}" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="acquisition_url" id="acquisition_url" value="{{ request.url }}" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
           </form>
         </div>
       </div>

--- a/templates/microcloud/contact-us.html
+++ b/templates/microcloud/contact-us.html
@@ -1,0 +1,155 @@
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
+
+{% block title %}Contact us{% endblock %}
+
+{% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
+
+{% block body_class %}is-paper{% endblock body_class %}
+
+{% block content %}
+
+<section class="p-strip is-shallow u-no-padding--bottom">
+  <div class="p-section--deep">
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        <h1>Contact us</h1>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="row--25-75 is-split-on-medium">
+    <hr class="p-rule">
+    <div class="col">
+      <h2 class="p-text--small-caps">Call us</h2>
+    </div>
+    <div class="col">
+      <div class="row">
+        <div class="col-6">
+          <ul class="p-list--divided">
+            <li class="p-list__item u-no-padding--bottom">
+              <div class="row">
+                <div class="col-3">
+                  Americas
+                </div>
+                <div class="col-3">
+                  <a href="tel:+17372040291">+1 737 204 0291</a>
+                </div>
+              </div>
+            </li>
+            <li class="p-list__item u-no-padding--bottom">
+              <div class="row">
+                <div class="col-3">
+                  France
+                </div>
+                <div class="col-3">
+                  <a href="tel:+33184889319">+33 18 48 89 319</a>
+                </div>
+              </div>
+            </li>
+            <li class="p-list__item u-no-padding--bottom">
+              <div class="row">
+                <div class="col-3">
+                  Germany
+                </div>
+                <div class="col-3">
+                  <a href="tel:+4961512746816">+49 615 127 46816</a>
+                </div>
+              </div>
+            </li>
+            <li class="p-list__item u-no-padding--bottom">
+              <div class="row">
+                <div class="col-3">
+                  Japan
+                </div>
+                <div class="col-3">
+                  <a href="tel:+81362053075">+81 3 6205 3075</a>
+                </div>
+              </div>
+            </li>
+            <li class="p-list__item u-no-padding--bottom">
+              <div class="row">
+                <div class="col-3">
+                  Spain
+                </div>
+                <div class="col-3">
+                  <a href="tel:+34932201131">+34 932 201131</a>
+                </div>
+              </div>
+            </li>
+            <li class="p-list__item u-no-padding--bottom">
+              <div class="row">
+                <div class="col-3">
+                  UK and rest of the world
+                </div>
+                <div class="col-3">
+                  <a href="tel:+442036565291">+44 203 656 5291</a>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="row--25-75 is-split-on-medium">
+    <hr class="p-rule">
+    <div class="col">
+      <h2 class="p-text--small-caps">Submit a question</h2>
+    </div>
+    <div class="col">
+      <div class="row">
+        <div class="col-6">
+          <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_5364">
+            <p>Tell us about your MicroCloud use case</p>
+            <ul class="p-list">
+              <li class="p-list__item">
+                <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" maxlength="2000"></textarea>
+              </li>
+              <li class="p-list__item">
+                <label for="firstName" class="is-required">First name</label>
+                <input class="p-form-validation__input" required="" id="firstName" name="firstName" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
+                <label for="lastName" class="is-required">Last name</label>
+                <input class="p-form-validation__input" required="" id="lastName" name="lastName" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
+                <label for="email" class="is-required">Email</label>
+                <input class="p-form-validation__input" required="" id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+              </li>
+              <li class="p-list__item">
+                <label for="phone" class="is-required">Phone number</label>
+                <input class="p-form-validation__input" required="" id="phone" name="phone" maxlength="255" type="tel" />
+              </li>
+              <li class="p-list__item">
+                <label class="p-checkbox">
+                  <input type="checkbox" aria-labelledby="canonicalUpdatesOptIn" class="p-checkbox__input" value="yes">
+                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+                </label>
+                <p style="padding-left: 2rem;">By submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.</p>
+              </li>
+            </ul>
+            
+            <hr />
+            <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit form</button>
+
+            <!-- hidden fields -->
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="4271" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://microk8s.io/thank-you" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+{% endblock %}

--- a/templates/microcloud/thank-you.html
+++ b/templates/microcloud/thank-you.html
@@ -1,0 +1,18 @@
+{% extends 'base_index.html' %}
+
+{% block title %}MicroCloud &ndash; Thank you{% endblock %}
+
+{% block body_class %}is-paper{% endblock body_class %}
+
+{% block content %}
+<section class="p-strip--whitesuru is-deep">
+  <div class="p-section">
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        <h1>Thank you for contacting us about MicroCloud.</h1>
+        <h2>A member of our team wil be in touch within one working day.</h2>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/partial/_data-navigation.html
+++ b/templates/partial/_data-navigation.html
@@ -12,7 +12,7 @@
   </div>
 </div>
 <header id="navigation" class="p-navigation is-dark" style="z-index: 9;">
-  <div class="row microsite-menu">
+  <div class="row data-fabric-menu">
     <div class="p-navigation__banner col-3">
       <div class="p-navigation__tagged-logo">
         <a class="p-navigation__link" href="/data">

--- a/templates/partial/_microcloud-navigation.html
+++ b/templates/partial/_microcloud-navigation.html
@@ -15,11 +15,11 @@
   <div class="row microsite-menu">
     <div class="p-navigation__banner col-3">
       <div class="p-navigation__tagged-logo">
-        <a class="p-navigation__link" href="/data">
+        <a class="p-navigation__link" href="/microcloud">
           <div class="p-navigation__logo-tag">
             <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="Canonical" width="95" />
           </div>
-          <span class="p-navigation__logo-title">Data Fabric</span>
+          <span class="p-navigation__logo-title">MicroCloud</span>
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="Toggle navigation"><i class="p-icon--chevron-down is-light"></i></a>
@@ -29,19 +29,10 @@
     <nav class="p-navigation__nav col-9" aria-label="Main navigation">
       <ul class="p-navigation__items">
         <li class="p-navigation__item">
-          <a href="/data/mongodb" class="p-navigation__link">MongoDB</a>
+          <a href="/microcloud/resources" class="p-navigation__link">Resources</a>
         </li>
         <li class="p-navigation__item">
-          <a href="/data/spark" class="p-navigation__link">Spark</a>
-        </li>
-        <li class="p-navigation__item">
-          <a href="/data/kafka" class="p-navigation__link">Kafka</a>
-        </li>
-        <li class="p-navigation__item">
-          <a href="/data/opensearch" class="p-navigation__link">OpenSearch</a>
-        </li>
-        <li class="p-navigation__item">
-          <a href="/data/docs" class="p-navigation__link">Docs</a>
+          <a href="https://canonical-microcloud.readthedocs-hosted.com/en/latest/" class="p-navigation__link">Docs</a>
         </li>
       </ul>
     </nav>

--- a/templates/partial/_microcloud-navigation.html
+++ b/templates/partial/_microcloud-navigation.html
@@ -1,17 +1,4 @@
-<div id="g-navigation" class="p-navigation is-dark">
-  <div class="p-navigation__row global-nav-row">
-    <div class="p-navigation__banner">
-      <a class="p-navigation__item p-global-nav-anchors" href="/">Canonical</a>
-      <a href="#g-navigation" class="p-navigation__toggle--open p-global-nav-anchors" title="menu">Menu</a>
-      <a href="#g-navigation-closed" class="p-navigation__toggle--close p-global-nav-anchors" title="close menu">Close menu</a>
-    </div>
-    <nav class="p-navigation__nav">
-      <ul class="p-navigation__items"></ul>
-      <ul class="p-navigation__items global-nav"></ul>
-    </nav>
-  </div>
-</div>
-<header id="navigation" class="p-navigation is-dark" style="z-index: 9;">
+<header id="navigation" class="p-navigation is-dark">
   <div class="row microsite-menu">
     <div class="p-navigation__banner col-3">
       <div class="p-navigation__tagged-logo">
@@ -28,16 +15,17 @@
 
     <nav class="p-navigation__nav col-9" aria-label="Main navigation">
       <ul class="p-navigation__items">
-        <li class="p-navigation__item">
+        <li class="p-navigation__item {% if '/resources' in request.path %}is-selected{% endif %}">
           <a href="/microcloud/resources" class="p-navigation__link">Resources</a>
         </li>
-        <li class="p-navigation__item">
+        <li class="p-navigation__item {% if '/roadshow' in request.path %}is-selected{% endif %}">
           <a href="/microcloud/roadshow" class="p-navigation__link">Roadshow</a>
         </li>
         <li class="p-navigation__item">
           <a href="https://canonical-microcloud.readthedocs-hosted.com/en/latest/" class="p-navigation__link">Docs</a>
         </li>
       </ul>
+      <ul class="p-navigation__items global-nav"></ul>
     </nav>
   </div>
 </header>

--- a/templates/partial/_microcloud-navigation.html
+++ b/templates/partial/_microcloud-navigation.html
@@ -32,6 +32,9 @@
           <a href="/microcloud/resources" class="p-navigation__link">Resources</a>
         </li>
         <li class="p-navigation__item">
+          <a href="/microcloud/roadshow" class="p-navigation__link">Roadshow</a>
+        </li>
+        <li class="p-navigation__item">
           <a href="https://canonical-microcloud.readthedocs-hosted.com/en/latest/" class="p-navigation__link">Docs</a>
         </li>
       </ul>

--- a/templates/partial/_microcloud-navigation.html
+++ b/templates/partial/_microcloud-navigation.html
@@ -1,5 +1,5 @@
 <header id="navigation" class="p-navigation is-dark">
-  <div class="row microsite-menu">
+  <div class="row microcloud-menu">
     <div class="p-navigation__banner col-3">
       <div class="p-navigation__tagged-logo">
         <a class="p-navigation__link" href="/microcloud">
@@ -9,7 +9,7 @@
           <span class="p-navigation__logo-title">MicroCloud</span>
         </a>
       </div>
-      <a href="#navigation" class="p-navigation__toggle--open" title="Toggle navigation"><i class="p-icon--chevron-down is-light"></i></a>
+      <a href="#navigation" class="p-navigation__toggle--open" title="Toggle navigation">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="Close menu">Close menu</a>
     </div>
 

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -2,6 +2,8 @@
 
   {% if request.path|get_nav_path == "data" %}
     {% include "partial/_data-navigation.html" %}
+  {% elif request.path|get_nav_path == "microcloud" %}
+    {% include "partial/_microcloud-navigation.html" %}
   {% else %}
     {% include "partial/_standard-navigation.html" %}
   {% endif %}


### PR DESCRIPTION
## Done

- Added form as per [doc](https://docs.google.com/document/d/1gIqyGENG6YQm0OH7WIS893stAzWZukfCtFD05bHr4pY/edit) and [design](https://www.figma.com/file/hzQYJM9Tui4wpmyZC0k0WS/23.10-C.com---MicroCloud-Rebranding?node-id=4%3A5822&mode=dev)
- Added subnav (no design provided)
  - Drive by: slight class rename to make clear that the subnav styles are reusable and not just for one microsite 

**NOTE: Resource tab will 404 as that page hasn't been merged into the feature branch yet**


## QA

- View the site locally in your web browser at: https://canonical-com-1102.demos.haus/microcloud/contact-us
- Check against doc and design
- Click through the subnav and ensure that everything works as expected (again, /resources will 404 until https://github.com/canonical/canonical.com/pull/1097 is merged)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6694 , https://warthogs.atlassian.net/browse/WD-6840, https://warthogs.atlassian.net/browse/WD-7124