### PR TITLE
Add modal and apply minor design updates to landing page

### DIFF
--- a/templates/microcloud/_microcloud-modal.html
+++ b/templates/microcloud/_microcloud-modal.html
@@ -1,0 +1,79 @@
+<div class="p-modal" style="display: none;" id="microcloud-modal">
+  <div class="p-modal__dialog is-paper " role="dialog">
+    <div class="js-pagination js-pagination--1">
+      <div class="js-formfield">
+      <div class="row--50-50 p-strip is-shallow">
+        <div class="col">
+          <h2 class="p-heading--1">Let's get in touch</h2>
+        </div>
+        <div class="col">
+          <button class="p-modal__close p-modal-close-button " aria-controls="microcloud-modal" aria-label="Close active modal" style="margin-top: 0;">Close</button>
+          <form action="https://ubuntu.com/marketo/submit" method="post" class="modal-form">
+            <div class="p-section--shallow">
+              <label for="Comments_from_lead__c">Please briefly tell us about your use case</label>
+              <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" maxlength="2000" placeholder="Anything you'd like to communicate about your needs or interests?"></textarea>
+            </div>
+            <div class="p-section--shallow">
+              <hr class="p-rule">
+              <p>How should we get in touch?</p>
+              <label for="firstName">First name:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text"/>
+
+              <label for="lastName">Last name:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text"/>
+
+              <label for="company">Company:</label>
+              <input required id="company" name="company" maxlength="255" type="text"/>
+
+              <label for="company">Title:</label>
+              <input required id="title" name="title" maxlength="255" type="text"/>
+
+              <label for="email">Email:</label>
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
+
+              <label for="phone">Phone number:</label>
+              <input id="phone" name="phone" maxlength="255" type="tel" pattern="[0-9\s]+" />
+                <p class="p-form-help-text" id="exampleHelpTextMessage">Format: only numbers</p>
+            </div>
+              <div class="p-section--shallow">
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+                </label>
+              </div>
+            <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</div>
+            {# These are honey pot fields to catch bots #}
+            <div class="u-off-screen">
+              <label class="website" for="website">Website:</label>
+              <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+            </div>
+            <div class="u-off-screen">
+              <label class="name" for="name">Name:</label>
+              <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+            </div>
+            {# End of honey pots #}
+
+            <div class="u-hide">
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="4271" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="acquisition_url" id="acquisition_url" value="{{ request.url }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
+            </div>
+
+            <div class="pagination">
+              <hr>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Submit</button>
+            </div>
+          </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/microcloud/index.html
+++ b/templates/microcloud/index.html
@@ -21,7 +21,8 @@
           <p>Straightforward and lightweight, but featureful.<br aria-hidden="true"/>MicroClouds serve compute near consumers, wherever they may be.</p>
         </div>
         <hr>
-        <a class="p-button--positive">Get in touch</a>
+        <a class="p-button--positive"href="/contact-us" aria-controls="microcloud-modal">Get in touch</a>
+        <br class="u-hide--medium u-hide--large" aria-hidden="true"/>
         <a href="https://ubuntu.com/engage/guide-to-micro-clouds">Read our guide to MicroCloud</a>
       </div>
     </div>
@@ -50,11 +51,15 @@
   <div class="u-fixed-width">
     <hr class="p-rule"/>
     <h2>Deploy a fully functional cloud in minutes:</h2>
-    <div class="row-cli__commands" aria-hidden="true">
+    <div class="row-cli__commands u-hide--small" aria-hidden="true">
       <p class="p-heading--2 u-no-padding--top u-no-margin--bottom" style="display: inline-block;">$ </p>
       <span class="row-cli__commands-list typer" id="main"
       data-words="snap install microcloud lxd microceph microovn,microcloud init"
       data-delay="50" data-deletedelay="5000" data-colors="#111111">snap install mic</span>
+    </div>
+    <div class="p-code-snippet u-hide--large u-hide--medium">
+      <pre class="p-code-snippet__block--icon is-wrapped"><code>snap install microcloud lxd microceph microovn</code></pre>
+       <pre class="p-code-snippet__block--icon is-wrapped"><code>microcloud init</code></pre>
     </div>
   </div>
 </section>
@@ -62,7 +67,7 @@
 <section class="p-section">
   <div class="row">
     <div class="col-start-large-4 col-9 col-medium-6">
-        <div class="row">
+        <div class="row u-hide--small">
           <div class="col-3 col-medium-2 p-section--shallow">
             {{ 
               image (
@@ -435,9 +440,16 @@
     <div class="p-section--shallow">
       <h2>MicroClouds are low-touch, efficient and reliable.<br aria-hidden="true"/> Do you have a use case in mind? Get in touch with our team.</h2>
     </div>
-        <a class="p-button--positive">Talk to an expert</a>
+        <a class="p-button--positive" href="/microcloud/contact-us">Talk to an expert</a>
     </div>
 </section>
 
 <script src="/static/js/typer.js" defer></script>
+<script src="{{ versioned_static('js/modals.js') }}"></script>
+
+{% with %}
+	{% set returnURL = "https://canonical.com/microcloud#success" %}
+	{% include "microcloud/_microcloud-modal.html" %}
+{% endwith %}
+
 {% endblock content %}

--- a/templates/microcloud/index.html
+++ b/templates/microcloud/index.html
@@ -30,7 +30,7 @@
 </section>
 
 <section class="p-section">
-  <div class="row--25-75">
+  <div class="row--25-75 is-split-on-medium">
     <hr class="p-rule"/>
     <div class="col">
       <h2>What is a MicroCloud?</h2>
@@ -51,13 +51,13 @@
   <div class="u-fixed-width">
     <hr class="p-rule"/>
     <h2>Deploy a fully functional cloud in minutes:</h2>
-    <div class="row-cli__commands u-hide--small" aria-hidden="true">
+    <div class="row-cli__commands u-hide--medium u-hide--small" aria-hidden="true">
       <p class="p-heading--2 u-no-padding--top u-no-margin--bottom" style="display: inline-block;">$ </p>
       <span class="row-cli__commands-list typer" id="main"
       data-words="snap install microcloud lxd microceph microovn,microcloud init"
       data-delay="50" data-deletedelay="5000" data-colors="#111111">snap install mic</span>
     </div>
-    <div class="p-code-snippet u-hide--large u-hide--medium">
+    <div class="p-code-snippet u-hide--large">
       <pre class="p-code-snippet__block--icon is-wrapped"><code>snap install microcloud lxd microceph microovn</code></pre>
        <pre class="p-code-snippet__block--icon is-wrapped"><code>microcloud init</code></pre>
     </div>


### PR DESCRIPTION
## Done

- Added microcloud modal and applied design suggestions as noted [here](https://github.com/canonical/canonical.com/pull/1103#issuecomment-1792155801)

## QA

- View the site locally in your web browser at: https://canonical-com-1109.demos.haus/microcloud
- See that the requested changes linked above were made
- Click on the modal CTA ("Get in touch" button in hero) 
  - There are 2 other CTAs on this page which will not work until https://github.com/canonical/canonical.com/pull/1102 is merged
- No doc or design, should match [current canonical modal style](https://canonical.com/data/mongodb) and [microcloud live modal copy](https://microcloud.is/#get-in-touch)


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6693
