### PR TITLE
fix(microcloud) two typos in roadshow page ("MicroCoud" -> "MicroCloud")

### DIFF
--- a/templates/microcloud/roadshow.html
+++ b/templates/microcloud/roadshow.html
@@ -16,7 +16,7 @@
       </div>
     </div>
     <div class="col-6 col-medium-3">
-      <p>Deploying your own cloud typically involves significant investments &ndash; in terms of costs, time and skills. MicroClouds help minimise these investments by providing you with a cost-effective open source cloud that deploys in minutes and is easy to operate and maintain. Join us on the roadshow to see it in action and discover how you can benefit by using MicroCoud.</p>
+      <p>Deploying your own cloud typically involves significant investments &ndash; in terms of costs, time and skills. MicroClouds help minimise these investments by providing you with a cost-effective open source cloud that deploys in minutes and is easy to operate and maintain. Join us on the roadshow to see it in action and discover how you can benefit by using MicroCloud.</p>
       <p class="u-no-margin--bottom">
         <a href="#find-us" class="p-button--positive u-no-margin--bottom">Check where to find us</a>
       </p>
@@ -216,7 +216,7 @@
       <div class="p-block">
         <p class="p-text--small-caps u-no-margin--bottom">Whitepaper</p>
         <h3 class="p-heading--2 u-no-padding--top">
-          <a href="https://ubuntu.com/engage/guide-to-micro-clouds">CTO's guide to MicroCouds</a>
+          <a href="https://ubuntu.com/engage/guide-to-micro-clouds">CTO's guide to MicroClouds</a>
         </h3>
       </div>
       <hr class="p-rule" />


### PR DESCRIPTION
## Done

- Fixed two "MicroCoud" typos in roadshow page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Go to `/microcloud/roadshow` - [DEMO LINK](https://canonical-com-1116.demos.haus/microcloud/roadshow)
- Check that there are no more "MicroCoud" typos