### PR TITLE
Fix navigation by checking for .p-modal before toggling

### DIFF
--- a/templates/careers/application/index.html
+++ b/templates/careers/application/index.html
@@ -345,7 +345,7 @@
       @param {Boolean} open If defined as `true` modal will be opened, if `false` modal will be closed, undefined toggles current visibility.
     */
     function toggleModal(modal, sourceEl, open) {
-      if (modal) {
+      if (modal && modal.classList.contains("p-modal")) {
         if (typeof open === 'undefined') {
           open = modal.style.display === 'none';
         }


### PR DESCRIPTION
## Done

Fixed navigation on candidates application page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Visit the candidate's application page on `http://0.0.0.0:8002/careers/application/<application-id>` and test the navigation bar

## Issue / Card

Fixes #1024

