### PR TITLE
WD-7312 - open privacy policy in a new tab on careers

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -175,7 +175,7 @@
             </label>
             <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
             <p>
-              In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.
+              In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/newsletter" target="_blank">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a>.
             </p>
             <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
             <input value="1212" name="formid" type="hidden">

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -60,7 +60,7 @@
       </label>
       <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
       <p>
-        In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.
+        In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a>.
       </p>
 
       <div>

--- a/templates/careers/application/_activate-email.html
+++ b/templates/careers/application/_activate-email.html
@@ -6,5 +6,5 @@
   <p>We would like to take this opportunity to wish you the very best with your next career steps.</p>
   <p>Regards,</p>
   <p>{{ hiring_lead["name"] }}</p>
-  <p>For further information on data collection, please refer to our <a href="https://ubuntu.com/legal/data-privacy/recruitment">recruitment privacy notice</a> and <a href="https://ubuntu.com/legal/data-privacy">privacy policy</a>.</p>
+  <p>For further information on data collection, please refer to our <a href="https://ubuntu.com/legal/data-privacy/recruitment" target="_blank">recruitment privacy notice</a> and <a href="https://ubuntu.com/legal/data-privacy" target="_blank">privacy policy</a>.</p>
 </div>

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -120,7 +120,7 @@
           {% endfor %}
         {% endif %}
         <hr style="margin: 1rem 0;" />
-        <p>In submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/data-privacy/recruitment">Recruitment Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy/">Privacy Policy</a>.</p>
+        <p>In submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/data-privacy/recruitment" target="_blank">Recruitment Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy/" target="_blank">Privacy Policy</a>.</p>
         <input type="hidden" name="mapped_url_token" value="" id="ghsrc" />
         <input type="submit" class="p-button--positive u-no-margin--bottom" name="submit" value="Submit application">
       </fieldset>

--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -164,7 +164,7 @@
       <h2 class="p-muted-heading">Data Privacy enquiries</h2>
     </div>
     <div class="col-9 col-medium-4">
-      <p>For information about data privacy, please read our <a href="https://www.ubuntu.com/legal/data-privacy">Privacy Policy</a> or <a href="https://ubuntu.com/legal/data-privacy/enquiry">submit an enquiry</a>. A member of our data privacy team will be in touch with you shortly.</p>
+      <p>For information about data privacy, please read our <a href="https://www.ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a> or <a href="https://ubuntu.com/legal/data-privacy/enquiry">submit an enquiry</a>. A member of our data privacy team will be in touch with you shortly.</p>
     </div>
   </div>
 

--- a/templates/data/_data-form.html
+++ b/templates/data/_data-form.html
@@ -49,7 +49,7 @@
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
               </div>
-            <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</div>
+            <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact" target="_blank">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy" target="_blank">Privacy Policy</a>.</div>
             {# These are honey pot fields to catch bots #}
             <div class="u-off-screen">
               <label class="website" for="website">Website:</label>

--- a/templates/data/_data-form.html
+++ b/templates/data/_data-form.html
@@ -49,7 +49,7 @@
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
               </div>
-            <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact" target="_blank">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy" target="_blank">Privacy Policy</a>.</div>
+            <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact" target="_blank">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a>.</div>
             {# These are honey pot fields to catch bots #}
             <div class="u-off-screen">
               <label class="website" for="website">Website:</label>

--- a/templates/data/_form-data-kafka.html
+++ b/templates/data/_form-data-kafka.html
@@ -50,7 +50,7 @@
                       <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                     </label>
                   </li>
-                  <li class="p-list__item">In submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</li>
+                  <li class="p-list__item">In submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</li>
                   {# These are honey pot fields to catch bots #}
                   <li class="u-off-screen">
                     <label class="website" for="website">Website:</label>

--- a/templates/data/_form-data-kafka.html
+++ b/templates/data/_form-data-kafka.html
@@ -50,7 +50,7 @@
                       <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                     </label>
                   </li>
-                  <li class="p-list__item">In submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</li>
+                  <li class="p-list__item">In submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</li>
                   {# These are honey pot fields to catch bots #}
                   <li class="u-off-screen">
                     <label class="website" for="website">Website:</label>

--- a/templates/data/_form-data-mongodb.html
+++ b/templates/data/_form-data-mongodb.html
@@ -34,7 +34,7 @@
                   <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
-                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
+                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
               </div>
               {# These are honey pot fields to catch bots #}
               <div class="u-off-screen">

--- a/templates/data/_form-data-mongodb.html
+++ b/templates/data/_form-data-mongodb.html
@@ -34,7 +34,7 @@
                   <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
-                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</p>
+                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
               </div>
               {# These are honey pot fields to catch bots #}
               <div class="u-off-screen">

--- a/templates/data/_form-data-opensearch.html
+++ b/templates/data/_form-data-opensearch.html
@@ -30,7 +30,7 @@
                   <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
-                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
+                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
               </div>
               {# These are honey pot fields to catch bots #}
               <div class="u-off-screen">

--- a/templates/data/_form-data-opensearch.html
+++ b/templates/data/_form-data-opensearch.html
@@ -30,7 +30,7 @@
                   <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
-                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</p>
+                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
               </div>
               {# These are honey pot fields to catch bots #}
               <div class="u-off-screen">

--- a/templates/data/_form-data-relational-dbs.html
+++ b/templates/data/_form-data-relational-dbs.html
@@ -30,7 +30,7 @@
                   <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
-                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
+                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
               </div>
               {# These are honey pot fields to catch bots #}
               <div class="u-off-screen">

--- a/templates/data/_form-data-relational-dbs.html
+++ b/templates/data/_form-data-relational-dbs.html
@@ -30,7 +30,7 @@
                   <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
-                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</p>
+                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
               </div>
               {# These are honey pot fields to catch bots #}
               <div class="u-off-screen">

--- a/templates/data/_form-data-spark.html
+++ b/templates/data/_form-data-spark.html
@@ -30,7 +30,7 @@
                   <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
-                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
+                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
               </div>
               {# These are honey pot fields to catch bots #}
               <div class="u-off-screen">

--- a/templates/data/_form-data-spark.html
+++ b/templates/data/_form-data-spark.html
@@ -30,7 +30,7 @@
                   <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
-                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</p>
+                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
               </div>
               {# These are honey pot fields to catch bots #}
               <div class="u-off-screen">

--- a/templates/microcloud/_microcloud-modal.html
+++ b/templates/microcloud/_microcloud-modal.html
@@ -41,7 +41,7 @@
                     <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                   </label>
                 </div>
-              <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</div>
+              <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact" target="_blank">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy" target="_blank">Privacy Policy</a>.</div>
               {# These are honey pot fields to catch bots #}
               <div class="u-off-screen">
                 <label class="website" for="website">Website:</label>

--- a/templates/microcloud/_microcloud-modal.html
+++ b/templates/microcloud/_microcloud-modal.html
@@ -41,7 +41,7 @@
                     <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                   </label>
                 </div>
-              <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact" target="_blank">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy" target="_blank">Privacy Policy</a>.</div>
+              <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact" target="_blank">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a>.</div>
               {# These are honey pot fields to catch bots #}
               <div class="u-off-screen">
                 <label class="website" for="website">Website:</label>

--- a/templates/microcloud/contact-us.html
+++ b/templates/microcloud/contact-us.html
@@ -56,7 +56,7 @@
                 </label>
               </li>
             </ul>
-            <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.</p>
+            <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a>.</p>
             
             <hr />
             <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit form</button>

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -36,9 +36,9 @@
         For further information on data collection,<br>
         please refer to our 
         {% if "/careers" in current_path %}
-          <a href="https://ubuntu.com/legal/data-privacy/recruitment">recruitment privacy notice</a> and 
+          <a href="https://ubuntu.com/legal/data-privacy/recruitment" target="_blank">recruitment privacy notice</a> and 
         {% endif %}
-        <a href="https://ubuntu.com/legal/data-privacy">privacy policy</a>.
+        <a href="https://ubuntu.com/legal/data-privacy" target="_blank">privacy policy</a>.
       </p>
     </div>
   </div>

--- a/templates/partners/become-a-partner.html
+++ b/templates/partners/become-a-partner.html
@@ -383,7 +383,7 @@
             <span class="p-checkbox__label mktospan mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</span>
           </label>
         </div>
-        <p>In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/newsletter">Canonical’s Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.</p>
+        <p>In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/newsletter" target="_blank">Canonical’s Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a>.</p>
         <div class="mktField">
           <button type="submit" class="p-button--positive mktoButton">Apply now</button>
           <input type="hidden" name="formid" class="mktoField" value="1260">

--- a/templates/partners/partial/_executive-summit-form.html
+++ b/templates/partners/partial/_executive-summit-form.html
@@ -52,7 +52,7 @@
                     <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                   </label>
                 </li>
-                <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact" target="_blank">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy" target="_blank">Privacy Policy</a>.</li>
+                <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact" target="_blank">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a>.</li>
                 {# These are honey pot fields to catch bots #}
                 <li class="u-off-screen">
                   <label class="website" for="website">Website:</label>

--- a/templates/partners/partial/_executive-summit-form.html
+++ b/templates/partners/partial/_executive-summit-form.html
@@ -52,7 +52,7 @@
                     <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                   </label>
                 </li>
-                <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+                <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact" target="_blank">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy" target="_blank">Privacy Policy</a>.</li>
                 {# These are honey pot fields to catch bots #}
                 <li class="u-off-screen">
                   <label class="website" for="website">Website:</label>

--- a/templates/partners/partial/_homepage-form.html
+++ b/templates/partners/partial/_homepage-form.html
@@ -49,7 +49,7 @@
                     <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                   </label>
                 </li>
-                <li class="p-list__item">By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact" target="_blank">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy" target="_blank">Privacy Policy</a>.</li>
+                <li class="p-list__item">By submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact" target="_blank">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a>.</li>
                 {# These are honey pot fields to catch bots #}
                 <li class="u-off-screen">
                   <label class="website" for="website">Website:</label>

--- a/templates/partners/partial/_homepage-form.html
+++ b/templates/partners/partial/_homepage-form.html
@@ -49,7 +49,7 @@
                     <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                   </label>
                 </li>
-                <li class="p-list__item">By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+                <li class="p-list__item">By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact" target="_blank">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy" target="_blank">Privacy Policy</a>.</li>
                 {# These are honey pot fields to catch bots #}
                 <li class="u-off-screen">
                   <label class="website" for="website">Website:</label>


### PR DESCRIPTION
## Done

Opening the privacy notice and privacy policy in a new tab in https://canonical-com-1136.demos.haus/careers

## QA

- [demo link](https://canonical-com-1136.demos.haus/)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the links to privacy notice and privacy policy open in a new tab

## Issue / Card
[WD-7312](https://warthogs.atlassian.net/browse/WD-7312)
Fixes #

## Screenshots



[WD-7312]: https://warthogs.atlassian.net/browse/WD-7312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ