### PR TITLE
WD-5190 - fix PM subheading

### DIFF
--- a/templates/careers/project-management.html
+++ b/templates/careers/project-management.html
@@ -11,7 +11,7 @@
     department=department,
     claim="The Project Management team at Canonical embodies and spearheads our company's strategy of excellence in execution. Project managers are engaged during all phases of projects, from pre-sales support to delivery and the hand-off of complete projects.",
     fast_track_jobs=fast_track_jobs,
-    block_1_subheading='Marketing at Canonical',
+    block_1_subheading='Project Management at Canonical',
     block_1_text=["Canonical's project management team ensures that all projects are delivered according to time, resource and scope expectations. The team creates, manages and maintains project-specific schedules and manages each project through its entire life-cycle. Ultimately, the team ensures that our clients' goals, as well as Canonical's goals, are met.", "Our Senior Project Managers fulfil high-profile customer relationship management roles. They provide account leadership and insight and are the primary interface for Canonical's key enterprise accounts. As expert engagement managers, they excel where relationship management and advocacy for Canonical's solutions are strategically crucial."],
     image_url='https://assets.ubuntu.com/v1/6195ae44-department-project-management-%402x.jpg',
     image_width="1500",


### PR DESCRIPTION
## Done

Update subheading for project management role page

## QA

- [demo link](https://canonical-com-1142.demos.haus/careers/project-management)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the subheading is correct

## Issue / Card
[WD-5190](https://warthogs.atlassian.net/browse/WD-5190)
Fixes #

## Screenshots



[WD-7312]: https://warthogs.atlassian.net/browse/WD-7312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-5190]: https://warthogs.atlassian.net/browse/WD-5190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ