### PR TITLE
Remove nvidia logo from the microcloud page

### DIFF
--- a/templates/microcloud/index.html
+++ b/templates/microcloud/index.html
@@ -338,19 +338,6 @@
         <div class="p-logo-section__item">
           {{ 
             image (
-            url="https://assets.ubuntu.com/v1/af8f702a-nvidia-logo.png",
-            alt="Nvidia",
-            width="381",
-            height="385",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ 
-            image (
             url="https://assets.ubuntu.com/v1/ddad56d7-intel-new-logo.png",
             alt="Intel",
             width="199",


### PR DESCRIPTION
## Done
Remove nvidia logo from the microcloud page

## QA
1. Open the demo
2. Go to /microcloud
3. See there is no nvidia logo on the page 
