### PR TITLE
WD-7949 - Tweak Data Fabric pages

### DIFF
--- a/templates/data/index.html
+++ b/templates/data/index.html
@@ -101,7 +101,7 @@
 						}}
             <hr class="p-rule">
             <p class="u-align-text--left">
-              <a class="off-screen" href="/data/docs/postgresql/iaas">Learn more<span class="u-off-screen"> about PostgreSQL</span>&nbsp;&rsaquo;</a>
+              <a class="off-screen" href="/data/postgresql">Learn more<span class="u-off-screen"> about PostgreSQL</span>&nbsp;&rsaquo;</a>
             </p>
 					</div>
           <div class="p-logo-section__item">
@@ -118,7 +118,7 @@
 						}}
             <hr class="p-rule">
             <p class="u-align-text--left">
-              <a class="off-screen" href="/data/docs/mysql/iaas">Learn more <span class="u-off-screen"> about MySQL</span>&nbsp;&rsaquo;</a>
+              <a class="off-screen" href="/data/mysql">Learn more <span class="u-off-screen"> about MySQL</span>&nbsp;&rsaquo;</a>
             </p>
 					</div>
           <div class="p-logo-section__item">

--- a/templates/data/mysql.html
+++ b/templates/data/mysql.html
@@ -12,29 +12,31 @@
 
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="p-section">
-    <div class="row">
-      <div class="col-3 u-hide--medium u-hide--small">
-        <a href="https://www.mysql.com/">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/37c2f953-mysql-logo.png",
-            alt="MySQL",
-            width="128",
-            height="134",
-            hi_def=True,
-            loading="auto"
-            ) | safe
-          }}
-        </a>
+    <div class="row--25-75 is-split-on-medium">
+      <div class="col">
+        <div class="p-image-wrapper">
+          <a href="https://www.mysql.com/">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/37c2f953-mysql-logo.png",
+              alt="MySQL",
+              width="128",
+              height="134",
+              hi_def=True,
+              loading="auto"
+              ) | safe
+            }}
+          </a>
+        </div>
       </div>
-      <div class="col-9 row">
-        <div class="col-medium-3">
-          <h1>MySQL operations, <br class="u-hide--large u-hide--small">simplified</h1>
+      <div class="col">
+        <div class="p-section--shallow">
+          <h1 class="u-no-margin--bottom">MySQL operations, simplified</h1>
         </div>
-        <div class="col-medium-3">
+        <div class="p-section--shallow">
           <p>Secure and automate the deployment, maintenance and upgrades of your MySQL databases across private and public clouds.</p>
-          <hr class="u-hide--medium u-hide--small">
-          <a class="p-button--positive" aria-controls="data-relational-dbs-modal" href="/contact-us">Contact us</a>
         </div>
+        <hr>
+        <a class="p-button--positive" aria-controls="data-relational-dbs-modal" href="/contact-us">Contact us</a>
       </div>
     </div>
   </div>
@@ -44,7 +46,7 @@
   <div class="row--25-75">
     <hr class="p-rule">
     <div class="col">
-      <h2 class="p-text--small-caps">Made to give you peace of mind</h2>
+      <h2 class="p-text--small-caps">Made to give you<br class="u-hide--small"> peace of mind</h2>
     </div>
     <div class="col">
       <ul class="p-list--divided">
@@ -59,7 +61,7 @@
 <section class="p-section">
   <div class="u-fixed-width">
     <hr class="p-rule">
-    <h2 class="p-text--small-caps">Run MySQL on your favorite stack and across clouds</h2>
+    <h2 class="p-text--small-caps">Run MySQL on your favourite stack and across clouds</h2>
     <div class="p-logo-section">
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">

--- a/templates/partial/_data-navigation.html
+++ b/templates/partial/_data-navigation.html
@@ -32,6 +32,9 @@
           <a href="/data/postgresql" class="p-navigation__link">PostgreSQL</a>
         </li>
         <li class="p-navigation__item">
+          <a href="/data/mysql" class="p-navigation__link">MySQL</a>
+        </li>
+        <li class="p-navigation__item">
           <a href="/data/mongodb" class="p-navigation__link">MongoDB</a>
         </li>
         <li class="p-navigation__item">
@@ -42,9 +45,6 @@
         </li>
         <li class="p-navigation__item">
           <a href="/data/opensearch" class="p-navigation__link">OpenSearch</a>
-        </li>
-        <li class="p-navigation__item">
-          <a href="/data/mysql" class="p-navigation__link">MySQL</a>
         </li>
         <li class="p-navigation__item">
           <a href="/data/docs" class="p-navigation__link">Docs</a>


### PR DESCRIPTION
## Done

- List MySQL right after PostgreSQL in the navigation
- On the [home](https://canonical.com/data), point “Learn more” links for PostgreSQL and MySQL to the new pages instead of documentation pages
- On the [MySQL page](https://canonical.com/data/mysql), add consistent spacing below the paragraph in the hero. I reused the code from PostgreSQL (uses the `row--25-75` layout). Also, added a missing line break ("Made to give you - peace of mind" and fixed a minor typo (should be "favourite" instead of "favorite")

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes [WD-7949](https://warthogs.atlassian.net/browse/WD-7949)

[WD-7949]: https://warthogs.atlassian.net/browse/WD-7949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ