### PR TITLE
Fix the title of careers pages

### DIFF
--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -1,6 +1,6 @@
 {% extends '/careers/base_job-details.html' %}
 
-{% block title %}{{ job.meta_title }} | Careers{% endblock %}
+{% block title %}{{ job.title }} | Careers{% endblock %}
 
 {% block meta_description %}{% if job.description %}{{ job.description }}{% else %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endif %}{% endblock %}
 

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -61,7 +61,7 @@ def _get_job_slug(job):
 
 
 def _add_req_to_content(job):
-    # Add reuisition ID to content
+    # Add requisition ID to content
     if job["requisition_id"]:
         job["content"] = (
             job["content"]


### PR DESCRIPTION
## Done
Fix the title of the careers description pages
Fix a typo in the comments

## QA

- Open the demo
- Navigate to a career description
- See the title of the page now contains the title of the vacancy
