### PR TITLE
ISV partners revamp

### DIFF
--- a/templates/partial/_standard-navigation.html
+++ b/templates/partial/_standard-navigation.html
@@ -45,6 +45,7 @@
                 <li><a href="/partners/channel-and-reseller" class="p-navigation__dropdown-item">Channel/reseller</a></li>
                 <li><a href="/partners/iot-device" class="p-navigation__dropdown-item">IoT devices</a></li>
                 <li><a href="/partners/ihv-and-oem" class="p-navigation__dropdown-item">IHV/OEM</a></li>
+                <li><a href="/partners/isv-partners" class="p-navigation__dropdown-item">ISVs</a></li>
                 <li><a href="/partners/gsi" class="p-navigation__dropdown-item">Global System Integrators</a></li>
                 <li><a href="/partners/public-cloud" class="p-navigation__dropdown-item">Public cloud</a></li>
                 <li><a href="/partners/silicon" class="p-navigation__dropdown-item">Silicon</a></li>

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -105,6 +105,19 @@
       <div class="row">
         <div class="col-3">
           <p class="p-heading--5">
+            <a href="/partners/isv-partners">ISVs&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+        <div class="col-6">
+          <p>Use Canonical products like containers, MicroK8s and Ubuntu to power your software and appliances</p>
+        </div>
+      </div>
+      <div class="row">
+        <hr class="p-rule">
+      </div>
+      <div class="row">
+        <div class="col-3">
+          <p class="p-heading--5">
             <a href="/partners/gsi">Global System Integrators&nbsp;&rsaquo;</a>
           </p>
         </div>

--- a/templates/partners/isv-partners.html
+++ b/templates/partners/isv-partners.html
@@ -6,44 +6,75 @@
 
 {% block meta_description %}Ubuntu is the most popular guest OS on both public and private clouds, thanks to its security, versatility and continually updated features.{% endblock %}
 
+{% block body_class %}is-paper{% endblock body_class %}
+
 {% block content %}
 
-<section class="p-strip--image is-dark">
-  <div class="p-strip--suru-background" style="padding-top: 3rem;">
-    <div class="u-fixed-width">
-      <h1>ISV Embedding Programme</h1>
-      <p>From containers through Ubuntu Server to MicroK8s, Canonical's portfolio is used by ISVs the world over to power SaaS, appliances and software solutions deployed within public clouds, data-centres, edge infrastructure and workstations. Our ISV Embedding programme offers the optimal technical, commercial and legal framework to enjoy cost-effective support across the lifecycle of your product.</p>
+{% with parent_name="Partners", parent_href="/partners", title="ISV Embedding programme" %}
+  {% include '/partial/_breadcrumbs.html' %}
+{% endwith %}
+
+<section class="p-section">
+  <div class="row--50-50">
+    <div class="col">
+      <h1>ISV Embedding<br class="u-hide--small"> Programme</h1>
+    </div>
+    <div class="col">
+      <div class="p-block">
+        <p>From Ubuntu Server to containers, Canonica's portfolio is used by independent software vendors (ISVs) around the world to power SaaS, appliances and software solutions deployed within public clouds, data -centres, edge infrastructure and workstations. Our ISV Embedding programme offers the optimal technical, commercial and legal framework to enjoy cost-effective support across the lifecycle of your product.</p>
+      </div>
       <a href="/partners/become-a-partner" class="p-button--positive">Become a partner</a>
     </div>
   </div>
 </section>
 
-<section class="p-strip is-deep">
+<section class="p-section">
+  <div class="u-fixed-width p-section">
+    <hr class="p-rule"/>
+    <h2>Benefits of the ISV Embedding programme</h2>
+  </div>
   <div class="row">
-    <h2>What&rsquo;s included</h2>
-    <p>There are many benefits for partners in the Canonical Public Cloud programme:</p>
-    <div class="col-6">
-      <ul class="p-list u-no-margin--bottom">
-        <p class="p-heading--5">Programme Entitlements</p>
-        <li class="p-list__item is-ticked">You support your end-customers</li>
-        <li class="p-list__item is-ticked">Direct L3 engineering support for your engineering team</li>
-        <li class="p-list__item is-ticked">Familiar Ubuntu Advantage Essential, Standard and Advanced Support tiers</li>
-        <li class="p-list__item is-ticked">Security patches for up to 10 years</li>
-        <li class="p-list__item is-ticked">Trademark, Modification and Redistribution rights </li>
-        <li class="p-list__item is-ticked">Be featured as a ISV Embedding Programme partner on the Canonical website, including the ability to use our trademarks and logos</li>
-        <li class="p-list__item is-ticked">Joint marketing: blogs, webinars and PR</li>
-      </ul>
-    </div>
-
-    <div class="col-6">
-      <ul class="p-list u-no-margin--bottom"></ul>
-        <p class="p-heading--5">Custom Image Builds</p>
-        <li class="p-list__item is-ticked">Canonical created images tailored for your performance, platform, compliance & governance requirements</li>
-        <li class="p-list__item is-ticked">Design workshop</li>
-        <li class="p-list__item is-ticked">Ongoing image maintenance and delivery for easy CI pipeline ingestion</li>
-        <p class="p-heading--5" style="padding-top: 1rem;">Dedicated partner team</p>
-        <li class="p-list__item is-ticked">Named resources within Canonical for GTM, technical training and marketing</li>
-      </ul>
+    <div class="col-start-large-4 col-9">
+      <hr class="p-rule"/>
+      <div class="row">
+        <div class="col-3">
+          <h3 class="p-heading--5">Programmme entitlements</h3>
+        </div>
+        <div class="col-6">
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">Direct L3 engineering support for your engineering team</li>
+            <li class="p-list__item is-ticked">You support your end -customers</li>
+            <li class="p-list__item is-ticked">Security patches for up to 10 years with <a href="https://ubuntu.com/pro">Ubuntu Pro</a></li>
+            <li class="p-list__item is-ticked">Trademark, modification and redistribution rights</li>
+            <li class="p-list__item is-ticked">Be featured as a partner on the Canonical website, including the ability to use our trademarks and logos</li>
+            <li class="p-list__item is-ticked">Joint marketing: blogs, webinars and PR</li>
+          </ul>
+        </div>
+      </div>
+      <hr class="p-rule"/>
+      <div class="row">
+        <div class="col-3">
+          <h3 class="p-heading--5">Custom image builds</h3>
+        </div>
+        <div class="col-6">
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">Canonical-created images tailored for your performance, platform, compliance and governance requirements</li>
+            <li class="p-list__item is-ticked">Design workshop </li>
+            <li class="p-list__item is-ticked">Ongoing image maintenance and delivery for easy CI pipeline ingestion </li>
+          </ul>
+        </div>
+      </div>
+      <hr class="p-rule"/>
+      <div class="row">
+        <div class="col-3">
+          <h3 class="p-heading--5">Dedicated partner team</h3>
+        </div>
+        <div class="col-6">
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">Named resources within Canonical for GTM, technical training and marketing</li>
+          </ul>
+        </div>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/partners/isv-partners.html
+++ b/templates/partners/isv-partners.html
@@ -21,7 +21,7 @@
     </div>
     <div class="col">
       <div class="p-block">
-        <p>From Ubuntu Server to containers, Canonica's portfolio is used by independent software vendors (ISVs) around the world to power SaaS, appliances and software solutions deployed within public clouds, data -centres, edge infrastructure and workstations. Our ISV Embedding programme offers the optimal technical, commercial and legal framework to enjoy cost-effective support across the lifecycle of your product.</p>
+        <p>From Ubuntu Server to containers, Canonical's portfolio is used by independent software vendors (ISVs) around the world to power SaaS, appliances and software solutions deployed within public clouds, data centres, edge infrastructure and workstations. Our ISV Embedding programme offers the optimal technical, commercial and legal framework to enjoy cost-effective support across the lifecycle of your product.</p>
       </div>
       <a href="/partners/become-a-partner" class="p-button--positive">Become a partner</a>
     </div>

--- a/templates/partners/isv-partners.html
+++ b/templates/partners/isv-partners.html
@@ -34,13 +34,13 @@
     <h2>Benefits of the ISV Embedding programme</h2>
   </div>
   <div class="row">
-    <div class="col-start-large-4 col-9">
+    <div class="col-start-large-4 col-9 col-medium-6">
       <hr class="p-rule"/>
       <div class="row">
-        <div class="col-3">
+        <div class="col-3 col-medium-3">
           <h3 class="p-heading--5">Programmme entitlements</h3>
         </div>
-        <div class="col-6">
+        <div class="col-6 col-medium-3">
           <ul class="p-list--divided">
             <li class="p-list__item is-ticked">Direct L3 engineering support for your engineering team</li>
             <li class="p-list__item is-ticked">You support your end -customers</li>
@@ -53,10 +53,10 @@
       </div>
       <hr class="p-rule"/>
       <div class="row">
-        <div class="col-3">
+        <div class="col-3 col-medium-3">
           <h3 class="p-heading--5">Custom image builds</h3>
         </div>
-        <div class="col-6">
+        <div class="col-6 col-medium-3">
           <ul class="p-list--divided">
             <li class="p-list__item is-ticked">Canonical-created images tailored for your performance, platform, compliance and governance requirements</li>
             <li class="p-list__item is-ticked">Design workshop </li>
@@ -66,10 +66,10 @@
       </div>
       <hr class="p-rule"/>
       <div class="row">
-        <div class="col-3">
+        <div class="col-3 col-medium-3">
           <h3 class="p-heading--5">Dedicated partner team</h3>
         </div>
-        <div class="col-6">
+        <div class="col-6 col-medium-3">
           <ul class="p-list--divided">
             <li class="p-list__item is-ticked">Named resources within Canonical for GTM, technical training and marketing</li>
           </ul>

--- a/templates/partners/partial/_footer.html
+++ b/templates/partners/partial/_footer.html
@@ -1,30 +1,11 @@
-<section class="p-section l-footer--sticky">
-  <div class="row">
+<section class="p-strip--white is-deep l-footer--sticky">
+  <div class="u-fixed-width">
+    <h3 class="p-heading--2">
+      <a href="/partners/find-a-partner">Find a partner&nbsp;&rsaquo;</a>
+    </h3>
     <hr class="p-rule">
-    <div class="col-6 col-medium-3">
-      <h3 class="p-heading--2">Find a partner</h3>
-    </div>
-    <div class="col-6 col-medium-3">
-      <p>Looking for a supplier with Ubuntu expertise? Select from the complete list of our partners.</p>
-      <hr class="p-rule">
-      <p>
-        <a href="/partners/find-a-partner">Find a partner&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-  </div>
-</section>
-<section class="p-strip is-deep u-no-padding--top">
-  <div class="row">
-    <hr class="p-rule">
-    <div class="col-6 col-medium-3">
-      <h3 class="p-heading--2">Become a partner</h3>
-    </div>
-    <div class="col-6 col-medium-3">
-      <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
-      <hr class="p-rule">
-      <p>
-        <a href="/partners/become-a-partner">Become a partner&nbsp;&rsaquo;</a>
-      </p>
-    </div>
+    <h3 class="p-heading--2">
+      <a href="/partners/become-a-partner">Become a partner&nbsp;&rsaquo;</a>
+    </h3>
   </div>
 </section>

--- a/templates/partners/partial/_footer.html
+++ b/templates/partners/partial/_footer.html
@@ -1,4 +1,4 @@
-<section class="p-strip--white is-deep l-footer--sticky">
+<section class="p-strip--white is-deep">
   <div class="u-fixed-width">
     <h3 class="p-heading--2">
       <a href="/partners/find-a-partner">Find a partner&nbsp;&rsaquo;</a>


### PR DESCRIPTION
## Done

- Updated ISV partners page as per [doc](https://docs.google.com/document/d/1qWWpFbwZykjAIt-Kf6iFCXPCnmmuKBbU5mzvILnO-q0/edit) and [mock-up](https://www.figma.com/file/KQSCmTqOjY4gfKvJPyvzj2/Canonical.com-latest-only?node-id=12110%3A16698&mode=dev)
- Added mention to ISV page on partners landing as per [doc](https://docs.google.com/document/d/1SwCceQv625Kdc3wAvzSFBBA3qt3CxzDmc0DAfo3LJfs/edit)
- Updated partners subnav and shared footer

## QA

- View the site locally in your web browser at: https://canonical-com-1154.demos.haus/partners
- See that the link to the [ISV partners page](https://canonical-com-1154.demos.haus/partners/isv-partners) exists, matches relevant doc, and routes correctly
- Check ISV partners page against doc and design


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5266
