### PR TITLE
Display the full name in a candidate withdrawal email

### DIFF
--- a/webapp/application.py
+++ b/webapp/application.py
@@ -474,6 +474,11 @@ def application_withdrawal(token):
     hiring_lead_name = application["hiring_lead"]["name"]
     hiring_lead_email = application["hiring_lead"]["emails"]
 
+    applicant_name = (
+        f"{application['candidate']['first_name']} "
+        f"{application['candidate']['last_name']}"
+    )
+
     application_url = (
         f"https://canonical.greenhouse.io/people/{candidate_id}?"
         f"application_id={payload['application_id']}"
@@ -490,7 +495,7 @@ def application_withdrawal(token):
 
     email_message = flask.render_template(
         "careers/application/_withdrawal_notification-email.html",
-        applicant_name=application["candidate"]["first_name"],
+        applicant_name=applicant_name,
         hiring_lead_name=hiring_lead_name,
         position=application["role_name"],
         hiring_lead=application["hiring_lead"],


### PR DESCRIPTION
## Done

Updated the candidate withdrawal email template context variable `applicant_name` to be the full name.

## QA

- Create a job (or reopen a closed application) on the test position
- Run this branch locally and visit the application page
- Withdraw and see the email sent to the candidate
- See your full name including last name in the email

