### PR TITLE
[WD-6157] add link to download datasheet to /data/opensearch

### DIFF
--- a/templates/data/opensearch.html
+++ b/templates/data/opensearch.html
@@ -14,27 +14,28 @@
 
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="p-section">
-  <div class="row--25-75">
-    <div class="col">
-      <div class="p-image-wrapper">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/858e64ad-logo-open-search.svg",
-          alt="Opensearch",
-          width="40",
-          height="40",
-          hi_def=True,
-          loading="auto"
-          ) | safe
-        }}
+    <div class="row--25-75">
+      <div class="col">
+        <div class="p-image-wrapper">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/858e64ad-logo-open-search.svg",
+            alt="Opensearch",
+            width="40",
+            height="40",
+            hi_def=True,
+            loading="auto"
+            ) | safe
+          }}
+        </div>
       </div>
-    </div>
-    <div class="col">
-      <div class="p-section--shallow">
-        <h1>OpenSearch<sup>&reg;</sup> operations, simplified</h1>
-        <p>Secure and automate the deployment, maintenance and upgrades of your search and analytics suite across private and public clouds.</p>
-      </div>
-      <hr>
+      <div class="col">
+        <div class="p-section--shallow">
+          <h1>OpenSearch<sup>&reg;</sup> operations, simplified</h1>
+          <p>Secure and automate the deployment, maintenance and upgrades of your search and analytics suite across private and public clouds.</p>
+        </div>
+        <hr />
         <a class="p-button--positive" href="/contact-us" aria-controls="data-spark-modal">Contact us</a>
+        <a href="https://assets.ubuntu.com/v1/a7d1c19a-Charmed%20OpenSearch%20-%20Datasheet%20(1).pdf">Download the datasheet&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>
@@ -42,7 +43,7 @@
 
 <section class="p-section">
   <div class="row--25-75 is-split-on-medium">
-    <hr class="p-rule">
+    <hr class="p-rule" />
     <div class="col">
       <h2 class="p-text--small-caps">Deploy and operate<br class="u-hide--small"> reliably everywhere</h2>
     </div>
@@ -59,7 +60,7 @@
 
 <section class="p-section">
   <div class="u-fixed-width">
-    <hr class="p-rule">
+    <hr class="p-rule" />
     <h2 class="p-text--small-caps">Run OpenSearch<sup>&reg;</sup> on</h2>
     <div class="p-logo-section">
       <div class="p-logo-section__items">
@@ -142,7 +143,7 @@
 </section>
 
 <section class="p-section">
-  <hr class="p-rule is-fixed-width">
+  <hr class="p-rule is-fixed-width" />
   <div class="row--50-50">
     <div class="col">
       <h2>A hyper-automated OpenSearch with enterprise-grade support</h2>
@@ -150,7 +151,7 @@
   
     <div class="col">
       <p>OpenSearch is a fantastic open source search and analytics suite. But operating and supporting a production OpenSearch solution can be complex and challenging. Canonical's Charmed OpenSearch helps you automate operational tasks and spend more time on value-driving activities.</p>
-      <hr class="p-rule is-muted">
+      <hr class="p-rule is-muted" />
       <div class="p-section--shallow">
         <ul class="p-list--divided u-no-margin--bottom">
           <li class="p-list__item is-ticked">Automated security and configuration best practice</li>
@@ -169,12 +170,12 @@
 
 <section class="p-section">
   <div class="u-fixed-width p-section--shallow">
-		<hr class="p-rule">
+		<hr class="p-rule" />
 		<h2>OpenSearch enterprise use cases</h2>
 	</div>
   <div class="row--25-75 is-split-on-medium">
     <div class="col">
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <div class="row">
         <div class="col-3">
           <h3 class="p-heading--5">Search</h3>
@@ -183,7 +184,7 @@
           <p>OpenSearch enhances your website or e-commerce search capabilities with full-text querying, autocomplete, scroll search, and customisable scoring and ranking.</p>
         </div>
       </div>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <div class="row">
         <div class="col-3">
           <h3 class="p-heading--5">Analytics and machine learning</h3>
@@ -192,7 +193,7 @@
           <p>You can use OpenSearch in multiple analytics solutions such as events analytics, trace analytics, and machine learning, which uses algorithms such as anomaly detection and data clustering.</p>
         </div>
       </div>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <div class="row">
         <div class="col-3">
           <h3 class="p-heading--5">Observability and reporting</h3>
@@ -201,7 +202,7 @@
           <p>OpenSearch can be used to create observability applications through the OpenSearch Dashboard. It can also be used to schedule, export and share reports. </p>
         </div>
       </div>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <div class="row">
         <div class="col-3">
           <h3 class="p-heading--5">Vector databases</h3>
@@ -215,7 +216,7 @@
 </section>
 
 <section class="p-section">
-  <hr class="p-rule is-fixed-width">
+  <hr class="p-rule is-fixed-width" />
   <div class="row--50-50">
     <div class="col">
       <div class="p-section--shallow">
@@ -224,7 +225,7 @@
     </div>
     <div class="col">
       <p>We provide 10 years of support and security patching for your OpenSearch artefacts in the format of your choice through our Ubuntu Pro subscription.</p>
-      <hr class="p-rule is-muted">
+      <hr class="p-rule is-muted" />
       <div class="p-section--shallow">
         <ul class="p-list--divided u-no-margin--bottom">
           <li class="p-list__item is-ticked"><a href="https://snapcraft.io/charmed-mysql">Snaps</a> for added confinement and atomic updates on any Linux distribution</li>
@@ -241,7 +242,7 @@
 
 <section class="p-section--shallow">
   <div class="row--25-75 is-split-on-medium">
-    <hr class="p-rule">
+    <hr class="p-rule" />
     <div class="col">
       <h3 class="p-heading--2">Services</h3>
     </div>
@@ -265,7 +266,7 @@
           </div>
         </div>
       </div>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <div class="row">
         <div class="col-3">
           <h3 class="p-heading--5">Consulting</h3>
@@ -285,7 +286,9 @@
     </div>
   </div>
 </section>
-<hr class="is-fixed-width">
+
+<hr class="is-fixed-width" />
+
 <section class="p-strip is-deep">
   <div class="u-fixed-width">
     <p class="p-heading--2"><a href="https://ubuntu.com/data/docs/opensearch/iaas">Get started with Charmed OpenSearch&nbsp;&rsaquo;</a></p>
@@ -294,7 +297,7 @@
 
 <section class="p-section--shallow">
   <div class="row--50-50">
-    <hr class="p-rule">
+    <hr class="p-rule" />
     <div class="col">
       <h2>OpenSearch resources</h2>
     </div>
@@ -305,14 +308,14 @@
         </h3>
         <p>Learn about OpenSearch architecture, plugins and tools.</p>
       </div>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <div class="p-section--shallow">
         <h3 class="p-heading--5 u-no-margin--bottom">
           <a href="https://ubuntu.com/engage/opensearch-ai-webinar">Future-proof AI applications with OpenSearch as a vector database</a>
         </h3>
         <p>Give your generative AI models a broader and deeper pool of data with the right vector database.</p>
       </div>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <div class="p-section--shallow">
         <h3 class="p-heading--5 u-no-margin--bottom">
           <a href="https://www.youtube.com/watch?v=62B-hG7OWbM">Charmed OpenSearch open source projects</a>
@@ -325,7 +328,7 @@
 
 <section class="p-section">
   <div class="row">
-    <hr class="p-rule">
+    <hr class="p-rule" />
     <div class="col-6">
       <p>OpenSearch is a registered trademark of Amazon Web Services. Other trademarks are property of their respective owners. Charmed OpenSearch is not sponsored, endorsed, or affiliated with Amazon Web Services.</p>
     </div>


### PR DESCRIPTION
## Done

Added a link to download PDF datasheet according to [copy doc](https://docs.google.com/document/d/1nVdoKoPrXw8lsvHEtMichlPNfxYU9Uj1zmKowcUXQ_w/edit).

## QA

- Navigate to /data/opensearch and click on `Download the datasheet`. Make sure PDF opens from the assets server.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6157
