### PR TITLE
Fix email address in open-documentation-academy.html

### DIFF
--- a/templates/documentation/open-documentation-academy.html
+++ b/templates/documentation/open-documentation-academy.html
@@ -101,7 +101,7 @@
             <li class="p-list__item">Subscribe to our calendar: <a href="https://calendar.google.com/calendar/u/0?cid=Y19mYTY4YzE5YWEwY2Y4YWE1ZWNkNzMyNjZmNmM0ZDllOTRhNTIwNTNjODc1ZjM2ZmQ3Y2MwNTQ0MzliOTIzZjMzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20">Open Documentation Academy events</a></li>
             <li class="p-list__item"><a href="https://discourse.ubuntu.com/c/open-documentation-academy">Join our discussion forum on the Ubuntu Community Hub</a></li>
             <li class="p-list__item"><a href="https://fosstodon.org/@CanonicalDocumentation">Follow our progress online through Mastodon</a></li>
-            <li class="p-list__item">Email our academy leadership team directly: <a href="mailto:opendocsacademy@canonical.com">opendocsacademy@canonical.com</a></li>
+            <li class="p-list__item">Email our academy leadership team directly: <a href="mailto:docsacademy@canonical.com">docsacademy@canonical.com</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
The published email address is currently wrong. It should be 	docsacademy@canonical.com.

## Done

Fixed Open Documentation Academy contact email address.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
