### PR TITLE
[WD-8454] update favicon for all browsers and devices

### DIFF
--- a/static/files/site.webmanifest
+++ b/static/files/site.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "Canonical",
+  "short_name": "",
+  "icons": [
+    {
+      "src": "https://assets.ubuntu.com/v1/9c69b268-COF%20android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "https://assets.ubuntu.com/v1/c55060fd-COF%20android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -58,16 +58,10 @@
 
     {% block extra_metatags %}{% endblock %}
 
-    <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png" type="image/png" sizes="32x32">
-    <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/6ead207a-COF-favicon-48x48.png" type="image/png" sizes="48x48">
-    <link rel="apple-touch-icon-precomposed" sizes="144x144"
-      href="https://assets.ubuntu.com/v1/f38b9c7e-COF%20apple-touch-icon.png">
-    <link rel="apple-touch-icon-precomposed" sizes="114x114"
-      href="https://assets.ubuntu.com/v1/f2ddbdc6-apple-touch-icon-114x114-precomposed.png">
-    <link rel="apple-touch-icon-precomposed" sizes="72x72"
-      href="https://assets.ubuntu.com/v1/f193fb82-apple-touch-icon-72x72-precomposed.png">
-    <link rel="apple-touch-icon-precomposed"
-      href="https://assets.ubuntu.com/v1/205d458b-apple-touch-icon-precomposed.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="https://assets.ubuntu.com/v1/f38b9c7e-COF%20apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="https://assets.ubuntu.com/v1/16c27f81-COF%20favicon-16x16.png">
+    <link rel="manifest" href="{{ versioned_static('files/site.webmanifest') }}">
 
     <link rel="preconnect" href="https://assets.ubuntu.com">
 


### PR DESCRIPTION
## Done

- Updated links to favicon icons for different browsers and devices (iOS/Androd). Followed the instructions provided in https://favicon.io/favicon-converter/
- Used existing favicon images from Assets Manager

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check favicon on different browsers
- Check favicon on mobile devices by adding a webpage to Home screen

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8454
