### PR TITLE
WD-8434 - update newsletter signup form on /blog

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -89,7 +89,16 @@
             <p class="p-notification__message">Your submission was sent successfully! <a href="#" onclick="document.querySelector('#success').classList.add('u-hide');"><i class="p-notification__close">Close</i></a></p>
           </div>
       </div>
-  </div>
+    </div>
+    <div id="newsletter-signup" class="p-strip u-no-padding--top">
+      <div class="u-fixed-width">
+        <div class="p-notification--positive u-no-margin--bottom">
+          <div class="p-notification__content">
+            <p class="p-notification__message">Thank you for signing up for our newsletter!<br/>In these regular emails you will find the latest updates from Canonical and upcoming events where you can meet our team.<a href="#" onclick="location.href = document.referrer; return false;"><i class="p-notification__close">Close</i></a></p>
+          </div>
+        </div>
+      </div>
+    </div>
     <div id="main-content">
       {% include "partial/_navigation.html" %}
       {% block content %}{% endblock content %}

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -93,7 +93,7 @@
     <div id="newsletter-signup" class="u-hide">
       <div class="p-notification--positive u-no-margin--bottom">
           <div class="p-notification__content">
-            <p class="p-notification__message">Thank you for signing up for our newsletter!<br/>In these regular emails you will find the latest updates from Canonical and upcoming events where you can meet our team.<a href="#" onclick="document.querySelector('#newsletter-signup').classList.add('u-hide');"><i class="p-notification__close">Close</i></a></p>
+            <p class="p-notification__message">Thank you for signing up for our newsletter!<br/>In these regular emails you will find the latest updates from Canonical and upcoming events where you can meet our team.<a href="#" onclick="location.href = document.referrer; return false;"><i class="p-notification__close">Close</i></a></p>
           </div>
       </div>
     </div>
@@ -111,19 +111,12 @@
     <script>
 
       (function() {
-        // Foorm submission notification
+        // Newsletter submission notification
         var successElement = "#success";
         if (location.hash === successElement) {
           document.querySelector(successElement).classList.remove("u-hide");
         } else {
           document.querySelector(successElement).classList.add("u-hide");
-        }
-
-        var newsletterElement = "#newsletter-signup";
-        if (location.hash === newsletterElement) {
-          document.querySelector(newsletterElement).classList.remove("u-hide");
-        } else {
-          document.querySelector(newsletterElement).classList.add("u-hide");
         }
 
         let params = new URLSearchParams(window.location.search);

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -93,7 +93,7 @@
     <div id="newsletter-signup" class="u-hide">
       <div class="p-notification--positive u-no-margin--bottom">
           <div class="p-notification__content">
-            <p class="p-notification__message">Thank you for signing up for our newsletter!<br/>In these regular emails you will find the latest updates from Canonical and upcoming events where you can meet our team.<a href="#" onclick="location.href = document.referrer; return false;"><i class="p-notification__close">Close</i></a></p>
+            <p class="p-notification__message">Thank you for signing up for our newsletter!<br/>In these regular emails you will find the latest updates from Canonical and upcoming events where you can meet our team.<a href="#" onclick="document.querySelector('#newsletter-signup').classList.add('u-hide');"><i class="p-notification__close">Close</i></a></p>
           </div>
       </div>
     </div>
@@ -111,12 +111,19 @@
     <script>
 
       (function() {
-        // Newsletter submission notification
+        // Foorm submission notification
         var successElement = "#success";
         if (location.hash === successElement) {
           document.querySelector(successElement).classList.remove("u-hide");
         } else {
           document.querySelector(successElement).classList.add("u-hide");
+        }
+
+        var newsletterElement = "#newsletter-signup";
+        if (location.hash === newsletterElement) {
+          document.querySelector(newsletterElement).classList.remove("u-hide");
+        } else {
+          document.querySelector(newsletterElement).classList.add("u-hide");
         }
 
         let params = new URLSearchParams(window.location.search);

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -111,7 +111,7 @@
     <script>
 
       (function() {
-        // Foorm submission notification
+        // Form submission notification
         var successElement = "#success";
         if (location.hash === successElement) {
           document.querySelector(successElement).classList.remove("u-hide");

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -90,13 +90,11 @@
           </div>
       </div>
     </div>
-    <div id="newsletter-signup" class="p-strip u-no-padding--top">
-      <div class="u-fixed-width">
-        <div class="p-notification--positive u-no-margin--bottom">
+    <div id="newsletter-signup" class="u-hide">
+      <div class="p-notification--positive u-no-margin--bottom">
           <div class="p-notification__content">
             <p class="p-notification__message">Thank you for signing up for our newsletter!<br/>In these regular emails you will find the latest updates from Canonical and upcoming events where you can meet our team.<a href="#" onclick="location.href = document.referrer; return false;"><i class="p-notification__close">Close</i></a></p>
           </div>
-        </div>
       </div>
     </div>
     <div id="main-content">

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -125,58 +125,19 @@
           <h2 class="p-muted-heading">Newsletter signup</h2>
         </div>
         <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_1212" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-          <p >Select topics you're interested in:</p>
-
-          <ul class="p-list">
-            <li class="p-list__item u-clearfix">
-              <label class="p-checkbox">
-                <input class="p-checkbox__input" type="checkbox" aria-labelledby="insightscloudserver" name="insightscloudserver" value="true" />
-                <span class="p-checkbox__label" id="insightscloudserver">Cloud and Server</span>
-              </label>
-            </li>
-            <li class="p-list__item u-clearfix">
-              <label class="p-checkbox">
-                <input class="p-checkbox__input" type="checkbox" aria-labelledby="insightsdesktop" name="insightsdesktop" value="true" />
-                <span class="p-checkbox__label" id="insightsdesktop">Desktop</span>
-              </label>
-            </li>
-            <li class="p-list__item u-clearfix">
-              <label class="p-checkbox">
-                <input class="p-checkbox__input" type="checkbox" aria-labelledby="insightsiot" name="insightsiot" value="true" />
-                  <span class="p-checkbox__label" id="insightsiot">Internet of Things</span>
-                </label>
-              </li>
-              <li class="p-list__item u-clearfix">
-                <label class="p-checkbox">
-                  <input class="p-checkbox__input" aria-labelledby="insightsrobotics" name="insightsrobotics" value="true" type="checkbox">
-                  <span class="p-checkbox__label" id="insightsrobotics">Robotics</span>
-                </label>
-              </li>
-              <li class="p-list__item u-clearfix">
-                <label class="p-checkbox">
-                  <input class="p-checkbox__input" aria-labelledby="insightstutorials" name="insightstutorials" value="true" type="checkbox">
-                  <span class="p-checkbox__label" id="insightstutorials">Tutorials</span>
-                </label>
-              </li>
-              {# These are honey pot fields to catch bots #}
-              <li class="u-off-screen">
-                <label class="website" for="website">Website:</label>
-                <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
-              </li>
-              <li class="u-off-screen">
-                <label class="name" for="name">Name:</label>
-                <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
-              </li>
-              {# End of honey pots #}
-            </ul>
-
+            <p>Get the latest Canonical news and updates in your inbox.</p>
             <label for="email">
-              <span>Work email: <span>*</span></span>
+              <span required>Work email:</span>
             </label>
             <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
-            <p>
-              In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/newsletter" target="_blank">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a>.
-            </p>
+            <div class="p-section--shallow">
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+                <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+              </label>           
+                <p>By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank">Canonical's Privacy Policy</a>.</p>
+              </div>
+
             <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
             <input value="1212" name="formid" type="hidden">
             <input type="hidden" name="Consent_to_Processing__c" value="yes" />

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -149,7 +149,7 @@
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-            <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
+            <input type="hidden" name="thankyoumessage" value="Thank you for signing up for our newsletter!<br />In these regular emails you will find the latest updates from Canonical and upcoming events where you can meet our team.">
         </form>
       </div>
   </aside>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -139,7 +139,7 @@
             <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
             <input value="1212" name="formid" type="hidden">
             <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical.com/blog#success" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical.com/blog#newsletter-signup" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -131,7 +131,7 @@
             <div class="p-section--shallow">
               <label class="p-checkbox">
                 <input reuired class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-                <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.&ast;</span>
+                <span class="p-checkbox__label" id="canonicalUpdatesOptIn">&ast;I agree to receive information about Canonical's products and services.</span>
               </label>           
                 <p>By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank">Canonical's Privacy Policy</a>.</p>
               </div>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -130,13 +130,13 @@
             <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
             <div class="p-section--shallow">
               <label class="p-checkbox">
-                <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-                <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+                <input reuired class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+                <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.&ast;</span>
               </label>           
                 <p>By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank">Canonical's Privacy Policy</a>.</p>
               </div>
 
-            <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
+            <button type="submit" class="u-no-margin--bottom">Sign up</button>
             <input value="1212" name="formid" type="hidden">
             <input type="hidden" name="Consent_to_Processing__c" value="yes" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical.com/blog#newsletter-signup" />

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -126,9 +126,7 @@
         </div>
         <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_1212" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
             <p>Get the latest Canonical news and updates in your inbox.</p>
-            <label for="email">
-              <span required>Work email:</span>
-            </label>
+            <label class="is-required" for="email">Work email:</label>
             <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
             <div class="p-section--shallow">
               <label class="p-checkbox">

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -124,31 +124,7 @@
           <hr class="p-rule u-hide--medium u-hide--large">
           <h2 class="p-muted-heading">Newsletter signup</h2>
         </div>
-        <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_1212" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-            <p>Get the latest Canonical news and updates in your inbox.</p>
-            <label class="is-required" for="email">Work email:</label>
-            <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
-            <div class="p-section--shallow">
-              <label class="p-checkbox">
-                <input reuired class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-                <span class="p-checkbox__label" id="canonicalUpdatesOptIn">&ast;I agree to receive information about Canonical's products and services.</span>
-              </label>           
-                <p>By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank">Canonical's Privacy Policy</a>.</p>
-              </div>
-
-            <button type="submit" class="u-no-margin--bottom">Sign up</button>
-            <input value="1212" name="formid" type="hidden">
-            <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical-com-1173.demos.haus/blog#newsletter-signup" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-            <input type="hidden" name="thankyoumessage" value="Thank you for signing up for our newsletter!<br />In these regular emails you will find the latest updates from Canonical and upcoming events where you can meet our team.">
-        </form>
+      {% include 'blog/newsletter-form.html' %}
       </div>
   </aside>
     <section class="p-section col-6 col-medium-4">

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -139,7 +139,7 @@
             <button type="submit" class="u-no-margin--bottom">Sign up</button>
             <input value="1212" name="formid" type="hidden">
             <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical.com/blog#newsletter-signup" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical-com-1173.demos.haus/blog#newsletter-signup" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -20,10 +20,19 @@
   </div>
 </div>
 {% if current_page and current_page == 1 %}
-    {% if featured_articles %}
-      {% include "blog/featured-articles.html" %}
-    {% endif %}
-  {% include 'blog/newsletter-form.html' %}
+  {% if featured_articles %}
+    {% include "blog/featured-articles.html" %}
+  {% endif %}
+  <div class="row p-section">
+    <hr class="p-rule">
+    <div class="col-3 col-medium-2">
+      <h2>Newsletter <br>signup</h2>
+    </div>
+
+    <div class="col-6 col-medium-4">
+      {% include 'blog/newsletter-form.html' %}
+    </div>
+  </div>
 {% endif %}
 <section class="p-section" id="posts-list">
   <div class="row">

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -12,7 +12,7 @@
         <div class="p-section--shallow">
           <label class="p-checkbox">
             <input required class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-            <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.&ast;</span>
+            <span class="p-checkbox__label" id="canonicalUpdatesOptIn">&ast;I agree to receive information about Canonical's products and services.</span>
           </label>           
             <p>By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank">Canonical's Privacy Policy</a>.</p>
           </div>

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -1,34 +1,32 @@
-<div class="row p-section">
-  <hr class="p-rule">
-  <div class="col-3 col-medium-2">
-    <h2>Newsletter <br>signup</h2>
+<form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_4960"
+  onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
+  <p>Get the latest Canonical news and updates in your inbox.</p>
+  <label class="is-required" for="email">Work email:</label>
+  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+  <div class="p-section--shallow">
+    <label class="p-checkbox">
+      <input required class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn"
+        name="canonicalUpdatesOptIn" type="checkbox">
+      <span class="p-checkbox__label" id="canonicalUpdatesOptIn">&ast;I agree to receive information about Canonical's
+        products and services.</span>
+    </label>
+    <p>By submitting this form, I confirm that I have read and agree to <a
+        href="https://www.ubuntu.com/legal/dataprivacy" target="_blank">Canonical's Privacy Policy</a>.</p>
   </div>
 
-  <div class="col-6 col-medium-4">
-    <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_1212" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-        <p>Get the latest Canonical news and updates in your inbox.</p>
-        <label class="is-required" for="email">Work email:</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
-        <div class="p-section--shallow">
-          <label class="p-checkbox">
-            <input required class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-            <span class="p-checkbox__label" id="canonicalUpdatesOptIn">&ast;I agree to receive information about Canonical's products and services.</span>
-          </label>           
-            <p>By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank">Canonical's Privacy Policy</a>.</p>
-          </div>
-
-        <button type="submit" class="u-no-margin--bottom">Sign up</button>
-        <input value="1212" name="formid" type="hidden">
-        <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical-com-1173.demos.haus/blog#newsletter-signup" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-        <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
-    </form>
-  </div>
-</div>
+  <button type="submit" class="u-no-margin--bottom">Sign up</button>
+  <input value="1212" name="formid" type="hidden">
+  <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+  <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL"
+    value="https://canonical-com-1173.demos.haus/blog#newsletter-signup" />
+  <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+  <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+  <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+  <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+  <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+  <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+  <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c"
+    id="Facebook_Click_ID__c" value="" />
+  <input type="hidden" name="thankyoumessage"
+    value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
+</form>

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -11,13 +11,13 @@
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
         <div class="p-section--shallow">
           <label class="p-checkbox">
-            <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-            <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+            <input required class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+            <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.&ast;</span>
           </label>           
             <p>By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank">Canonical's Privacy Policy</a>.</p>
           </div>
 
-        <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
+        <button type="submit" class="u-no-margin--bottom">Sign up</button>
         <input value="1212" name="formid" type="hidden">
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical.com/blog#newsletter-signup" />

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -6,68 +6,20 @@
 
   <div class="col-6 col-medium-4">
     <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_1212" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-      <p>Select topics you're interested in:</p>
-
-      <ul class="p-list--divided">
-        <li class="p-list__item u-sv1">
+        <p>Get the latest Canonical news and updates in your inbox.</p>
+        <label for="email">
+          <span required>Work email:</span>
+        </label>
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
+        <div class="p-section--shallow">
           <label class="p-checkbox">
-            <input class="p-checkbox__input" type="checkbox" aria-labelledby="insightscloudserver" name="insightscloudserver" value="true" />
-            <span class="p-checkbox__label" id="insightscloudserver">Cloud and Server</span>
-          </label>
-        </li>
+            <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+            <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+          </label>           
+            <p>By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank">Canonical's Privacy Policy</a>.</p>
+          </div>
 
-        <li class="p-list__item u-sv1">
-          <label class="p-checkbox">
-            <input class="p-checkbox__input" type="checkbox" aria-labelledby="insightsdesktop" name="insightsdesktop" value="true" />
-            <span class="p-checkbox__label" id="insightsdesktop">Desktop</span>
-          </label>
-        </li>
-
-        <li class="p-list__item u-sv1">
-          <label class="p-checkbox">
-            <input class="p-checkbox__input" type="checkbox" aria-labelledby="insightsiot" name="insightsiot" value="true" />
-            <span class="p-checkbox__label" id="insightsiot">Internet of Things</span>
-          </label>
-        </li>
-
-        <li class="p-list__item u-sv1">
-          <label class="p-checkbox">
-            <input class="p-checkbox__input" aria-labelledby="insightsrobotics" name="insightsrobotics" value="true" type="checkbox">
-            <span class="p-checkbox__label" id="insightsrobotics">Robotics</span>
-          </label>
-        </li>
-
-        <li class="p-list__item u-sv1">
-          <label class="p-checkbox">
-            <input class="p-checkbox__input" aria-labelledby="insightstutorials" name="insightstutorials" value="true" type="checkbox">
-            <span class="p-checkbox__label" id="insightstutorials">Tutorials</span>
-          </label>
-        </li>
-        {# These are honey pot fields to catch bots #}
-        <li class="u-off-screen">
-          <label class="website" for="website">Website:</label>
-          <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
-        </li>
-        <li class="u-off-screen">
-          <label class="name" for="name">Name:</label>
-          <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
-        </li>
-        {# End of honey pots #}
-      </ul>
-
-      <label for="email">
-        <span>Work email: <span>*</span></span>
-      </label>
-      <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
-      <p>
-        In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a>.
-      </p>
-
-      <div>
-        <span class="p-card--content">
-          <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
-        </span>
-
+        <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
         <input value="1212" name="formid" type="hidden">
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical.com/blog#success" />
@@ -79,7 +31,6 @@
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
         <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
-      </div>
     </form>
   </div>
 </div>

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -20,7 +20,7 @@
         <button type="submit" class="u-no-margin--bottom">Sign up</button>
         <input value="1212" name="formid" type="hidden">
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical.com/blog#newsletter-signup" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="/blog#newsletter-signup" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -15,10 +15,10 @@
   </div>
 
   <button type="submit" class="u-no-margin--bottom">Sign up</button>
-  <input value="1212" name="formid" type="hidden">
+  <input value="4960" name="formid" type="hidden">
   <input type="hidden" name="Consent_to_Processing__c" value="yes" />
   <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL"
-    value="https://canonical-com-1173.demos.haus/blog#newsletter-signup" />
+    value="https://canonical.com/blog#newsletter-signup" />
   <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
   <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
   <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -20,7 +20,7 @@
         <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
         <input value="1212" name="formid" type="hidden">
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical.com/blog#success" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical.com/blog#newsletter-signup" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -20,7 +20,7 @@
         <button type="submit" class="u-no-margin--bottom">Sign up</button>
         <input value="1212" name="formid" type="hidden">
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://www.canonical.com/blog#newsletter-signup" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://canonical-com-1173.demos.haus/blog#newsletter-signup" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -7,9 +7,7 @@
   <div class="col-6 col-medium-4">
     <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_1212" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
         <p>Get the latest Canonical news and updates in your inbox.</p>
-        <label for="email">
-          <span required>Work email:</span>
-        </label>
+        <label class="is-required" for="email">Work email:</label>
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
         <div class="p-section--shallow">
           <label class="p-checkbox">

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -20,7 +20,7 @@
         <button type="submit" class="u-no-margin--bottom">Sign up</button>
         <input value="1212" name="formid" type="hidden">
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="/blog#newsletter-signup" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="https://www.canonical.com/blog#newsletter-signup" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />


### PR DESCRIPTION
## Done

Update newsletter signup from according got the copy doc. Please check the form ob the /blog page and on individual articles

To test this PR on a demo I had to change the link to the success url. The link will be changed back to the prod link before merge. DO NOT merge before the link is changed back

## QA

- [demo link](https://canonical-com-1173.demos.haus//blog)
- [copy doc](https://docs.google.com/document/d/1CuQlCuH9d_uqGq0xGQ3cLkIdXVofPXgxgYF6UbMln-E/edit)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the form is according to copy doc

## Issue / Card
[WD-8434](https://warthogs.atlassian.net/browse/WD-8434)

Fixes #

## Screenshots


[WD-8434]: https://warthogs.atlassian.net/browse/WD-8434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ