### PR TITLE
chore: change Snaps link in mongodb page

### DIFF
--- a/templates/data/mongodb.html
+++ b/templates/data/mongodb.html
@@ -217,7 +217,7 @@
       <p>We provide 10 years of support and security patching for your MongoDB artefacts in the format of your choice through our <a href="https://ubuntu.com/pro/subscribe">Ubuntu Pro subscription</a>.</p>
       <hr class="p-rule">
       <ul class="p-list--divided u-no-padding--bottom">
-        <li class="p-list__item is-ticked"><a href="https://snapcraft.io/charmed-mysql">Snaps</a> for added confinement and atomic updates on any Linux distribution</li>
+        <li class="p-list__item is-ticked"><a href="https://snapcraft.io/charmed-mongodb">Snaps</a> for added confinement and atomic updates on any Linux distribution</li>
         <li class="p-list__item is-ticked"><a href="https://ubuntu.com/server/docs/rock-images/introduction">OCI-compliant images</a> for your containerised environments</li>
         <li class="p-list__item is-ticked"><a href="https://charmhub.io/">Charmed operator</a> for automated MongoDB operations management</li>
       </ul>


### PR DESCRIPTION
## Done

- Changed Snaps link in mongodb page from https://snapcraft.io/charmed-mysql to https://snapcraft.io/charmed-mongodb

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #1172 

## Screenshots

[if relevant, include a screenshot]
