### PR TITLE
add 48x48 size favicon for google search

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -59,6 +59,7 @@
     {% block extra_metatags %}{% endblock %}
 
     <link rel="apple-touch-icon" sizes="180x180" href="https://assets.ubuntu.com/v1/f38b9c7e-COF%20apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="48x48" href="https://assets.ubuntu.com/v1/6ead207a-COF-favicon-48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="https://assets.ubuntu.com/v1/16c27f81-COF%20favicon-16x16.png">
     <link rel="manifest" href="{{ versioned_static('files/site.webmanifest') }}">


### PR DESCRIPTION
## Done

Google Search is still not showing Canonical favicon. Maybe adding 48x48 size favicon will help.

## QA

- Can be QA-d only after deployment.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8454
