### PR TITLE
Fix broken privacy link

### DIFF
--- a/templates/lxd/_form-lxd-install.html
+++ b/templates/lxd/_form-lxd-install.html
@@ -26,7 +26,7 @@
                   <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
-                <p>By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy">Canonical's Privacy Policy</a>.</p>
+                <p>By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/data-privacy">Canonical's Privacy Policy</a>.</p>
               </div>
               {# These are honey pot fields to catch bots #}
               <div class="u-off-screen">

--- a/templates/lxd/_form-lxd-install.html
+++ b/templates/lxd/_form-lxd-install.html
@@ -26,7 +26,7 @@
                   <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
-                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</p>
+                <p>By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy">Canonical's Privacy Policy</a>.</p>
               </div>
               {# These are honey pot fields to catch bots #}
               <div class="u-off-screen">

--- a/templates/solutions/_form-big-data-ai.html
+++ b/templates/solutions/_form-big-data-ai.html
@@ -45,7 +45,7 @@
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
               </div>
-            <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</div>
+            <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy">Canonical's Privacy Policy</a>.</div>
             {# These are honey pot fields to catch bots #}
             <div class="u-off-screen">
               <label class="website" for="website">Website:</label>

--- a/templates/solutions/_form-big-data-ai.html
+++ b/templates/solutions/_form-big-data-ai.html
@@ -45,7 +45,7 @@
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
               </div>
-            <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy">Canonical's Privacy Policy</a>.</div>
+            <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/data-privacy">Canonical's Privacy Policy</a>.</div>
             {# These are honey pot fields to catch bots #}
             <div class="u-off-screen">
               <label class="website" for="website">Website:</label>


### PR DESCRIPTION
## Done

- Updated privacy links so that they route to u.com as expected 

## QA

- View the site locally in your web browser at: https://canonical-com-1182.demos.haus/solutions/big-data-ai#get-in-touch and https://canonical-com-1182.demos.haus/lxd/install#get-in-touch
- See that the privacy policy link at the bottom no longer throws 404

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8870
