### PR TITLE
auto delete interviews on withdrawal (WD-7721)

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,6 @@ SECRET_KEY=local_development_fake_key
 # https://canonical.greenhouse.io/configure/dev_center/credentials
 HARVEST_API_KEY=
 APPLICATION_CRYPTO_SECRET_KEY=super_secret
+
+SERVICE_ACCOUNT_EMAIL=test_email@email.com
+SERVICE_ACCOUNT_PRIVATE_KEY=test_private_key

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -42,6 +42,9 @@ jobs:
 
       - name: Test site
         run: dotrun & curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost:8002
+        env:
+          SERVICE_ACCOUNT_EMAIL: test_email@email.com
+          SERVICE_ACCOUNT_PRIVATE_KEY: test_private_key
 
   lint-scss:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,7 +6,6 @@ env:
   APPLICATION_CRYPTO_SECRET_KEY: insecure_test_key
   SERVICE_ACCOUNT_EMAIL: test_email@email.com
   SERVICE_ACCOUNT_PRIVATE_KEY: test_private_key
-  TESTING: true
 
 jobs:
   run-image:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -42,9 +42,6 @@ jobs:
 
       - name: Test site
         run: dotrun & curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost:8002
-        env:
-          SERVICE_ACCOUNT_EMAIL: test_email@email.com
-          SERVICE_ACCOUNT_PRIVATE_KEY: test_private_key
 
   lint-scss:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,6 +6,7 @@ env:
   APPLICATION_CRYPTO_SECRET_KEY: insecure_test_key
   SERVICE_ACCOUNT_EMAIL: test_email@email.com
   SERVICE_ACCOUNT_PRIVATE_KEY: test_private_key
+  TESTING: true
 
 jobs:
   run-image:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,6 +4,8 @@ env:
   SECRET_KEY: insecure_test_key
   HARVEST_API_KEY: local_development_fake_key
   APPLICATION_CRYPTO_SECRET_KEY: insecure_test_key
+  SERVICE_ACCOUNT_EMAIL: test_email@email.com
+  SERVICE_ACCOUNT_PRIVATE_KEY: test_private_key
 
 jobs:
   run-image:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Run image
         run: |
-          docker run --detach --env SECRET_KEY=insecure_secret_key  --env APPLICATION_CRYPTO_SECRET_KEY=insecure_secret_key --network host canonical-com
+          docker run --detach --env SECRET_KEY=insecure_secret_key  --env APPLICATION_CRYPTO_SECRET_KEY=insecure_secret_key --env SERVICE_ACCOUNT_EMAIL=test_email@email.com --env SERVICE_ACCOUNT_PRIVATE_KEY=test_private_key --network host canonical-com
           sleep 1
           curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,3 @@
-# syntax=docker/dockerfile:experimental
-
-
 # Build stage: Install python dependencies
 # ===
 FROM ubuntu:focal AS python-dependencies

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -142,6 +142,9 @@ staging:
             key: token
             name: directory-api
 
+        - name: FLASK_DEBUG
+          value: True
+
   nginxConfigurationSnippet: |
     more_set_headers "X-Robots-Tag: noindex";
     if ($host != 'staging.canonical.com' ) {
@@ -155,3 +158,6 @@ demo:
       secretKeyRef:
         key: token
         name: directory-api
+
+    - name: FLASK_DEBUG
+      value: True

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ python-slugify==7.0.0
 vcrpy-unittest==0.1.7
 cryptography==36.0.2
 gql==2.0.0
+google-api-python-client==2.49.0
+google-auth-httplib2==0.1.0
+google-auth-oauthlib==0.5.1
+pytz==2024.1

--- a/templates/careers/application/_withdrawal-feedback-not-needed-email.html
+++ b/templates/careers/application/_withdrawal-feedback-not-needed-email.html
@@ -1,7 +1,8 @@
 <div>
   <p>Dear {{ interviewer_name }},</p>
   <p>This is an automated email to inform you that {{ applicant_name }} has withdrawn their application for the {{ position }} position.</p>
-  <p>As a result, there is no longer any need to submit a scorecard for your recent interview &quot;{{ interview_title }}&quot; with them on {{ interview_date }}.</p>
+  <p>As a result, you will not be able to submit the scorecard via Greenhouse for your recent interview &quot;{{ interview_title }}&quot; with them on {{ interview_date }}.</p>
+  <p>Please reach out to the Talent Science team so that you can submit your scorecard.</p>
   <p>Thank you for your committment to Canonical's hiring process!</p>
   <p>Regards,<br>Workplace Engineering</p>
 </div>

--- a/templates/careers/application/_withdrawal-feedback-not-needed-email.html
+++ b/templates/careers/application/_withdrawal-feedback-not-needed-email.html
@@ -1,0 +1,7 @@
+<div>
+  <p>Dear {{ interviewer_name }},</p>
+  <p>This is an automated email to inform you that {{ applicant_name }} has withdrawn their application for the {{ position }} position.</p>
+  <p>As a result, there is no longer any need to submit a scorecard for your recent interview &quot;{{ interview_title }}&quot; with them on {{ interview_date }}.</p>
+  <p>Thank you for your committment to Canonical's hiring process!</p>
+  <p>Regards,<br>Workplace Engineering</p>
+</div>

--- a/templates/careers/application/_withdrawal-interview-canceled-email.html
+++ b/templates/careers/application/_withdrawal-interview-canceled-email.html
@@ -1,0 +1,8 @@
+<div>
+  <p>Dear {{ interviewer_name }},</p>
+  <p>This is an automated email to inform you that your upcoming interview &quot;{{ interview_title }}&quot; with {{ applicant_name }} on {{ interview_date }} has been canceled.</p>
+  <p>The reason for the cancelation is that {{ applicant_name }} has withdrawn their application for the {{ position }} position.</p>
+  <p>You should receive a Google Calendar email notification of the cancelation soon if you haven't already.</p>
+  <p>Thank you for your committment to Canonical's hiring process!</p>
+  <p>Regards,<br>Workplace Engineering</p>
+</div>

--- a/templates/careers/application/_withdrawal_notification-email.html
+++ b/templates/careers/application/_withdrawal_notification-email.html
@@ -2,7 +2,7 @@
   <p>Dear {{ hiring_lead_name }},</p>
   <p>This is an automated email to inform you that {{ applicant_name }} has withdrawn their application for the {{ position }} position.</p>
   <p>The candidate was in {{ current_stage["name"] }} stage.</p>
-  <p>If this is an interview stage, please make sure you check the activity feed of the candidate in Greenhouse and delete any pending interviews directly from Google Calendar.</p>
+  <!-- <p>If this is an interview stage, please make sure you check the activity feed of the candidate in Greenhouse and delete any pending interviews directly from Google Calendar.</p> -->
   <p><a href="{{application_url}}">Click here to access the candidate's application.</a></p>
   <p>Regards,<br>Talent Science Engineering</p>
 </div>

--- a/templates/careers/application/_withdrawal_notification-email.html
+++ b/templates/careers/application/_withdrawal_notification-email.html
@@ -2,7 +2,6 @@
   <p>Dear {{ hiring_lead_name }},</p>
   <p>This is an automated email to inform you that {{ applicant_name }} has withdrawn their application for the {{ position }} position.</p>
   <p>The candidate was in {{ current_stage["name"] }} stage.</p>
-  <!-- <p>If this is an interview stage, please make sure you check the activity feed of the candidate in Greenhouse and delete any pending interviews directly from Google Calendar.</p> -->
   <p><a href="{{application_url}}">Click here to access the candidate's application.</a></p>
   <p>Regards,<br>Talent Science Engineering</p>
 </div>

--- a/templates/careers/application/withdrawal.html
+++ b/templates/careers/application/withdrawal.html
@@ -20,9 +20,9 @@
       </div>
 
       <!--
-        Similarly for interview canceled emails
+        Similarly for interview canceled/feedback not needed emails
       -->
-      {% for email in all_cancelation_emails %}
+      {% for email in all_sent_emails %}
         <div class="u-fixed-width">
           <div class="p-notification--caution">
             <div class="p-notification__content">

--- a/templates/careers/application/withdrawal.html
+++ b/templates/careers/application/withdrawal.html
@@ -18,6 +18,21 @@
           </div>
         </div>
       </div>
+
+      <!--
+        Similarly for interview canceled emails
+      -->
+      {% for email in all_cancelation_emails %}
+        <div class="u-fixed-width">
+          <div class="p-notification--caution">
+            <div class="p-notification__content">
+              <h5 class="p-notification__title">[DEBUG] This email wasn't sent because you're in debug mode</h5>
+              <p>The following email would have been sent to {{ email["interviewer"] }}:</p>
+              <p><blockquote>{{ email["message"] | safe }}</blockquote></p>
+            </div>
+          </div>
+        </div>
+      {% endfor %}
     {% endif %}
 </section>
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,4 +1,7 @@
+import json
 import unittest
+from unittest.mock import MagicMock, patch
+import flask
 
 from vcr_unittest import VCRTestCase
 from webapp.app import app
@@ -8,6 +11,7 @@ from webapp.application import (
     _get_gia_feedback,
     _get_employee_directory_data,
     _submitted_email_match,
+    application_withdrawal,
 )
 
 all_stages = [
@@ -254,3 +258,122 @@ class TestCandidateEmailMatches(unittest.TestCase):
         }
         self.assertTrue(_submitted_email_match("foo@bar.com", application))
         self.assertFalse(_submitted_email_match("a@b.com", application))
+
+class TestInterviewAutoDeletionOnWithdrawal(unittest.TestCase):
+    def setUp(self):
+        # fake constants
+        self.fake_application = {
+            "id": "123",
+            "role_name": "Fake Job",
+            "candidate": {"id": "444", "first_name": "John", "last_name": "Doe"},
+            "hiring_lead": {"id": "777", "name": "Hiring Lead", "emails": "hiring_lead@example.com"},
+            "current_stage": "Fake Stage"
+        }
+        self.fake_timezone = "America/Toronto"
+        self.fake_scheduled_interview = {
+            "status": "scheduled", # should remain after filtering
+            "interviewers": [
+                {
+                    "name": "Fake Interviewer 1",
+                    "email": "fake_interviewer1@email.com"
+                }
+            ],
+            "start": {
+                "date_time": "2024-02-29T20:00:00.000Z"
+            },
+            "external_event_id": "fake_event_id_1",
+            "interview": {
+                "name": "Fake Interview 1"
+            }
+        }
+        self.fake_completed_interview = {
+            "status": "completed", # should be filtered out
+            "interviewers": [
+                {
+                    "name": "Fake Interviewer 2",
+                    "email": "fake_interviewer2@email.com"
+                }
+            ],
+            "start": {
+                "date_time": "2024-02-27T20:00:00.000Z"
+            },
+            "external_event_id": "fake_event_id_2",
+            "interview": {
+                "name": "Fake Interview 2"
+            }
+        }
+        self.fake_withdrawal_reason_id = None
+        self.fake_withdrawal_message = None
+
+        # functions that we want to mock
+        self.mock_decrypt = patch("webapp.application.cipher.decrypt").start()
+        self.mock_get_application = patch("webapp.application._get_application").start()
+        self.mock_render_template = patch("webapp.application.flask.render_template").start()
+        self.mock_calendar_api = patch("webapp.application.calendar").start()
+        self.mock_reject_application = patch("webapp.application.harvest.reject_application").start()
+        self.mock_get_interviews_scheduled = patch("webapp.application.harvest.get_interviews_scheduled").start()
+        self.mock_send_mail = patch("webapp.application._send_mail").start()
+
+        # set return values for mocks
+        self.mock_decrypt.return_value = json.dumps({"application_id": self.fake_application["id"]})
+        self.mock_get_application.return_value = self.fake_application
+        self.mock_calendar_api.get_timezone.return_value = self.fake_timezone
+        self.mock_calendar_api.delete_event_from_interview_calendar.return_value = None
+        self.mock_reject_application.return_value = MagicMock(status_code=200)
+        self.mock_get_interviews_scheduled.return_value = [self.fake_scheduled_interview, self.fake_completed_interview]
+        self.mock_send_mail.return_value = None
+
+        # create test context
+        self.ctx = app.test_request_context()
+        self.ctx.push()
+
+        # set debug to true so we can test and ensure _send_mail is not called
+        flask.current_app.debug = True
+
+    def test_candidate_withdrawal_process(self):
+        # call application_withdrawal function with a fake token
+        application_withdrawal("fake_token")
+
+        # ensure that get_interviews_scheduled was called with the right id
+        self.mock_get_interviews_scheduled.assert_called_once_with(
+            self.fake_application["id"]
+        )
+
+        # ensure that delete_event_from_interview_calendar only called once
+        # (this asserts that the filtering worked, since only one of the
+        # fake interviews has a status of "scheduled")
+        self.mock_calendar_api.delete_event_from_interview_calendar.assert_called_once()
+
+        # ensure that delete_event_from_interview_calendar was called with
+        # the correct argument
+        self.mock_calendar_api.delete_event_from_interview_calendar.assert_called_with(event_id=self.fake_scheduled_interview["external_event_id"])
+
+        # ensure _send_mail is not called (since debug is True)
+        self.mock_send_mail.assert_not_called()
+
+        # ensure get_timezone is called with correct email
+        self.mock_calendar_api.get_timezone.assert_called_with(self.fake_scheduled_interview["interviewers"][0]["email"])
+
+        # ensure datetime conversion worked
+        expected_datetime = "February 29, 2024 at 03:00PM" # formatted version of fake_scheduled_interview["start"]["date_time"], based on fake_timezone
+        _, kwargs = self.mock_render_template.call_args_list[0] # first call to render_template should be for the interviewer emails which have interview_date passed
+        self.assertIn("interview_date", kwargs)
+        self.assertEqual(kwargs['interview_date'], expected_datetime)
+
+        # ensure that harvest rejection fn is called with correct arguments
+        self.mock_reject_application.assert_called_once_with(
+            self.fake_application["id"],
+            self.fake_application["hiring_lead"]["id"],
+            self.fake_withdrawal_reason_id,
+            self.fake_withdrawal_message
+        )
+
+    def tearDown(self):
+        # stop all of the patches from setUp
+        patch.stopall()
+
+        # pop the test context
+        self.ctx.pop()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -314,7 +314,7 @@ class TestInterviewAutoDeletionOnWithdrawal(unittest.TestCase):
         self.mock_render_template = patch(
             "webapp.application.flask.render_template"
         ).start()
-        self.mock_calendar_api = patch("webapp.application.calendar").start()
+        self.mock_cal = patch("webapp.application.CalendarAPI").start()
         self.mock_reject_application = patch(
             "webapp.application.harvest.reject_application"
         ).start()
@@ -331,8 +331,10 @@ class TestInterviewAutoDeletionOnWithdrawal(unittest.TestCase):
             {"application_id": self.fake_application["id"]}
         )
         self.mock_get_application.return_value = self.fake_application
-        self.mock_calendar_api.get_timezone.return_value = self.fake_timezone
-        self.mock_calendar_api.delete_interview_event.return_value = None
+        self.mock_cal.return_value.get_timezone.return_value = (
+            self.fake_timezone
+        )
+        self.mock_cal.return_value.delete_interview_event.return_value = None
         self.mock_reject_application.return_value = MagicMock(status_code=200)
         self.mock_get_interviews_scheduled.return_value = [
             self.fake_scheduled_interview,
@@ -360,11 +362,11 @@ class TestInterviewAutoDeletionOnWithdrawal(unittest.TestCase):
         # ensure that delete_interview_event only called once
         # (this asserts that the filtering worked, since only one of the
         # fake interviews has a status of "scheduled")
-        self.mock_calendar_api.delete_interview_event.assert_called_once()
+        self.mock_cal.return_value.delete_interview_event.assert_called_once()
 
         # ensure that delete_interview_event was called with
         # the correct argument
-        self.mock_calendar_api.delete_interview_event.assert_called_with(
+        self.mock_cal.return_value.delete_interview_event.assert_called_with(
             event_id=self.fake_scheduled_interview["external_event_id"]
         )
 
@@ -372,7 +374,7 @@ class TestInterviewAutoDeletionOnWithdrawal(unittest.TestCase):
         self.mock_send_mail.assert_not_called()
 
         # ensure get_timezone is called with correct email
-        self.mock_calendar_api.get_timezone.assert_called_with(
+        self.mock_cal.return_value.get_timezone.assert_called_with(
             self.fake_scheduled_interview["interviewers"][0]["email"]
         )
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -322,6 +322,9 @@ class TestInterviewAutoDeletionOnWithdrawal(unittest.TestCase):
             "webapp.application.harvest.get_interviews_scheduled"
         ).start()
         self.mock_send_mail = patch("webapp.application._send_mail").start()
+        self.mock_google_authenticate = patch(
+            "webapp.google_calendar.CalendarAPI._authenticate"
+        ).start()
 
         # set return values for mocks
         self.mock_decrypt.return_value = json.dumps(
@@ -336,6 +339,7 @@ class TestInterviewAutoDeletionOnWithdrawal(unittest.TestCase):
             self.fake_completed_interview,
         ]
         self.mock_send_mail.return_value = None
+        self.mock_google_authenticate = None
 
         # create test context
         self.ctx = app.test_request_context()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -306,7 +306,7 @@ class TestInterviewAutoDeletionOnWithdrawal(unittest.TestCase):
         self.fake_withdrawal_reason_id = None
         self.fake_withdrawal_message = None
 
-        # functions that we want to mock
+        # mock functions
         self.mock_decrypt = patch("webapp.application.cipher.decrypt").start()
         self.mock_get_application = patch(
             "webapp.application._get_application"

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -329,8 +329,7 @@ class TestInterviewAutoDeletionOnWithdrawal(unittest.TestCase):
         )
         self.mock_get_application.return_value = self.fake_application
         self.mock_calendar_api.get_timezone.return_value = self.fake_timezone
-        self.mock_calendar_api.delete_event_from_interview_calendar\
-            .return_value = None
+        self.mock_calendar_api.delete_interview_event.return_value = None
         self.mock_reject_application.return_value = MagicMock(status_code=200)
         self.mock_get_interviews_scheduled.return_value = [
             self.fake_scheduled_interview,
@@ -354,18 +353,16 @@ class TestInterviewAutoDeletionOnWithdrawal(unittest.TestCase):
             self.fake_application["id"]
         )
 
-        # ensure that delete_event_from_interview_calendar only called once
+        # ensure that delete_interview_event only called once
         # (this asserts that the filtering worked, since only one of the
         # fake interviews has a status of "scheduled")
-        self.mock_calendar_api.delete_event_from_interview_calendar\
-            .assert_called_once()
+        self.mock_calendar_api.delete_interview_event.assert_called_once()
 
-        # ensure that delete_event_from_interview_calendar was called with
+        # ensure that delete_interview_event was called with
         # the correct argument
-        self.mock_calendar_api.delete_event_from_interview_calendar\
-            .assert_called_with(
-                event_id=self.fake_scheduled_interview["external_event_id"]
-            )
+        self.mock_calendar_api.delete_interview_event.assert_called_with(
+            event_id=self.fake_scheduled_interview["external_event_id"]
+        )
 
         # ensure _send_mail is not called (since debug is True)
         self.mock_send_mail.assert_not_called()

--- a/tests/test_google_calendar.py
+++ b/tests/test_google_calendar.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import MagicMock, patch
-from datetime import datetime, timedelta
 from webapp.google_calendar import CalendarAPI
 
 # Interview calendar
@@ -34,51 +33,6 @@ class TestGoogleCalendar(unittest.TestCase):
 
         # create a CalendarAPI object
         self.calendar_api = CalendarAPI()
-
-    def test_get_events(self):
-        # create datetime objects for start and end
-        start = datetime.now() - timedelta(days=1)
-        end = datetime.now()
-
-        # call the get_events method
-        self.calendar_api.get_events(self.fake_calendar_id, start, end)
-
-        # assertions
-        self.mock_events.list.assert_called_with(
-            calendarId=self.fake_calendar_id,
-            timeMin=start.isoformat() + "Z",
-            timeMax=end.isoformat() + "Z",
-            singleEvents=True,
-            orderBy="startTime",
-        )
-        self.mock_events.list().execute.assert_called_once()
-
-    def test_get_single_event(self):
-        # call the get_single_event method
-        self.calendar_api.get_single_event(
-            self.fake_calendar_id, self.fake_event_id
-        )
-
-        # assertions
-        self.mock_events.get.assert_called_with(
-            calendarId=self.fake_calendar_id,
-            eventId=self.fake_event_id,
-        )
-        self.mock_events.get().execute.assert_called_once()
-
-    def test_delete_event(self):
-        # call the delete_event method
-        self.calendar_api.delete_event(
-            self.fake_calendar_id, self.fake_event_id
-        )
-
-        # assertions
-        self.mock_events.delete.assert_called_with(
-            calendarId=self.fake_calendar_id,
-            eventId=self.fake_event_id,
-            sendUpdates="all",
-        )
-        self.mock_events.delete().execute.assert_called_once()
 
     def test_delete_interview_event(self):
         # call the delete_interview_event method

--- a/tests/test_google_calendar.py
+++ b/tests/test_google_calendar.py
@@ -9,16 +9,20 @@ INTERVIEW_CALENDAR = (
     + "264f99684232ee4ec491@group.calendar.google.com"
 )
 
+
 class TestGoogleCalendar(unittest.TestCase):
-    @patch('webapp.google_calendar.build')
-    @patch('webapp.google_calendar.service_account.Credentials.from_service_account_info')
+    @patch("webapp.google_calendar.build")
+    @patch(
+        "webapp.google_calendar.service_account."
+        + "Credentials.from_service_account_info"
+    )
     def setUp(self, mock_from_service_account_info, mock_build):
         # fake constants
         self.fake_calendar_id = "calendar_id"
         self.fake_event_id = "event_id"
         self.fake_timezone = "America/Toronto"
         self.fake_email = "email@email.com"
-        
+
         # mock functions
         self.mock_service = MagicMock()
         self.mock_events = MagicMock()
@@ -45,13 +49,15 @@ class TestGoogleCalendar(unittest.TestCase):
             timeMin=start.isoformat() + "Z",
             timeMax=end.isoformat() + "Z",
             singleEvents=True,
-            orderBy='startTime',
+            orderBy="startTime",
         )
         self.mock_events.list().execute.assert_called_once()
 
     def test_get_single_event(self):
         # call the get_single_event method
-        self.calendar_api.get_single_event(self.fake_calendar_id, self.fake_event_id)
+        self.calendar_api.get_single_event(
+            self.fake_calendar_id, self.fake_event_id
+        )
 
         # assertions
         self.mock_events.get.assert_called_with(
@@ -59,10 +65,12 @@ class TestGoogleCalendar(unittest.TestCase):
             eventId=self.fake_event_id,
         )
         self.mock_events.get().execute.assert_called_once()
-    
+
     def test_delete_event(self):
         # call the delete_event method
-        self.calendar_api.delete_event(self.fake_calendar_id, self.fake_event_id)
+        self.calendar_api.delete_event(
+            self.fake_calendar_id, self.fake_event_id
+        )
 
         # assertions
         self.mock_events.delete.assert_called_with(
@@ -83,14 +91,16 @@ class TestGoogleCalendar(unittest.TestCase):
             sendUpdates="all",
         )
         self.mock_events.delete().execute.assert_called_once()
-    
+
     def test_get_timezone(self):
         # create a mock_calendars object
         mock_calendars = MagicMock()
 
         # set return values
         self.mock_service.calendars.return_value = mock_calendars
-        mock_calendars.get().execute.return_value = {"timeZone": self.fake_timezone}
+        mock_calendars.get().execute.return_value = {
+            "timeZone": self.fake_timezone
+        }
 
         # call the get_timezone method
         timezone = self.calendar_api.get_timezone(self.fake_email)

--- a/tests/test_google_calendar.py
+++ b/tests/test_google_calendar.py
@@ -1,0 +1,105 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timedelta
+from webapp.google_calendar import CalendarAPI
+
+# Interview calendar
+INTERVIEW_CALENDAR = (
+    "c_0a3348ba0132da2077be501edacc1ba7415ac132612d"
+    + "264f99684232ee4ec491@group.calendar.google.com"
+)
+
+class TestGoogleCalendar(unittest.TestCase):
+    @patch('webapp.google_calendar.build')
+    @patch('webapp.google_calendar.service_account.Credentials.from_service_account_info')
+    def setUp(self, mock_from_service_account_info, mock_build):
+        # fake constants
+        self.fake_calendar_id = "calendar_id"
+        self.fake_event_id = "event_id"
+        self.fake_timezone = "America/Toronto"
+        self.fake_email = "email@email.com"
+        
+        # mock functions
+        self.mock_service = MagicMock()
+        self.mock_events = MagicMock()
+        mock_from_service_account_info.return_value = MagicMock()
+
+        # set return values of mocks
+        self.mock_service.events.return_value = self.mock_events
+        mock_build.return_value = self.mock_service
+
+        # create a CalendarAPI object
+        self.calendar_api = CalendarAPI()
+
+    def test_get_events(self):
+        # create datetime objects for start and end
+        start = datetime.now() - timedelta(days=1)
+        end = datetime.now()
+
+        # call the get_events method
+        self.calendar_api.get_events(self.fake_calendar_id, start, end)
+
+        # assertions
+        self.mock_events.list.assert_called_with(
+            calendarId=self.fake_calendar_id,
+            timeMin=start.isoformat() + "Z",
+            timeMax=end.isoformat() + "Z",
+            singleEvents=True,
+            orderBy='startTime',
+        )
+        self.mock_events.list().execute.assert_called_once()
+
+    def test_get_single_event(self):
+        # call the get_single_event method
+        self.calendar_api.get_single_event(self.fake_calendar_id, self.fake_event_id)
+
+        # assertions
+        self.mock_events.get.assert_called_with(
+            calendarId=self.fake_calendar_id,
+            eventId=self.fake_event_id,
+        )
+        self.mock_events.get().execute.assert_called_once()
+    
+    def test_delete_event(self):
+        # call the delete_event method
+        self.calendar_api.delete_event(self.fake_calendar_id, self.fake_event_id)
+
+        # assertions
+        self.mock_events.delete.assert_called_with(
+            calendarId=self.fake_calendar_id,
+            eventId=self.fake_event_id,
+            sendUpdates="all",
+        )
+        self.mock_events.delete().execute.assert_called_once()
+
+    def test_delete_interview_event(self):
+        # call the delete_interview_event method
+        self.calendar_api.delete_interview_event(self.fake_event_id)
+
+        # assertions
+        self.mock_events.delete.assert_called_with(
+            calendarId=INTERVIEW_CALENDAR,
+            eventId=self.fake_event_id,
+            sendUpdates="all",
+        )
+        self.mock_events.delete().execute.assert_called_once()
+    
+    def test_get_timezone(self):
+        # create a mock_calendars object
+        mock_calendars = MagicMock()
+
+        # set return values
+        self.mock_service.calendars.return_value = mock_calendars
+        mock_calendars.get().execute.return_value = {"timeZone": self.fake_timezone}
+
+        # call the get_timezone method
+        timezone = self.calendar_api.get_timezone(self.fake_email)
+
+        # assertions
+        mock_calendars.get.assert_called_with(calendarId=self.fake_email)
+        mock_calendars.get().execute.assert_called_once()
+        self.assertEqual(timezone, self.fake_timezone)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,7 +1,6 @@
 import logging
 
 from vcr_unittest import VCRTestCase
-from unittest.mock import patch
 from webapp.app import app
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,7 +1,7 @@
 import logging
 
 from vcr_unittest import VCRTestCase
-import unittest
+from unittest.mock import patch
 from webapp.app import app
 
 
@@ -151,6 +151,3 @@ class TestRoutes(VCRTestCase):
         """
 
         self.assertEqual(self.client.get("/not-found-url").status_code, 404)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,7 @@
 import logging
 
 from vcr_unittest import VCRTestCase
+import unittest
 from webapp.app import app
 
 
@@ -150,3 +151,6 @@ class TestRoutes(VCRTestCase):
         """
 
         self.assertEqual(self.client.get("/not-found-url").status_code, 404)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -77,7 +77,6 @@ application = flask.Blueprint(
 
 session = talisker.requests.get_session()
 harvest = Harvest(session=session, api_key=os.environ.get("HARVEST_API_KEY"))
-calendar = CalendarAPI()
 cipher = Cipher(os.environ.get("APPLICATION_CRYPTO_SECRET_KEY"))
 base_url = "https://harvest.greenhouse.io/v1"
 
@@ -496,6 +495,7 @@ def application_withdrawal(token):
     ]
     all_sent_emails = []
 
+    calendar = CalendarAPI()
     for scheduled_interview in scheduled_interviews:
         # get interviewer information
         interviewer = scheduled_interview["interviewers"][0]

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -487,15 +487,6 @@ def application_withdrawal(token):
         f"application_id={payload['application_id']}"
     )
 
-    # call the Harvest API to reject the application
-    response = harvest.reject_application(
-        application["id"],
-        application["hiring_lead"]["id"],
-        withdrawal_reason_id,
-        withdrawal_message,
-    )
-    response.raise_for_status()
-
     # get all scheduled interviews
     scheduled_interviews = harvest.get_interviews_scheduled(application["id"])
     scheduled_interviews = [
@@ -549,6 +540,15 @@ def application_withdrawal(token):
                     "Interview Cancelation - Candidate Withdrawal for " + applicant_name,
                     interview_canceled_email,
                 )
+
+    # call the Harvest API to reject the application
+    response = harvest.reject_application(
+        application["id"],
+        application["hiring_lead"]["id"],
+        withdrawal_reason_id,
+        withdrawal_message,
+    )
+    response.raise_for_status()
 
     email_message = flask.render_template(
         "careers/application/_withdrawal_notification-email.html",

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -77,6 +77,7 @@ application = flask.Blueprint(
 
 session = talisker.requests.get_session()
 harvest = Harvest(session=session, api_key=os.environ.get("HARVEST_API_KEY"))
+calendar = CalendarAPI()
 cipher = Cipher(os.environ.get("APPLICATION_CRYPTO_SECRET_KEY"))
 base_url = "https://harvest.greenhouse.io/v1"
 
@@ -486,16 +487,15 @@ def application_withdrawal(token):
         f"application_id={payload['application_id']}"
     )
 
-    # get all scheduled interviews
+    # get all candidate interviews from Harvest API
     scheduled_interviews = harvest.get_interviews_scheduled(application["id"])
     scheduled_interviews = [
         interview
         for interview in scheduled_interviews
         if interview["status"] == "scheduled"
     ]
-    all_cancelation_emails = []
+    all_sent_emails = []
 
-    calendar = CalendarAPI()
     for scheduled_interview in scheduled_interviews:
         # get interviewer information
         interviewer = scheduled_interview["interviewers"][0]
@@ -529,7 +529,7 @@ def application_withdrawal(token):
                 interview_date=interview_date,
                 position=application["role_name"],
             )
-            all_cancelation_emails.append(
+            all_sent_emails.append(
                 {
                     "interviewer": interviewer["email"],
                     "message": interview_canceled_email,
@@ -577,7 +577,7 @@ def application_withdrawal(token):
         debug_skip_sending=debug_skip_sending,
         email_message=email_message,
         hiring_lead_email=hiring_lead_email,
-        all_cancelation_emails=all_cancelation_emails,
+        all_sent_emails=all_sent_emails,
     )
 
 

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -10,6 +10,7 @@ from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 from requests.exceptions import HTTPError
 import pytz
+import logging
 
 
 import flask
@@ -522,7 +523,7 @@ def application_withdrawal(token):
             # empty response is returned on successful deletion
             # so raise exception if not empty
             if delete_response:
-                raise Exception(
+                logging.error(
                     "Delete response not empty, error deleting event:\n"
                     + str(delete_response)
                 )

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -543,7 +543,7 @@ def application_withdrawal(token):
                 + "-feedback-not-needed-email.html"
             )
             email_title = (
-                "Interview Feedback Not Needed - "
+                "Interview Feedback - "
                 + f"Candidate Withdrawal for {applicant_name}"
             )
 
@@ -566,8 +566,10 @@ def application_withdrawal(token):
         # send email
         debug_skip_sending = flask.current_app.debug
         if not debug_skip_sending:
+            # also sending cancelation/feedback email to TS inbox
+            # for tracking from their end.
             _send_mail(
-                interviewer["email"],
+                [interviewer["email"], "talent-mailbox@canonical.com"],
                 email_title,
                 email_for_interviewer,
             )

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -504,7 +504,7 @@ def application_withdrawal(token):
         if interview["status"] == "scheduled"
     ]
     all_cancelation_emails = []
-    
+
     for scheduled_interview in scheduled_interviews:
         # get interviewer information
         interviewer = scheduled_interview["interviewers"][0]

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -502,14 +502,16 @@ def application_withdrawal(token):
         interviewer_timezone = calendar.get_timezone(interviewer["email"])
 
         # convert interview time to interviewer's timezone
-        date_time_str = interview["start"]["date_time"]
-        date_time_obj = datetime.fromisoformat(
-            date_time_str.replace("Z", "+00:00")
+        interview_datetime_str = interview["start"]["date_time"]
+        interview_datetime_obj = datetime.fromisoformat(
+            interview_datetime_str.replace("Z", "+00:00")
         )
-        date_time_obj = date_time_obj.astimezone(
+        interview_datetime_obj = interview_datetime_obj.astimezone(
             pytz.timezone(interviewer_timezone)
         )
-        interview_date = date_time_obj.strftime("%B %d, %Y at %I:%M%p")
+        interview_date = interview_datetime_obj.strftime(
+            "%B %d, %Y at %I:%M%p"
+        )
 
         if interview["status"] == "scheduled":
             # if interview still upcoming, delete interview event

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -517,30 +517,43 @@ def application_withdrawal(token):
                 event_id=interview["external_event_id"]
             )
 
-            # empty response is returned on successful deletion so raise exception if not empty
+            # empty response is returned on successful deletion
+            # so raise exception if not empty
             if delete_response:
                 raise Exception(
                     "Delete response not empty, error deleting event:\n"
                     + str(delete_response)
                 )
-            
+
             # email template and title for canceled interview
-            email_template = "careers/application/_withdrawal-interview-canceled-email.html"
-            email_title = f"Interview Cancelation - Candidate Withdrawal for {applicant_name}"
+            email_template = (
+                "careers/application/_withdrawal"
+                + "-interview-canceled-email.html"
+            )
+            email_title = (
+                "Interview Cancelation - "
+                + f"Candidate Withdrawal for {applicant_name}"
+            )
         else:
             # otherwise, set email template and title for feedback not needed
-            email_template = "careers/application/_withdrawal-feedback-not-needed-email.html"
-            email_title = f"Interview Feedback Not Needed - Candidate Withdrawal for {applicant_name}"
-            
+            email_template = (
+                "careers/application/_withdrawal"
+                + "-feedback-not-needed-email.html"
+            )
+            email_title = (
+                "Interview Feedback Not Needed - "
+                + f"Candidate Withdrawal for {applicant_name}"
+            )
+
         # build email to send to interviewer
         email_for_interviewer = flask.render_template(
-                email_template,
-                interviewer_name=interviewer["name"],
-                interview_title=interview["interview"]["name"],
-                applicant_name=applicant_name,
-                interview_date=interview_date,
-                position=application["role_name"],
-            )
+            email_template,
+            interviewer_name=interviewer["name"],
+            interview_title=interview["interview"]["name"],
+            applicant_name=applicant_name,
+            interview_date=interview_date,
+            position=application["role_name"],
+        )
         all_sent_emails.append(
             {
                 "interviewer": interviewer["email"],

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -521,23 +521,27 @@ def application_withdrawal(token):
             # send email to interviewer
             # confirming cancelation of their interview
             interview_canceled_email = flask.render_template(
-                "careers/application/_withdrawal-interview-canceled-email.html",
+                "careers/application/_withdrawal"
+                + "-interview-canceled-email.html",
                 interviewer_name=interviewer["name"],
                 interview_title=scheduled_interview["interview"]["name"],
                 applicant_name=applicant_name,
                 interview_date=interview_date,
                 position=application["role_name"],
             )
-            all_cancelation_emails.append({
-                "interviewer": interviewer["email"],
-                "message": interview_canceled_email
-            })
+            all_cancelation_emails.append(
+                {
+                    "interviewer": interviewer["email"],
+                    "message": interview_canceled_email,
+                }
+            )
 
             debug_skip_sending = flask.current_app.debug
             if not debug_skip_sending:
                 _send_mail(
                     interviewer["email"],
-                    "Interview Cancelation - Candidate Withdrawal for " + applicant_name,
+                    "Interview Cancelation - Candidate Withdrawal for "
+                    + applicant_name,
                     interview_canceled_email,
                 )
 

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -512,7 +512,7 @@ def application_withdrawal(token):
         interview_date = date_time_obj.strftime("%B %d, %Y at %I:%M%p")
 
         # delete interview event
-        delete_response = calendar.delete_event_from_interview_calendar(
+        delete_response = calendar.delete_interview_event(
             event_id=scheduled_interview["external_event_id"]
         )
 

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -517,8 +517,6 @@ def application_withdrawal(token):
 
         # if deletion successful, empty response object is returned
         if not delete_response:
-            print(f"SUCCESS: Canceled interview between {interviewer['name']} (interviewer) and {applicant_name} (candidate)")
-
             # send email to interviewer confirming cancelation of their interview
             interview_canceled_email = flask.render_template(
                 "careers/application/_withdrawal-interview-canceled-email.html",

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -498,26 +498,37 @@ def application_withdrawal(token):
 
     # get all scheduled interviews
     scheduled_interviews = harvest.get_interviews_scheduled(application["id"])
-    scheduled_interviews = [interview for interview in scheduled_interviews if interview["status"] == "scheduled"]
+    scheduled_interviews = [
+        interview
+        for interview in scheduled_interviews
+        if interview["status"] == "scheduled"
+    ]
     all_cancelation_emails = []
-        
+    
     for scheduled_interview in scheduled_interviews:
         # get interviewer information
         interviewer = scheduled_interview["interviewers"][0]
-        interviewer_timezone = calendar.get_timezone(email=interviewer["email"])
+        interviewer_timezone = calendar.get_timezone(interviewer["email"])
 
         # convert interview time to interviewer's timezone
         date_time_str = scheduled_interview["start"]["date_time"]
-        date_time_obj = datetime.fromisoformat(date_time_str.replace("Z", "+00:00"))
-        date_time_obj = date_time_obj.astimezone(pytz.timezone(interviewer_timezone))
+        date_time_obj = datetime.fromisoformat(
+            date_time_str.replace("Z", "+00:00")
+        )
+        date_time_obj = date_time_obj.astimezone(
+            pytz.timezone(interviewer_timezone)
+        )
         interview_date = date_time_obj.strftime("%B %d, %Y at %I:%M%p")
 
         # delete interview event
-        delete_response = calendar.delete_event_from_interview_calendar(event_id=scheduled_interview["external_event_id"])
+        delete_response = calendar.delete_event_from_interview_calendar(
+            event_id=scheduled_interview["external_event_id"]
+        )
 
         # if deletion successful, empty response object is returned
         if not delete_response:
-            # send email to interviewer confirming cancelation of their interview
+            # send email to interviewer
+            # confirming cancelation of their interview
             interview_canceled_email = flask.render_template(
                 "careers/application/_withdrawal-interview-canceled-email.html",
                 interviewer_name=interviewer["name"],
@@ -526,7 +537,10 @@ def application_withdrawal(token):
                 interview_date=interview_date,
                 position=application["role_name"],
             )
-            all_cancelation_emails.append({ "interviewer": interviewer["email"], "message": interview_canceled_email })
+            all_cancelation_emails.append({
+                "interviewer": interviewer["email"],
+                "message": interview_canceled_email
+            })
 
             debug_skip_sending = flask.current_app.debug
             if not debug_skip_sending:

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -79,7 +79,6 @@ session = talisker.requests.get_session()
 harvest = Harvest(session=session, api_key=os.environ.get("HARVEST_API_KEY"))
 cipher = Cipher(os.environ.get("APPLICATION_CRYPTO_SECRET_KEY"))
 base_url = "https://harvest.greenhouse.io/v1"
-calendar = CalendarAPI()
 
 directory_api_url = "https://directory.wpe.internal/graphql/"
 directory_api_token = f'token {os.getenv("DIRECTORY_API_TOKEN", "")}'
@@ -496,6 +495,7 @@ def application_withdrawal(token):
     ]
     all_cancelation_emails = []
 
+    calendar = CalendarAPI()
     for scheduled_interview in scheduled_interviews:
         # get interviewer information
         interviewer = scheduled_interview["interviewers"][0]

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -8,7 +8,9 @@ import os
 SERVICE_ACCOUNT_INFO = {
     "token_uri": "https://oauth2.googleapis.com/token",
     "client_email": os.environ.get("SERVICE_ACCOUNT_EMAIL"),
-    "private_key": os.environ.get("SERVICE_ACCOUNT_PRIVATE_KEY").replace("\\n", "\n"),
+    "private_key": os.environ
+                    .get("SERVICE_ACCOUNT_PRIVATE_KEY")
+                    .replace("\\n", "\n"),
 }
 
 # Workplace Engineering account
@@ -16,6 +18,7 @@ WPE_EMAIL = "wpe-data@canonical.com"
 
 # Interview calendar
 INTERVIEW_CALENDAR = "c_0a3348ba0132da2077be501edacc1ba7415ac132612d264f99684232ee4ec491@group.calendar.google.com"
+
 
 class CalendarAPI:
     def __init__(self):
@@ -35,7 +38,7 @@ class CalendarAPI:
             print("An error occurred: %s" % error)
 
         return service
-    
+
     def get_events(self, calendar_id, start, end):
         return (
             self.service.events()
@@ -48,7 +51,7 @@ class CalendarAPI:
             )
             .execute()
         )
-    
+
     def get_single_event(self, calendar_id, event_id):
         return (
             self.service.events()
@@ -58,7 +61,7 @@ class CalendarAPI:
             )
             .execute()
         )
-    
+
     def delete_event(self, calendar_id, event_id):
         return (
             self.service.events()
@@ -69,7 +72,7 @@ class CalendarAPI:
             )
             .execute()
         )
-    
+
     def delete_event_from_interview_calendar(self, event_id):
         return (
             self.service.events()

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -30,7 +30,8 @@ class CalendarAPI:
     def _authenticate(self):
         # don't authenticate in test env since key is a dummy key and will
         # give an error
-        if os.environ.get("TESTING"): return None
+        if os.environ.get("TESTING"):
+            return None
 
         # authenticate
         SCOPES = ["https://www.googleapis.com/auth/calendar"]

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -28,11 +28,6 @@ class CalendarAPI:
         self.service = self._authenticate()
 
     def _authenticate(self):
-        # don't authenticate in test env since key is a fake key and will
-        # give an error
-        if os.environ.get("TESTING"):
-            return None
-
         # authenticate
         SCOPES = ["https://www.googleapis.com/auth/calendar"]
         credentials = service_account.Credentials.from_service_account_info(

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -43,35 +43,6 @@ class CalendarAPI:
 
         return service
 
-    def get_events(self, calendar_id, start, end):
-        return (
-            self.service.events()
-            .list(
-                calendarId=calendar_id,
-                timeMin=start.isoformat() + "Z",
-                timeMax=end.isoformat() + "Z",
-                singleEvents=True,
-                orderBy="startTime",
-            )
-            .execute()
-        )
-
-    def get_single_event(self, calendar_id, event_id):
-        return (
-            self.service.events()
-            .get(calendarId=calendar_id, eventId=event_id)
-            .execute()
-        )
-
-    def delete_event(self, calendar_id, event_id):
-        return (
-            self.service.events()
-            .delete(
-                calendarId=calendar_id, eventId=event_id, sendUpdates="all"
-            )
-            .execute()
-        )
-
     def delete_interview_event(self, event_id):
         return (
             self.service.events()

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -28,6 +28,11 @@ class CalendarAPI:
         self.service = self._authenticate()
 
     def _authenticate(self):
+        # don't authenticate in test env since key is a dummy key and will
+        # give an error
+        if os.environ.get("TESTING"): return None
+
+        # authenticate
         SCOPES = ["https://www.googleapis.com/auth/calendar"]
         credentials = service_account.Credentials.from_service_account_info(
             SERVICE_ACCOUNT_INFO, scopes=SCOPES

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -1,8 +1,8 @@
+import os
+
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-
-import os
 
 # Google Calendar credentials
 SERVICE_ACCOUNT_INFO = {

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -28,7 +28,7 @@ class CalendarAPI:
         self.service = self._authenticate()
 
     def _authenticate(self):
-        # don't authenticate in test env since key is a dummy key and will
+        # don't authenticate in test env since key is a fake key and will
         # give an error
         if os.environ.get("TESTING"):
             return None

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -8,16 +8,19 @@ import os
 SERVICE_ACCOUNT_INFO = {
     "token_uri": "https://oauth2.googleapis.com/token",
     "client_email": os.environ.get("SERVICE_ACCOUNT_EMAIL"),
-    "private_key": os.environ
-                   .get("SERVICE_ACCOUNT_PRIVATE_KEY")
-                   .replace("\\n", "\n"),
+    "private_key": os.environ.get("SERVICE_ACCOUNT_PRIVATE_KEY").replace(
+        "\\n", "\n"
+    ),
 }
 
 # Workplace Engineering account
 WPE_EMAIL = "wpe-data@canonical.com"
 
 # Interview calendar
-INTERVIEW_CALENDAR = "c_0a3348ba0132da2077be501edacc1ba7415ac132612d264f99684232ee4ec491@group.calendar.google.com"
+INTERVIEW_CALENDAR = (
+    "c_0a3348ba0132da2077be501edacc1ba7415ac132612d"
+    + "264f99684232ee4ec491@group.calendar.google.com"
+)
 
 
 class CalendarAPI:
@@ -55,10 +58,7 @@ class CalendarAPI:
     def get_single_event(self, calendar_id, event_id):
         return (
             self.service.events()
-            .get(
-                calendarId=calendar_id,
-                eventId=event_id
-            )
+            .get(calendarId=calendar_id, eventId=event_id)
             .execute()
         )
 
@@ -66,9 +66,7 @@ class CalendarAPI:
         return (
             self.service.events()
             .delete(
-                calendarId=calendar_id,
-                eventId=event_id,
-                sendUpdates="all"
+                calendarId=calendar_id, eventId=event_id, sendUpdates="all"
             )
             .execute()
         )
@@ -79,7 +77,7 @@ class CalendarAPI:
             .delete(
                 calendarId=INTERVIEW_CALENDAR,
                 eventId=event_id,
-                sendUpdates="all"
+                sendUpdates="all",
             )
             .execute()
         )

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -77,7 +77,7 @@ class CalendarAPI:
             .execute()
         )
 
-    def delete_event_from_interview_calendar(self, event_id):
+    def delete_interview_event(self, event_id):
         return (
             self.service.events()
             .delete(

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -9,8 +9,8 @@ SERVICE_ACCOUNT_INFO = {
     "token_uri": "https://oauth2.googleapis.com/token",
     "client_email": os.environ.get("SERVICE_ACCOUNT_EMAIL"),
     "private_key": os.environ
-                    .get("SERVICE_ACCOUNT_PRIVATE_KEY")
-                    .replace("\\n", "\n"),
+                   .get("SERVICE_ACCOUNT_PRIVATE_KEY")
+                   .replace("\\n", "\n"),
 }
 
 # Workplace Engineering account
@@ -83,7 +83,7 @@ class CalendarAPI:
             )
             .execute()
         )
-    
+
     def get_timezone(self, email):
         calendar = self.service.calendars().get(calendarId=email).execute()
 

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -1,0 +1,87 @@
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+import os
+
+# Google Calendar credentials
+SERVICE_ACCOUNT_INFO = {
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "client_email": os.environ.get("SERVICE_ACCOUNT_EMAIL"),
+    "private_key": os.environ.get("SERVICE_ACCOUNT_PRIVATE_KEY").replace("\\n", "\n"),
+}
+
+# Workplace Engineering account
+WPE_EMAIL = "wpe-data@canonical.com"
+
+# Interview calendar
+INTERVIEW_CALENDAR = "c_0a3348ba0132da2077be501edacc1ba7415ac132612d264f99684232ee4ec491@group.calendar.google.com"
+
+class CalendarAPI:
+    def __init__(self):
+        self.service = self._authenticate()
+
+    def _authenticate(self):
+        SCOPES = ["https://www.googleapis.com/auth/calendar"]
+        credentials = service_account.Credentials.from_service_account_info(
+            SERVICE_ACCOUNT_INFO, scopes=SCOPES
+        )
+        try:
+            delegated_credentials = credentials.with_subject(WPE_EMAIL)
+            service = build(
+                "calendar", "v3", credentials=delegated_credentials
+            )
+        except HttpError as error:
+            print("An error occurred: %s" % error)
+
+        return service
+    
+    def get_events(self, calendar_id, start, end):
+        return (
+            self.service.events()
+            .list(
+                calendarId=calendar_id,
+                timeMin=start.isoformat() + "Z",
+                timeMax=end.isoformat() + "Z",
+                singleEvents=True,
+                orderBy="startTime",
+            )
+            .execute()
+        )
+    
+    def get_single_event(self, calendar_id, event_id):
+        return (
+            self.service.events()
+            .get(
+                calendarId=calendar_id,
+                eventId=event_id
+            )
+            .execute()
+        )
+    
+    def delete_event(self, calendar_id, event_id):
+        return (
+            self.service.events()
+            .delete(
+                calendarId=calendar_id,
+                eventId=event_id,
+                sendUpdates="all"
+            )
+            .execute()
+        )
+    
+    def delete_event_from_interview_calendar(self, event_id):
+        return (
+            self.service.events()
+            .delete(
+                calendarId=INTERVIEW_CALENDAR,
+                eventId=event_id,
+                sendUpdates="all"
+            )
+            .execute()
+        )
+    
+    def get_timezone(self, email):
+        calendar = self.service.calendars().get(calendarId=email).execute()
+
+        return calendar["timeZone"]


### PR DESCRIPTION
## Done

- Added Google Calendar API class
  - Class taken from the [interview scheduler repo](https://github.com/canonical/interview-scheduler/blob/main/scheduler/google_calendar.py)
  - Added a `delete_event_from_interview_calendar()` function which as you might guess deletes an interview from the interview calendar (the interview calendar is the shared calendar on which all interviews are scheduled)
  - Also added `sendUpdates="all"` to the delete request itself. This ensures a notification is sent to all attendees of the meeting telling them that it was canceled. The old parameter for this was `sendNotifications` (a boolean), but that has since been deprecated.
- Updated the email sent to the hiring lead when a candidate withdraws. Before, it explicitly told them to look for any pending interviews and delete them, but now this isn't necessary anymore since it will happen automatically.
- Created a new template for the email that will be sent to each interviewer letting them know that their interview was canceled because the candidate withdrew their application.
- Added debug mode functionality to the main `/templates/application/withdrawal.html` template (which is displayed once the candidate withdrawal is confirmed) to display the emails that would have been sent to the interviewers if not in debug mode.
- Implemented the actual interview auto-deletion flow:
  - When the candidate clicks on the confirmation link they received in their email to confirm their withdrawal, the `application_withdrawal()` (line 465 in `/webapp/application.py`) function is called.
  - Inside this function, we pull all the scheduled interviews for the current application from the Harvest API and filter for the ones with a status of `scheduled` (the other options for this status are `complete` and `awaiting_feedback`, both of which indicate that the interview has already happened and thus does not need to be deleted).
  - We loop through this list of scheduled interviews, grab the interviewer info and their timezone, format the interview date/time to match the interviewers timezone (so that the email they receive shows the correct time for them), delete the interview, and then create the email to alert the interviewer of the cancelation.
  - Each cancelation interview is saved in an array so that we can display them all in debug mode.
  - **UPDATE:** We are now also pulling the interviews with a status of `awaiting_feedback` so that we can alert those interviewers that a scorecard submission is no longer necessary. These interview events are not deleted however, as they will have already passed.

## QA

### Prep
- Add `SERVICE_ACCOUNT_EMAIL` and `SERVICE_ACCOUNT_PRIVATE_KEY` to `.env.local` (for Google Calendar API)
- Create a test candidate on GH for the "Dev - test 1" job. Make sure to input your email address (or one you have access to) since it will be needed to set the candidate's availabilities
- Move the test candidate to the "Early Stage Interviews" stage.
- Add yourself as a default interviewer for this candidate.
- Input candidate availabilities via email specifically. I.e. click "Request Availability", send the email, fill out the form received in email.
- Wait for main interview-scheduler cronjob to run (it runs every 4 hours) or run the test-scheduler cronjob, then an interview should be scheduled.
  - **NB:** I also have a local script that can schedule these interviews the same way the interview-scheduler does, so if you aren't getting one scheduled when it runs (this can happen sometimes if it just doesn't find one to schedule) or if it's just taking too long, let me know and I can manually schedule a test interview for you.
- Make sure the interview actually shows up in GH, otherwise it won't show up in the scheduled interviews returned from the Harvest API.
- Once there is a scheduled interview in GH, you can move on to the steps below to run the site and test the deletion process.

### Testing the auto-deletion flow
- Check out this feature branch
- Run the site with `dotrun`
- View the site locally in your web browser at: http://localhost:8002/
- Navigate to the test candidate's candidate page (you can get the candidate page URL from the `https://harvest.greenhouse.io/v1/applications/{{application_id}}` endpoint on the Harvest API)
- Click the withdraw button, enter the email you put as the candidate's email, select any reason and click submit
- On the subsequent page, you should see a debug message along with the withdrawal confirmation email that would have been sent to the candidate. Click that link to confirm the withdrawal.
- This should reject the candidate on GH, delete any upcoming interviews, and then render the `/templates/application/withdrawal.html` template, which should have the email(s) that would've been sent to the interviewer(s).

(btw, let me know if this is too long! I tried to be as like thorough as possible with the QA steps)

## Issue / Card

[WD-7721](https://warthogs.atlassian.net/browse/WD-7721)

## Screenshots

[if relevant, include a screenshot]


[WD-7721]: https://warthogs.atlassian.net/browse/WD-7721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ