### PR TITLE
[WD-9294] remove the work Fabric from data bubble navigation

### DIFF
--- a/templates/partial/_data-navigation.html
+++ b/templates/partial/_data-navigation.html
@@ -19,7 +19,7 @@
           <div class="p-navigation__logo-tag">
             <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="Canonical" width="95" />
           </div>
-          <span class="p-navigation__logo-title">Data Fabric</span>
+          <span class="p-navigation__logo-title">Data</span>
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="Toggle navigation"><i class="p-icon--chevron-down is-light"></i></a>


### PR DESCRIPTION
## Done

Removed the word "Fabric" from "Data Fabric" in data bubble navigation to comply with the [copy doc](https://docs.google.com/document/d/1r1xnNihaTphO_eikifUEO7ocYfTDnbuRIaIfUCmya1c/edit).

## QA

- Navigate to /data and check if in the navigation it shows "Data" instead of "Data Fabric"

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9294