### PR TITLE
WD-9331 - add missing asterisk to Country field

### DIFF
--- a/templates/shared/forms/_country.html
+++ b/templates/shared/forms/_country.html
@@ -1,11 +1,16 @@
 {% if raw != "true" %}
 <li class="p-list__item">
-  <label for="country">{{ country or 'Country' }}:</label>
+  <label for="country"
+    {% if required == "false" %}
+    {% else %}
+      class="is-required"
+    {% endif %}
+  >{{ country or 'Country' }}:</label>
   {% endif %}
   <select
     {% if required == "false" %}
     {% else %}
-    required
+      required
     {% endif %}
     id="country"
     name="country"

--- a/templates/solutions/_form_infrastructure.html
+++ b/templates/solutions/_form_infrastructure.html
@@ -23,7 +23,9 @@
                   <label for="email" class="is-required">Email:</label>
                   <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
                 </li>
-                {% include "shared/forms/_country.html" %}
+                {% with required="true" %}
+                  {% include "shared/forms/_country.html" %}
+                {% endwith %}
                 <li class="p-list__item">
                   <label for="phone">Phone number:</label>
                   <input id="phone" name="phone" maxlength="255" type="tel" pattern="[0-9\s]+" />


### PR DESCRIPTION
## Done

Add missing asterisk to the Country field on /solutions/infrastructure

## QA

- [demo link](https://canonical-com-1195.demos.haus/solutions/infrastructure)
- [copy doc](https://docs.google.com/document/d/1dI16QM8pNusM-zmCtMQZSsmPvgQTUj6_ZrMQN00XOPQ/edit)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the asterisk appears near the field

## Issue / Card
[WD-9331](https://warthogs.atlassian.net/browse/WD-9331)

Fixes #

## Screenshots


[WD-9331]: https://warthogs.atlassian.net/browse/WD-9331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ