### PR TITLE
WD-9422 - remove section from /diversity

### DIFF
--- a/templates/careers/company-culture/diversity.html
+++ b/templates/careers/company-culture/diversity.html
@@ -142,29 +142,7 @@
           <p>The Culture and Identity working group supports our team members by conducting data-driven assessments of company culture, and inclusive naming initiatives.</p>
         </div>
       </div>
-      <hr class="u-no-margin--bottom">
-			<div class="row p-strip--diversity u-no-padding--top">
-        <div class="col-3 col-medium-1 col-small-1">
-          {{
-            image (
-            url="https://assets.ubuntu.com/v1/5078d2cf-Charlene-g.png",
-            alt="",
-            width="500",
-            height="751",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "u-image-margin--top"}
-            ) | safe
-          }}
-        </div>
-        <div class="col-6 col-medium-3 col-small-3">
-          <blockquote class="p-pull-quote--small u-no-margin--top u-stack u-no-padding--left">
-            <h4><em>"Our resource groups provide a great platform and opportunity to raise awareness of the wide spectrum of human physiological, cognitive and psychological experiences. It helps enhance our understanding of diversity and promote a more inclusive workplace."</em></h4>
-            <span class="p-pull-quote__citation u-no-margin--bottom"><strong>Charlene Gong</strong><br /> Workplace Engineer</span>
-          </blockquote>
-        </div>
-      </div>
-
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

Remove a section from /diversity
## QA

- [demo link](https://canonical-com-1198.demos.haus/careers/company-culture/diversity)
- [copy doc](https://docs.google.com/document/d/1l1UGJToc0ErHUMN9W8hELvF5sDyVRO7N0xDzncqA2SQ/edit)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the section is not displayed

## Issue / Card
[WD-9422](https://warthogs.atlassian.net/browse/WD-9422)
Fixes #

## Screenshots

[WD-9422]: https://warthogs.atlassian.net/browse/WD-9422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ