### PR TITLE
WD-9253 - add buttons to /documentation

### DIFF
--- a/templates/documentation/open-documentation-academy.html
+++ b/templates/documentation/open-documentation-academy.html
@@ -11,7 +11,7 @@
 {% block meta_image %}https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg{% endblock %}
 
 {% block documentation_content %}
-<div class="p-strip u-no-padding--top">
+<section class="p-strip u-no-padding--top">
   <div class="row" id="documentation">
     <aside class="col-3">
       <div class="p-side-navigation--raw-html is-sticky" id="drawer">
@@ -53,6 +53,8 @@
           <p>The Open Documentation Academy combines Canonical's documentation team with documentation newcomers, experts, and those in-between, to help us all improve documentation practice and become better writers.</p>
           <p>If you're a newcomer, we can provide help, advice, mentorship, and a hundred different tasks to get started on. If you're an expert, we want to create a place to share knowledge, a place to get involved with new developments, and somewhere you can ask for help on your own projects.</p>
           <p>A key aim of this initiative is to help lower the barrier into successful open-source software contribution, by making documentation into the gateway.</p>
+          <hr />
+          <a class="p-button--positive" href="https://discourse.ubuntu.com/c/open-documentation-academy/166">Join the Academy</a>
         </div>
       </div>
       <hr class="p-rule">
@@ -107,7 +109,16 @@
       </div>
     </main>
   </div>
-</div>
+</section>
+
+<section class="u-fixed-width">
+  <hr class="p-rule" />
+  <div class="p-strip is-deep">
+    <h2>
+      <a href="https://discourse.ubuntu.com/c/open-documentation-academy/166">Join the Academy&nbsp;&rsaquo;</a>
+    </h2>
+  </div>
+</section>
 
 {% endblock documentation_content %}
 


### PR DESCRIPTION
## Done

Add Join the academy buttons to /documentation/open-documentation-academy

## QA

- [demo link](https://canonical-com-1199.demos.haus/documentation/open-documentation-academy)
- [copy doc](https://docs.google.com/document/d/1nhy653-SOfTmGCIiSZHuGBCrwZlzEZJaA4kFBsw-5dc/edit)
- [figma](https://www.figma.com/file/599RqqmJN6hQwKMa5DJZDl/Canonical.com%2Fdocumentation?type=design&node-id=0-1&mode=design&t=aeqPaaspxkwSsN5o-0)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the buttons are correctly added

## Issue / Card
[WD-9253](https://warthogs.atlassian.net/browse/WD-9253)
Fixes #

## Screenshots

[WD-9253]: https://warthogs.atlassian.net/browse/WD-9253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ