### PR TITLE
[WD-9557] add links to datasheets in /data/mongodb

### DIFF
--- a/templates/data/mongodb.html
+++ b/templates/data/mongodb.html
@@ -284,7 +284,7 @@
               <li class="p-list__item is-ticked">Proof of Concept (PoC)</li>
               <li class="p-list__item is-ticked">Solution deployment</li>
               <li class="p-list__item is-ticked">
-                <a href="https://assets.ubuntu.com/v1/18de771d-Charmed%20MongoDB%20Training_Public%20Module-3.pdf">Charmed MongoDB training</a>
+                <a href="https://assets.ubuntu.com/v1/cfecb9cd-Charmed%20MongoDB%20Training_Public%20Module-4.pdf">Charmed MongoDB training</a>
               </li>
             </ul>
             <hr>
@@ -328,11 +328,11 @@
       <div class="row p-section--shallow">
         <div class="col-3">
           <h3 class="p-heading--5">
-            <a href="https://ubuntu.com/blog/database-on-kubernetes">Is your database on Kubernetes production-ready?</a>
+            <a href="https://ubuntu.com/engage/mongodb-support-security">Get our guide to MongoDB security and support</a>
           </h3>
         </div>
         <div class="col-6">
-          <p>Considerations for running your database in Kubernetes.</p>
+          <p>A guide to streamline MongoDB database operations.</p>
         </div>
       </div>
     </div>

--- a/templates/data/mongodb.html
+++ b/templates/data/mongodb.html
@@ -241,7 +241,7 @@
 <section class="p-strip is-deep">
   <div class="u-fixed-width">
     <p class="p-heading--2">
-      <a href="https://ubuntu.com/engage/mongodb-support-security">Get our guide to MongoDB security and support&nbsp;&rsaquo;</a>
+      <a href="https://ubuntu.com/engage/mongodb-enterprise-data-management">Download MongoDB® for enterprise data management&nbsp;&rsaquo;</a>
     </p>
   </div>
 </section>
@@ -267,7 +267,7 @@
               <li class="p-list__item is-ticked">24/7 support</li>
             </ul>
             <hr>
-            <a class="p-button--positive" href="/contact-us" aria-controls="data-mongodb-modal">Contact us</a>
+            <a href="https://assets.ubuntu.com/v1/eb8bfa49-Managed%20MongoDB_DS%20(1)-1.pdf">Read the Datasheet&nbsp;&rsaquo;</a>
           </div>
         </div>
       </div>
@@ -283,8 +283,12 @@
               <li class="p-list__item is-ticked">Platform architecture and design</li>
               <li class="p-list__item is-ticked">Proof of Concept (PoC)</li>
               <li class="p-list__item is-ticked">Solution deployment</li>
-              <li class="p-list__item is-ticked">Charmed MongoDB training</li>
+              <li class="p-list__item is-ticked">
+                <a href="https://assets.ubuntu.com/v1/18de771d-Charmed%20MongoDB%20Training_Public%20Module-3.pdf">Charmed MongoDB training</a>
+              </li>
             </ul>
+            <hr>
+            <a href="https://assets.ubuntu.com/v1/4220f815-Data%20Solutions%20Advisory%20version%20_updated%20-%20v3-2.pdf">Read the Datasheet&nbsp;&rsaquo;</a>
           </div>
         </div>
       </div>

--- a/templates/data/mongodb.html
+++ b/templates/data/mongodb.html
@@ -171,10 +171,10 @@
       <hr class="p-rule">
       <p>Get started with Charmed MongoDB documentation:</p>
       <p>
-        <a href="/data/docs/mongodb/iaas">Run Charmed MongoDB on IaaS&nbsp;&rsaquo;</a>
+        <a href="https://charmhub.io/mongodb">Run Charmed MongoDB on IaaS&nbsp;&rsaquo;</a>
       </p>
       <p>
-        <a href="/data/docs/mongodb/k8s">Run Charmed MongoDB on Kubernetes&nbsp;&rsaquo;</a>
+        <a href="https://charmhub.io/mongodb-k8s">Run Charmed MongoDB on Kubernetes&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

Added links to datasheets according to the [copy doc](https://docs.google.com/document/d/1mCztOFZYbC3TeUM7j7pGfSoxKzBs20W1pJHZhdLqKs8/edit#heading=h.1jrvb0hvej6k).

## QA

- Navigate to https://canonical-com-1202.demos.haus/data/mongodb
- Check if new links work (in the copy doc the stakeholder already applied the changes, so please check those that are highlighted in the screenshots below)
- Check the links that were replaced

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9557

## Screenshots

![Screenshot 2024-03-12 at 17 44 03](https://github.com/canonical/canonical.com/assets/15943863/3e03b0de-752c-457c-b377-dab89d126119)
![Screenshot 2024-03-12 at 17 52 27](https://github.com/canonical/canonical.com/assets/15943863/960bc45f-7252-4af3-bd1a-ce419fe897c2)

