### PR TITLE
WD-9529 - resize image on /data/opensearch

### DIFF
--- a/templates/data/kafka.html
+++ b/templates/data/kafka.html
@@ -19,8 +19,8 @@
         {{ image (
           url="https://assets.ubuntu.com/v1/21e02606-kafka.png",
           alt="",
-          width="90",
-          height="64",
+          width="128",
+          height="91",
           hi_def=True,
           loading="auto"
           ) | safe

--- a/templates/data/opensearch.html
+++ b/templates/data/opensearch.html
@@ -20,8 +20,8 @@
           {{ image (
             url="https://assets.ubuntu.com/v1/858e64ad-logo-open-search.svg",
             alt="Opensearch",
-            width="200",
-            height="200",
+            width="128",
+            height="128",
             hi_def=True,
             loading="auto"
             ) | safe

--- a/templates/data/opensearch.html
+++ b/templates/data/opensearch.html
@@ -20,8 +20,8 @@
           {{ image (
             url="https://assets.ubuntu.com/v1/858e64ad-logo-open-search.svg",
             alt="Opensearch",
-            width="40",
-            height="40",
+            width="200",
+            height="200",
             hi_def=True,
             loading="auto"
             ) | safe

--- a/templates/data/spark.html
+++ b/templates/data/spark.html
@@ -21,8 +21,8 @@
             image (
             url="https://assets.ubuntu.com/v1/56e5a802-spark-logo.png",
             alt="Apache Spark",
-            width="77",
-            height="40",
+            width="128",
+            height="67",
             hi_def=True,
             loading="auto"
             ) | safe


### PR DESCRIPTION
## Done

Make logo on /data/opensearch larger

## QA

- [demo link](https://canonical-com-1203.demos.haus/data/opensearch)
- [linked issue](https://warthogs.atlassian.net/browse/DPNPM-415)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the logo is larger

## Issue / Card
[WD-9529](https://warthogs.atlassian.net/browse/WD-9529)
Fixes #

## Screenshots

[WD-9529]: https://warthogs.atlassian.net/browse/WD-9529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ