### PR TITLE
update data fabric pages with bigger logos

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -778,6 +778,10 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   aspect-ratio: 3/2;
 }
 
+.u-aspect-ratio--16-9 {
+  aspect-ratio: 16/9;
+}
+
 .u-container--background {
   background: rgba(0 0 0 / 3%);
 }

--- a/templates/data/kafka.html
+++ b/templates/data/kafka.html
@@ -43,7 +43,7 @@
 </section>
 
 <section class="p-section">
-  <hr class="p-rule is-fixed-width">
+  <hr class="p-rule is-fixed-width" />
   <div class="row--50-50">
     <div class="col">
       <h2>Made to give you peace&nbsp;of&nbsp;mind</h2>

--- a/templates/data/kafka.html
+++ b/templates/data/kafka.html
@@ -14,18 +14,7 @@
 
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="p-section">
-    <div class="row--25-75">
-      <div class="col">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/21e02606-kafka.png",
-          alt="",
-          width="90",
-          height="64",
-          hi_def=True,
-          loading="auto"
-          ) | safe
-        }}
-      </div>
+    <div class="row--50-50">
       <div class="col">
         <div class="p-section--shallow">
           <h1 class="u-no-margin--bottom">Apache Kafka<sup>&reg;</sup> operations, simplified</h1>
@@ -33,46 +22,60 @@
         <div class="p-section--shallow">
           <p>Secure and automate the deployment, maintenance and upgrades of your Kafka environments across private and public clouds. </p>
         </div>
-        <hr>
+        <hr />
         <a class="p-button--positive" aria-controls="data-kafka-modal" href="/contact-us">Contact us</a>
+      </div>
+      <div class="col">
+        <div class="u-vertically-center u-aspect-ratio--16-9 p-image-wrapper u-container--background u-align--center p-strip">
+          {{ image (
+          url="https://assets.ubuntu.com/v1/99796c3b-kafka-logo.png",
+          alt="",
+          width="142",
+          height="186",
+          hi_def=True,
+          loading="auto"
+          ) | safe
+          }}
+        </div>
       </div>
     </div>
   </div>
 </section>
 
 <section class="p-section">
-  <div class="row--25-75 is-split-on-medium">
-    <hr class="p-rule">
+  <hr class="p-rule is-fixed-width">
+  <div class="row--50-50">
     <div class="col">
-      <h2 class="p-text--small-caps">Made to give you<br class="u-hide--small"> peace of mind</h2>
+      <h2>Made to give you peace&nbsp;of&nbsp;mind</h2>
     </div>
     <div class="col">
       <ul class="p-list--divided">
-        <li class="p-list__item p-heading--2">10 years security maintenance </li>
-        <li class="p-list__item p-heading--2">Open source</li>
-        <li class="p-list__item p-heading--2">Simple per node subscription</li>
+        <li class="p-list__item is-ticked">10 years security maintenance </li>
+        <li class="p-list__item is-ticked">Open source</li>
+        <li class="p-list__item is-ticked">Simple per node subscription</li>
       </ul>
     </div>
   </div>
 </section>
 
 <section class="p-section">
-  <div class="row">
-    <hr class="p-rule">
-    <div class="col-start-large-4 col-6">
+  <hr class="p-rule is-fixed-width">
+  <div class="row--50-50">
+    <div class="col">
       <div class="p-section--shallow">
         <h2>Hyper-automated Kafka<sup>&reg;</sup> with enterprise-grade support</h2>
       </div>
+    </div>
+    <div class="col">
       <p>Charmed Kafka is simply the best way to run Kafka, on the cloud or in your data centre. Runs directly on cloud infrastructure or on Kubernetes.</p>
       <hr class="p-rule is-muted">
-      <div class="p-section--shallow">
-        <ul class="p-list--divided">
-          <li class="p-list__item is-ticked">Automated security and configuration best practice</li>
-          <li class="p-list__item is-ticked">Built-in observability</li>
-          <li class="p-list__item is-ticked">Multi-cloud</li>
-          <li class="p-list__item is-ticked">Self-healing</li>
-        </ul>
-      </div>
+      <ul class="p-list--divided">
+        <li class="p-list__item is-ticked">Automated security and configuration best practice</li>
+        <li class="p-list__item is-ticked">Built-in observability</li>
+        <li class="p-list__item is-ticked">Multi-cloud</li>
+        <li class="p-list__item is-ticked">Self-healing</li>
+      </ul>
+      <hr>
       <p><a class="p-button" href="/data/docs/kafka/iaas">Get started with Charmed Kafka</a></p>
     </div>
   </div>

--- a/templates/data/kafka.html
+++ b/templates/data/kafka.html
@@ -59,7 +59,7 @@
 </section>
 
 <section class="p-section">
-  <hr class="p-rule is-fixed-width">
+  <hr class="p-rule is-fixed-width" />
   <div class="row--50-50">
     <div class="col">
       <div class="p-section--shallow">

--- a/templates/data/kafka.html
+++ b/templates/data/kafka.html
@@ -29,7 +29,7 @@
         <div class="u-vertically-center u-aspect-ratio--16-9 p-image-wrapper u-container--background u-align--center p-strip">
           {{ image (
           url="https://assets.ubuntu.com/v1/99796c3b-kafka-logo.png",
-          alt="",
+          alt="Kafka",
           width="142",
           height="186",
           hi_def=True,

--- a/templates/data/mongodb.html
+++ b/templates/data/mongodb.html
@@ -12,13 +12,15 @@
 
 {% block content %}
 
-<section class="p-strip--whitesuru is-shallow u-no-padding--bottom">
+<section class="p-strip is-shallow u-no-padding--bottom">
   <div class="p-section">
-    <div class="row--25-75">
+    <div class="row--50-50">
       <div class="col">
         <div class="p-section--shallow">
           <h1 class="u-no-margin--bottom">MongoDB<sup>&reg;</sup>database operations, simplified</h1>
         </div>
+      </div>
+      <div class="col">
         <div class="p-section--shallow">
           <p>Secure and automate the deployment, maintenance and upgrades of your MongoDB databases across private and public clouds. Deliver large amounts of data in high-performance applications.</p>
         </div>
@@ -31,16 +33,16 @@
 </section>
 
 <section class="p-section">
-  <div class="row--25-75 is-split-on-medium">
-    <hr class="p-rule">
+  <hr class="p-rule is-fixed-width">
+  <div class="row--50-50">
     <div class="col">
-      <h2 class="p-text--small-caps">Made to give you<br class="u-hide--small"> peace of mind</h2>
+      <h2>Made to give you peace&nbsp;of&nbsp;mind</h2>
     </div>
     <div class="col">
       <ul class="p-list--divided">
-        <li class="p-list__item p-heading--2">10 years of security maintenance and support</li>
-        <li class="p-list__item p-heading--2">Simple per node subscription</li>
-        <li class="p-list__item p-heading--2">Hybrid, multi-cloud ready</li>
+        <li class="p-list__item is-ticked"> 10 years of security maintenance and support</li>
+        <li class="p-list__item is-ticked"> Simple per node subscription</li>
+        <li class="p-list__item is-ticked"> Hybrid, multi-cloud ready</li>
       </ul>
     </div>
   </div>

--- a/templates/data/mysql.html
+++ b/templates/data/mysql.html
@@ -12,22 +12,7 @@
 
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="p-section">
-    <div class="row--25-75 is-split-on-medium">
-      <div class="col">
-        <div class="p-image-wrapper">
-          <a href="https://www.mysql.com/">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/37c2f953-mysql-logo.png",
-              alt="MySQL",
-              width="128",
-              height="134",
-              hi_def=True,
-              loading="auto"
-              ) | safe
-            }}
-          </a>
-        </div>
-      </div>
+    <div class="row--50-50">
       <div class="col">
         <div class="p-section--shallow">
           <h1 class="u-no-margin--bottom">MySQL operations, simplified</h1>
@@ -38,21 +23,36 @@
         <hr>
         <a class="p-button--positive" aria-controls="data-relational-dbs-modal" href="/contact-us">Contact us</a>
       </div>
+      <div class="col">
+        <div class="u-vertically-center u-aspect-ratio--16-9 p-image-wrapper u-container--background u-align--center p-strip">
+          <a href="https://www.mysql.com/">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/37c2f953-mysql-logo.png",
+            alt="MySQL",
+            width="178",
+            height="186",
+            hi_def=True,
+            loading="auto"
+            ) | safe
+            }}
+          </a>
+        </div>
+      </div>
     </div>
   </div>
 </section>
 
 <section class="p-section">
-  <div class="row--25-75">
-    <hr class="p-rule">
+  <hr class="p-rule is-fixed-width">
+  <div class="row--50-50">
     <div class="col">
-      <h2 class="p-text--small-caps">Made to give you<br class="u-hide--small"> peace of mind</h2>
+      <h2>Made to give you peace&nbsp;of&nbsp;mind</h2>
     </div>
     <div class="col">
       <ul class="p-list--divided">
-        <li class="p-list__item p-heading--2">SLA-backed support with optional screen sharing</li>
-        <li class="p-list__item p-heading--2">10 years of security maintenance</li>
-        <li class="p-list__item p-heading--2">Hybrid and multi-cloud ready</li>
+        <li class="p-list__item is-ticked">SLA-backed support with optional screen sharing</li>
+        <li class="p-list__item is-ticked">10 years of security maintenance</li>
+        <li class="p-list__item is-ticked">Hybrid and multi-cloud ready</li>
       </ul>
     </div>
   </div>

--- a/templates/data/opensearch.html
+++ b/templates/data/opensearch.html
@@ -14,20 +14,7 @@
 
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="p-section">
-    <div class="row--25-75">
-      <div class="col">
-        <div class="p-image-wrapper">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/858e64ad-logo-open-search.svg",
-            alt="Opensearch",
-            width="40",
-            height="40",
-            hi_def=True,
-            loading="auto"
-            ) | safe
-          }}
-        </div>
-      </div>
+    <div class="row--50-50">
       <div class="col">
         <div class="p-section--shallow">
           <h1>OpenSearch<sup>&reg;</sup> operations, simplified</h1>
@@ -37,22 +24,35 @@
         <a class="p-button--positive" href="/contact-us" aria-controls="data-spark-modal">Contact us</a>
         <a href="https://assets.ubuntu.com/v1/a7d1c19a-Charmed%20OpenSearch%20-%20Datasheet%20(1).pdf">Download the datasheet&nbsp;&rsaquo;</a>
       </div>
+      <div class="col">
+        <div class="u-vertically-center u-aspect-ratio--16-9 p-image-wrapper u-container--background u-align--center p-strip">
+          {{ image (
+          url="https://assets.ubuntu.com/v1/b71bf182-opensearch-logo.png",
+          alt="Opensearch",
+          width="197",
+          height="186",
+          hi_def=True,
+          loading="auto"
+          ) | safe
+          }}
+        </div>
+      </div>
     </div>
   </div>
 </section>
 
 <section class="p-section">
-  <div class="row--25-75 is-split-on-medium">
-    <hr class="p-rule" />
+  <hr class="p-rule is-fixed-width" />
+  <div class="row--50-50">
     <div class="col">
-      <h2 class="p-text--small-caps">Deploy and operate<br class="u-hide--small"> reliably everywhere</h2>
+      <h2>Made to give you peace&nbsp;of&nbsp;mind</h2>
     </div>
     <div class="col">
       <ul class="p-list--divided">
-        <li class="p-list__item p-heading--2">10 years security maintenance and support</li>
-        <li class="p-list__item p-heading--2">Open source</li>
-        <li class="p-list__item p-heading--2">Simple per node subscription</li>
-        <li class="p-list__item p-heading--2">Hybrid, multi-cloud ready</li>
+        <li class="p-list__item is-ticked">10 years security maintenance and support</li>
+        <li class="p-list__item is-ticked">Open source</li>
+        <li class="p-list__item is-ticked">Simple per node subscription</li>
+        <li class="p-list__item is-ticked">Hybrid, multi-cloud ready</li>
       </ul>
     </div>
   </div>

--- a/templates/data/opensearch.html
+++ b/templates/data/opensearch.html
@@ -27,9 +27,9 @@
       <div class="col">
         <div class="u-vertically-center u-aspect-ratio--16-9 p-image-wrapper u-container--background u-align--center p-strip">
           {{ image (
-          url="https://assets.ubuntu.com/v1/b71bf182-opensearch-logo.png",
+          url="https://assets.ubuntu.com/v1/6deb3921-opensearch-logo.png",
           alt="Opensearch",
-          width="197",
+          width="198",
           height="186",
           hi_def=True,
           loading="auto"

--- a/templates/data/postgresql.html
+++ b/templates/data/postgresql.html
@@ -12,16 +12,27 @@
 
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="p-section">
-    <div class="row--25-75 is-split-on-medium">
+    <div class="row--50-50">
       <div class="col">
-        <div class="p-image-wrapper">
+        <div class="p-section--shallow">
+          <h1 class="u-no-margin--bottom">PostgreSQL operations, simplified</h1>
+        </div>
+        <div class="p-section--shallow">
+          <p>Secure and automate the deployment, maintenance and upgrades of your PostgreSQL databases across private and
+            public clouds.</p>
+        </div>
+        <hr/>
+        <a class="p-button--positive" aria-controls="data-relational-dbs-modal" href="/contact-us">Contact us</a>
+      </div>
+      <div class="col">
+        <div class="u-vertically-center u-aspect-ratio--16-9 p-image-wrapper u-container--background u-align--center p-strip">
           <a href="https://www.postgresql.org/">
             {{ 
               image (
-              url="https://assets.ubuntu.com/v1/b0331e58-postgresql-logo-for-header.png",
+              url="https://assets.ubuntu.com/v1/6bdd1828-postgre-sql.png",
               alt="PostgreSQL",
-              width="198",
-              height="55",
+              width="258",
+              height="186",
               hi_def=True,
               loading="auto"
               ) | safe
@@ -29,31 +40,21 @@
           </a>
         </div>
       </div>
-      <div class="col">
-        <div class="p-section--shallow">
-          <h1 class="u-no-margin--bottom">PostgreSQL operations, simplified</h1>
-        </div>
-        <div class="p-section--shallow">
-          <p>Secure and automate the deployment, maintenance and upgrades of your PostgreSQL databases across private and public clouds.</p>
-        </div>
-        <hr>
-        <a class="p-button--positive" aria-controls="data-relational-dbs-modal" href="/contact-us">Contact us</a>
-      </div>
     </div>
   </div>
 </section>
 
 <section class="p-section">
-  <div class="row--25-75 is-split-on-medium">
-    <hr class="p-rule">
+  <hr class="p-rule is-fixed-width">
+  <div class="row--50-50">
     <div class="col">
-      <h2 class="p-text--small-caps">Made to give you<br class="u-hide--small"> peace of mind</h2>
+      <h2>Made to give you peace&nbsp;of&nbsp;mind</h2>
     </div>
     <div class="col">
       <ul class="p-list--divided">
-        <li class="p-list__item p-heading--2">SLA-backed support with optional screen sharing</li>
-        <li class="p-list__item p-heading--2">10 years of security maintenance</li>
-        <li class="p-list__item p-heading--2">Hybrid and multi-cloud ready</li>
+        <li class="p-list__item is-ticked">SLA-backed support with optional screen sharing</li>
+        <li class="p-list__item is-ticked">10 years of security maintenance</li>
+        <li class="p-list__item is-ticked">Hybrid and multi-cloud ready</li>
       </ul>
     </div>
 </section>

--- a/templates/data/spark.html
+++ b/templates/data/spark.html
@@ -14,21 +14,7 @@
 
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="p-section">
-    <div class="row--25-75 is-split-on-medium">
-      <div class="col">
-        <div class="p-image-wrapper">
-          {{
-            image (
-            url="https://assets.ubuntu.com/v1/56e5a802-spark-logo.png",
-            alt="Apache Spark",
-            width="77",
-            height="40",
-            hi_def=True,
-            loading="auto"
-            ) | safe
-          }}
-        </div>
-      </div>
+    <div class="row--50-50">
       <div class="col">
         <div class="p-section--shallow">
           <h1 class="u-no-margin--bottom">Apache Spark<sup>&reg;</sup> operations, simplified</h1>
@@ -39,42 +25,56 @@
         <hr>
         <a class="p-button--positive" aria-controls="data-spark-modal" href="/contact-us">Contact us</a>
       </div>
+      <div class="col">
+        <div class="u-vertically-center u-aspect-ratio--16-9 p-image-wrapper u-container--background u-align--center p-strip">
+          {{
+          image (
+          url="https://assets.ubuntu.com/v1/8baab06a-apache-spark-logo.png",
+          alt="Apache Spark",
+          width="143",
+          height="186",
+          hi_def=True,
+          loading="auto"
+          ) | safe
+          }}
+        </div>
+      </div>
     </div>
   </div>
 </section>
 
 <section class="p-section">
-  <div class="row--25-75 is-split-on-medium">
+  <div class="row--50-50">
     <hr class="p-rule">
     <div class="col">
-      <h2 class="p-text--small-caps">Made to give you<br class="u-hide--small"> peace of mind</h2>
+      <h2>Made to give you peace&nbsp;of&nbsp;mind</h2>
     </div>
     <div class="col">
       <ul class="p-list--divided">
-        <li class="p-list__item p-heading--2">10 years security maintenance </li>
-        <li class="p-list__item p-heading--2">Open source</li>
-        <li class="p-list__item p-heading--2">Simple per node subscription</li>
+        <li class="p-list__item is-ticked">10 years security maintenance </li>
+        <li class="p-list__item is-ticked">Open source</li>
+        <li class="p-list__item is-ticked">Simple per node subscription</li>
       </ul>
     </div>
   </div>
 </section>
 
 <section class="p-section">
-  <div class="row">
-    <hr class="p-rule">
-    <div class="col-start-large-4 col-6">
+  <hr class="p-rule is-fixed-width">
+  <div class="row--50-50">
+    <div class="col">
       <div class="p-section--shallow">
         <h2>A complete solution for Spark<sup>&reg;</sup> with enterprise-grade support</h2>
       </div>
+    </div>
+    <div class="col">
       <p>Simply the best way to run Apache Spark<sup>&reg;</sup>, whether on the cloud or in your data centre; runs on Kubernetes.</p>
       <hr class="p-rule is-muted">
-      <div class="p-section--shallow">
-        <ul class="p-list--divided">
-          <li class="p-list__item is-ticked">Supported and maintained for up to 10 years</li>
-          <li class="p-list__item is-ticked">Integrated monitoring</li>
-          <li class="p-list__item is-ticked">Includes a fully supported distribution of Apache Spark</li>
-        </ul>
-      </div>
+      <ul class="p-list--divided">
+        <li class="p-list__item is-ticked">Supported and maintained for up to 10 years</li>
+        <li class="p-list__item is-ticked">Integrated monitoring</li>
+        <li class="p-list__item is-ticked">Includes a fully supported distribution of Apache Spark</li>
+      </ul>
       <a class="p-button--positive" href="/data/docs/spark/k8s">Get started with Charmed Spark</a> 
       <a class="p-button" aria-controls="data-spark-modal">Get support</a>
     </div>


### PR DESCRIPTION
## Done

- update top sections into 50-50 split format, make kafka and other logos bigger and in boxes (Request from Rob Gibbon)
- update sections immediately after so it works better when sandwitched between 50-50 splits


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots
![image](https://github.com/canonical/canonical.com/assets/2741678/bd62c93c-9069-4d3a-8980-2a03c2b1aa60)

[if relevant, include a screenshot]
