### PR TITLE
Add logic for loading-spinner on forms

### DIFF
--- a/static/js/forms.js
+++ b/static/js/forms.js
@@ -18,6 +18,8 @@ function attachLoadingSpinner(submitButton) {
 }
 const form = document.querySelector("form");
 const submitButton = form.querySelector('button[type="submit"]');
-if (submitButton) {
+// Exclude forms that don't need loader
+const cancelLoader = submitButton.classList.contains("no-loader");
+if (submitButton && !cancelLoader) {
   form.addEventListener("submit", () => attachLoadingSpinner(submitButton));
 }

--- a/static/js/forms.js
+++ b/static/js/forms.js
@@ -1,0 +1,23 @@
+/**
+ *
+ * @param {Node} submitButton
+ *
+ * Attaches a loading spinner to the submit button on
+ * form submission
+ */
+function attachLoadingSpinner(submitButton) {
+  const spinnerIcon = document.createElement("i");
+  spinnerIcon.className = "p-icon--spinner u-animation--spin is-light";
+  const buttonRect = submitButton.getBoundingClientRect();
+  submitButton.style.width = buttonRect.width + "px";
+  submitButton.style.height = buttonRect.height + "px";
+  submitButton.classList.add("is-processing");
+  submitButton.disabled = true;
+  submitButton.innerText = "";
+  submitButton.appendChild(spinnerIcon);
+}
+const form = document.querySelector("form");
+const submitButton = form.querySelector('button[type="submit"]');
+if (submitButton) {
+  form.addEventListener("submit", () => attachLoadingSpinner(submitButton));
+}

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -103,6 +103,7 @@
     {% include 'partial/_footer.html' %}
 
     <script defer src="{{ versioned_static('js/navigation.js') }}"></script>
+    <script src="{{ versioned_static('js/forms.js') }}"></script>
     <script src="{{ versioned_static('js/modules/cookie-policy/cookie-policy.js') }}"></script>
     <script>
       cpNs.cookiePolicy();


### PR DESCRIPTION
## Done

- Copies the code from [u.com](https://github.com/canonical/ubuntu.com/blob/main/static/js/src/static-forms.js#L150) to the [vanilla loading spinner](https://vanillaframework.io/docs/patterns/buttons#processing) on successful form submission

## QA

- fill in a [modal form](https://canonical-com-1207.demos.haus/#get-in-touch) check that the spinner is attached on form submission
- do the same for a [static form](https://canonical-com-1207.demos.haus/partners/become-a-partner)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8603

