### PR TITLE
Fix inverted link color

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -846,3 +846,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   background-color: $colors--dark-theme--background-default;
   color: $colors--dark-theme--text-default;
 }
+
+.p-link--inverted {
+  @extend .is-dark;
+}


### PR DESCRIPTION
## Done

- Fixed broken link colors on the meganav 

## QA

- View the site locally in your web browser at: http://0.0.0.0:8002/data
- Click on "All canonical"
- See that link color looks correct

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9655

## Screenshots

![image](https://github.com/canonical/canonical.com/assets/17607612/68b8450d-cec3-43c4-ab8f-7062a88c67ec)
