### PR TITLE
Add Google Calendar env keys for canonical-com-blog

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -98,6 +98,16 @@ production:
         - name: SENTRY_DSN
           value: https://aedc7a57f0bc4d22bf7c0b6d63c3e1bb@sentry.is.canonical.com//14
 
+        - name: SERVICE_ACCOUNT_EMAIL
+          secretKeyRef:
+            key: scheduler_account_email
+            name: greenhouse-credentials
+
+        - name: SERVICE_ACCOUNT_PRIVATE_KEY
+          secretKeyRef:
+            key: scheduler_account_private_key
+            name: greenhouse-credentials
+
   nginxConfigurationSnippet: |
     if ($host = 'blog.canonical.com' ) {
       rewrite ^ https://canonical.com/blog$request_uri? permanent;
@@ -144,6 +154,16 @@ staging:
 
         - name: FLASK_DEBUG
           value: True
+
+        - name: SERVICE_ACCOUNT_EMAIL
+          secretKeyRef:
+            key: scheduler_account_email
+            name: greenhouse-credentials
+
+        - name: SERVICE_ACCOUNT_PRIVATE_KEY
+          secretKeyRef:
+            key: scheduler_account_private_key
+            name: greenhouse-credentials
 
   nginxConfigurationSnippet: |
     more_set_headers "X-Robots-Tag: noindex";


### PR DESCRIPTION
## Done

- Added `SERVICE_ACCOUNT_EMAIL` and `SERVICE_ACCOUNT_PRIVATE_KEY` env variables to the `/blog` route in `site.yaml`, for both production and staging, as this was stopping deployments from succeeding.

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
