### PR TITLE
Fix application page ordered list

### DIFF
--- a/static/sass/_pattern_application.scss
+++ b/static/sass/_pattern_application.scss
@@ -15,7 +15,8 @@
           font-size: 1rem;
           font-weight: 500;
           height: 2rem !important;
-          line-height: 1.9rem !important;
+          line-height: 1.6rem !important;
+          border:  3px solid transparent;
           margin-top: 0.6rem !important;
           text-align: center;
           width: 2rem !important;
@@ -67,15 +68,15 @@
           &::before {
             background-color: $color-x-dark;
             color: $color-light;
-            content: counter(li);
+            content: counter(list-item);
           }
         }
 
         &--stepper-not-completed {
           &::before {
             background-color: $color-x-light;
-            border: 3px solid $color-x-dark;
-            content: counter(li);
+            border-color: $color-x-dark;
+            content: counter(list-item);
           }
         }
       }


### PR DESCRIPTION
## Done

- Fix wrong ordered list numbers on the application page
- Center the numbers in the hiring stages list

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/application/[token]
  - Or you can mock an application locally by updating the function `application_index` in `webapp/application.py`:
  ```py
    
  @application.route("/<string:token>")
  def application_index(token):
      withdrawn = False
      application = { "status": "active", "candidate": { "first_name": "John", "last_name": "Doe" }, "stage_progress": { "application": True, "assessment": True, "early_stage": True, "late_stage": False, "offer": False }, "scheduled_interviews": [], "to_be_rejected": False, "role_name": "Software Engineer", "source": {"id": "2"},
          "hiring_lead": {"name": "Jane Doe"}}
      return flask.render_template(
          "careers/application/index.html",
          withdrawal_reasons= { key: value for key, value in withdrawal_reasons.items() if key != "33" },
          token= "token",
          application=application,
          candidate=application["candidate"],
          withdrawn=withdrawn,
      )
  ```
  - Then go to http://0.0.0.0:8002/careers/application/test
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Make sure that the stages are properly numbered
- Make sure that the numbers are properly centered

## Issue / Card

Fixes #1219

## Screenshots

### Current
<img width="1326" alt="image" src="https://github.com/canonical/canonical.com/assets/36013798/00d655a0-b00e-4aab-a150-90a7d25cb717">

### After changes
<img width="1318" alt="image" src="https://github.com/canonical/canonical.com/assets/36013798/ab6e5532-e86c-404f-ac48-62a6d16518a0">

