### PR TITLE
Add djLint formatter/linter for Jinja templates

### DIFF
--- a/.djlintrc
+++ b/.djlintrc
@@ -1,0 +1,18 @@
+{
+  "blank_line_after_tag": "load,extends",
+  "blank_line_before_tag": "load,extends,block, macro",
+  "close_void_tags": true,
+  "ignore": "J018,H006,H021,H023,H029,T002,T003,T028",
+  "include": "H017",
+  "max_blank_lines": 1,
+  "max_line_length": "120",
+  "profile": "jinja",
+  "format_css": true,
+  "format_js": true,
+  "css": {
+    "indent_size": 2
+  },
+  "js": {
+    "indent_size": 2
+  }
+}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -98,7 +98,7 @@ jobs:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           echo "The following files have changed: $CHANGED_FILES"
-          yarn lint-jinja
+          djlint $CHANGED_FILES --lint
 
   test-python:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -86,8 +86,19 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo pip3 install djlint
 
+      - name: Get changed HTML files in the templates folder
+        id: changed-files
+        uses: tj-actions/changed-files@v43
+        with:
+          files: templates/**
+
       - name: Lint jinja
-        run: yarn lint-jinja
+        if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          echo "The following files have changed: $CHANGED_FILES"
+          yarn lint-jinja
 
   test-python:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,6 +72,23 @@ jobs:
       - name: Lint python
         run: yarn lint-python
 
+  lint-jinja:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install node dependencies
+        run: yarn install --immutable
+
+      - name: Install python dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          sudo pip3 install djlint
+
+      - name: Lint jinja
+        run: yarn lint-jinja
+
   test-python:
     runs-on: ubuntu-22.04
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format-prettier": "prettier -w 'static/js/*.{js,jsx,ts,tsx}' 'static/sass/*.scss'",
     "lint-python": "flake8 --extend-ignore=E203 webapp tests && black --check --line-length 79 webapp tests",
     "lint-scss": "stylelint static/**/*.scss",
+    "lint-jinja": "djlint $(git diff --name-only HEAD | xargs) --lint || true",
     "serve": "./entrypoint 0.0.0.0:${PORT}",
     "start": "yarn run build && concurrently --raw 'yarn run watch' 'yarn run serve'",
     "test": "yarn run lint-scss && yarn run lint-python && yarn run test-python",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format-prettier": "prettier -w 'static/js/*.{js,jsx,ts,tsx}' 'static/sass/*.scss'",
     "lint-python": "flake8 --extend-ignore=E203 webapp tests && black --check --line-length 79 webapp tests",
     "lint-scss": "stylelint static/**/*.scss",
-    "lint-jinja": "BRANCH=main djlint $(git diff --name-only --diff-filter=d $(git merge-base HEAD $BRANCH)) --lint || true",
+    "lint-jinja": "djlint $CHANGED_FILES --lint || true",
     "serve": "./entrypoint 0.0.0.0:${PORT}",
     "start": "yarn run build && concurrently --raw 'yarn run watch' 'yarn run serve'",
     "test": "yarn run lint-scss && yarn run lint-python && yarn run test-python",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "format-prettier": "prettier -w 'static/js/*.{js,jsx,ts,tsx}' 'static/sass/*.scss'",
     "lint-python": "flake8 --extend-ignore=E203 webapp tests && black --check --line-length 79 webapp tests",
     "lint-scss": "stylelint static/**/*.scss",
-    "lint-jinja": "djlint $CHANGED_FILES --lint || true",
     "serve": "./entrypoint 0.0.0.0:${PORT}",
     "start": "yarn run build && concurrently --raw 'yarn run watch' 'yarn run serve'",
     "test": "yarn run lint-scss && yarn run lint-python && yarn run test-python",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format-prettier": "prettier -w 'static/js/*.{js,jsx,ts,tsx}' 'static/sass/*.scss'",
     "lint-python": "flake8 --extend-ignore=E203 webapp tests && black --check --line-length 79 webapp tests",
     "lint-scss": "stylelint static/**/*.scss",
-    "lint-jinja": "djlint $(git diff --name-only HEAD | xargs) --lint || true",
+    "lint-jinja": "BRANCH=main djlint $(git diff --name-only --diff-filter=d $(git merge-base HEAD $BRANCH)) --lint || true",
     "serve": "./entrypoint 0.0.0.0:${PORT}",
     "start": "yarn run build && concurrently --raw 'yarn run watch' 'yarn run serve'",
     "test": "yarn run lint-scss && yarn run lint-python && yarn run test-python",

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ google-api-python-client==2.49.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.5.1
 pytz==2024.1
+djlint==1.34.1

--- a/templates/solutions/telco/index.html
+++ b/templates/solutions/telco/index.html
@@ -377,7 +377,7 @@
           </ul>
         </div>
       </div>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <div class="row">
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Access our blog</h3>
@@ -390,7 +390,7 @@
           </ul>
         </div>
       </div>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <div class="row">
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Download our whitepapers</h3>
@@ -402,7 +402,7 @@
           </ul>
         </div>
       </div>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <div class="row">
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Contact us</h3>


### PR DESCRIPTION
## Done

- Added djLint fotmatter/linter support
- Defined a configuration file `.djlintrc` for it
- Added a yarn script `lint-jinja` that checks linting in Jinja templates that were changed
- Added GH CI job for running `lint-jinja` script

## QA

- Set up djLint in your codebase as described in Discourse topic here: https://discourse.canonical.com/t/configuring-editors-for-formatting-and-linting/188
- Open any Jinja template and format it
- Save the formatted file
- Run `yarn lint-jinja` script in the terminal and check that it has checked one changed file and that the check has passed
- Change another Jinja template and save it without formatting it
- Run `yarn lint-jinja` and check that the file is reported as having a linting error
- Open the file and check where djLint is reporting errors by hovering on places that are highlighted red
- Format the file and fix remaining linting errors and save
- Run `yarn lint-jinja` again and check that the file has passed the linting check

## Issue / Card

There is no issue
