### PR TITLE
Fix Candidate Reports Download Issue (WD-9878)

### DIFF
--- a/static/js/applications/get-report.js
+++ b/static/js/applications/get-report.js
@@ -1,19 +1,21 @@
-const form = document.getElementById("request-assessment-form");
-const input = form.querySelector("#request-assessment-email");
+const requestAssessmentForm = document.getElementById("request-assessment-form");
+const input = requestAssessmentForm.querySelector("#request-assessment-email");
 const inputContainer = input.parentNode;
-const errorMessage = form.querySelector("#exampleInputErrorMessage");
-const buttons = form.querySelectorAll("footer button");
-const loadingIcon = form.querySelector(".p-icon--spinner");
-const submitButton = form.querySelector("#request-assessment-submit");
-const closeModalButton = form.querySelector(".p-modal__close");
+const errorMessage = requestAssessmentForm.querySelector("#exampleInputErrorMessage");
+const buttons = requestAssessmentForm.querySelectorAll("footer button");
+const loadingIcon = requestAssessmentForm.querySelector(".p-icon--spinner");
+const requestAssessmentSubmitButton = requestAssessmentForm.querySelector(
+  "#request-assessment-submit"
+);
+const closeModalButton = requestAssessmentForm.querySelector(".p-modal__close");
 const requestButtonContainer = document.getElementById(
   "reportRequestContainer"
 );
 
-submitButton.addEventListener("click", (e) => {
+requestAssessmentSubmitButton.addEventListener("click", (e) => {
   e.preventDefault();
   runGet();
-  fetch(form.dataset.action, {
+  fetch(requestAssessmentForm.dataset.action, {
     method: "POST",
     headers: {
       Accept: "application/json",


### PR DESCRIPTION
## Done

- Renamed the `form` and `submitButton` identifiers in `get-report.js` because they were clashing with identifiers inside a newly added script from last week.
- Renamed them to `requestAssessmentForm` and `requestAssessmentSubmitButton` to constrain the names to the use case and hopefully avoid such clashes in future.

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://localhost:8002/
- Navigate to [Professor Dumbledore's candidate page](http://localhost:8002/careers/application/gAAAAABjttUfUHinT891Vx0MEX9ae5PHq3zYdigM-bH4Q_iW0jSeI9zMFf5qRh_oNSWneVktbzr2wzMyeaW3iEnYPFcVFkXkxw==)
- Attempt to download Dumbledore's reports and see if the process works now.
