### PR TITLE
Reimplement Delete Interview On Withdrawal, With New Deletion Logic

### DIFF
--- a/templates/careers/application/_withdrawal-interview-canceled-email.html
+++ b/templates/careers/application/_withdrawal-interview-canceled-email.html
@@ -2,7 +2,11 @@
   <p>Dear {{ interviewer_name }},</p>
   <p>This is an automated email to inform you that your upcoming interview &quot;{{ interview_title }}&quot; with {{ applicant_name }} on {{ interview_date }} has been canceled.</p>
   <p>The reason for the cancelation is that {{ applicant_name }} has withdrawn their application for the {{ position }} position.</p>
-  <p>You should receive a Google Calendar email notification of the cancelation soon if you haven't already.</p>
+  {% if can_be_deleted %}
+    <p>You should receive a Google Calendar email notification of the cancelation soon if you haven't already.</p>
+  {% else %}
+    <p>Unfortunately, the interview could not be automatically deleted from Google Calendar because it was not on the Interview Calendar. Please contact your Hiring Lead to manually delete the event.</p>
+  {% endif %}
   <p>Thank you for your committment to Canonical's hiring process!</p>
   <p>Regards,<br>Workplace Engineering</p>
 </div>

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,4 +1,7 @@
+import json
 import unittest
+from unittest.mock import MagicMock, patch
+import flask
 
 from vcr_unittest import VCRTestCase
 from webapp.app import app
@@ -8,6 +11,7 @@ from webapp.application import (
     _get_gia_feedback,
     _get_employee_directory_data,
     _submitted_email_match,
+    application_withdrawal,
 )
 
 all_stages = [
@@ -254,6 +258,147 @@ class TestCandidateEmailMatches(unittest.TestCase):
         }
         self.assertTrue(_submitted_email_match("foo@bar.com", application))
         self.assertFalse(_submitted_email_match("a@b.com", application))
+
+
+class TestInterviewAutoDeletionOnWithdrawal(unittest.TestCase):
+    def setUp(self):
+        # fake constants
+        self.fake_application = {
+            "id": "123",
+            "role_name": "Fake Job",
+            "candidate": {
+                "id": "444",
+                "first_name": "John",
+                "last_name": "Doe",
+            },
+            "hiring_lead": {
+                "id": "777",
+                "name": "Hiring Lead",
+                "emails": "hiring_lead@example.com",
+            },
+            "current_stage": "Fake Stage",
+        }
+        self.fake_timezone = "America/Toronto"
+        self.fake_scheduled_interview = {
+            "status": "scheduled",  # should remain after filtering
+            "interviewers": [
+                {
+                    "name": "Fake Interviewer 1",
+                    "email": "fake_interviewer1@email.com",
+                }
+            ],
+            "start": {"date_time": "2024-02-29T20:00:00.000Z"},
+            "external_event_id": "fake_event_id_1",
+            "interview": {"name": "Fake Interview 1"},
+        }
+        self.fake_completed_interview = {
+            "status": "completed",  # should be filtered out
+            "interviewers": [
+                {
+                    "name": "Fake Interviewer 2",
+                    "email": "fake_interviewer2@email.com",
+                }
+            ],
+            "start": {"date_time": "2024-02-27T20:00:00.000Z"},
+            "external_event_id": "fake_event_id_2",
+            "interview": {"name": "Fake Interview 2"},
+        }
+        self.fake_withdrawal_reason_id = None
+        self.fake_withdrawal_message = None
+
+        # mock functions
+        self.mock_decrypt = patch("webapp.application.cipher.decrypt").start()
+        self.mock_get_application = patch(
+            "webapp.application._get_application"
+        ).start()
+        self.mock_render_template = patch(
+            "webapp.application.flask.render_template"
+        ).start()
+        self.mock_cal = patch("webapp.application.CalendarAPI").start()
+        self.mock_reject_application = patch(
+            "webapp.application.harvest.reject_application"
+        ).start()
+        self.mock_get_interviews_scheduled = patch(
+            "webapp.application.harvest.get_interviews_scheduled"
+        ).start()
+        self.mock_send_mail = patch("webapp.application._send_mail").start()
+        self.mock_google_authenticate = patch(
+            "webapp.google_calendar.CalendarAPI._authenticate"
+        ).start()
+
+        # set return values for mocks
+        self.mock_decrypt.return_value = json.dumps(
+            {"application_id": self.fake_application["id"]}
+        )
+        self.mock_get_application.return_value = self.fake_application
+        self.mock_cal.return_value.get_timezone.return_value = (
+            self.fake_timezone
+        )
+        self.mock_cal.return_value.delete_interview_event.return_value = None
+        self.mock_cal.return_value.is_on_interview_calendar.return_value = True
+        self.mock_reject_application.return_value = MagicMock(status_code=200)
+        self.mock_get_interviews_scheduled.return_value = [
+            self.fake_scheduled_interview,
+            self.fake_completed_interview,
+        ]
+        self.mock_send_mail.return_value = None
+        self.mock_google_authenticate = None
+
+        # create test context
+        self.ctx = app.test_request_context()
+        self.ctx.push()
+
+        # set debug to true so we can test and ensure _send_mail is not called
+        flask.current_app.debug = True
+
+    def test_candidate_withdrawal_process(self):
+        # call application_withdrawal function with a fake token
+        application_withdrawal("fake_token")
+
+        # ensure that get_interviews_scheduled was called with the right id
+        self.mock_get_interviews_scheduled.assert_called_once_with(
+            self.fake_application["id"]
+        )
+
+        # ensure that delete_interview_event only called once
+        # (this asserts that the filtering worked, since only one of the
+        # fake interviews has a status of "scheduled")
+        self.mock_cal.return_value.delete_interview_event.assert_called_once()
+
+        # ensure that delete_interview_event was called with
+        # the correct argument
+        self.mock_cal.return_value.delete_interview_event.assert_called_with(
+            event_id=self.fake_scheduled_interview["external_event_id"]
+        )
+
+        # ensure _send_mail is not called (since debug is True)
+        self.mock_send_mail.assert_not_called()
+
+        # ensure get_timezone is called with correct email
+        self.mock_cal.return_value.get_timezone.assert_called_with(
+            self.fake_scheduled_interview["interviewers"][0]["email"]
+        )
+
+        # ensure datetime conversion worked
+        expected_datetime = "February 29, 2024 at 03:00PM"
+        _, kwargs = self.mock_render_template.call_args_list[0]
+        self.assertIn("interview_date", kwargs)
+        self.assertEqual(kwargs["interview_date"], expected_datetime)
+
+        # ensure that harvest rejection fn is called with correct arguments
+        self.mock_reject_application.assert_called_once_with(
+            self.fake_application["id"],
+            self.fake_application["hiring_lead"]["id"],
+            self.fake_withdrawal_reason_id,
+            self.fake_withdrawal_message,
+        )
+
+    def tearDown(self):
+        # stop all of the patches from setUp
+        patch.stopall()
+
+        # pop the test context
+        self.ctx.pop()
 
 
 if __name__ == "__main__":

--- a/tests/test_google_calendar.py
+++ b/tests/test_google_calendar.py
@@ -1,0 +1,80 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from webapp.google_calendar import CalendarAPI
+
+# Interview calendar
+INTERVIEW_CALENDAR = (
+    "c_0a3348ba0132da2077be501edacc1ba7415ac132612d"
+    + "264f99684232ee4ec491@group.calendar.google.com"
+)
+
+
+class TestGoogleCalendar(unittest.TestCase):
+    @patch("webapp.google_calendar.build")
+    @patch(
+        "webapp.google_calendar.service_account."
+        + "Credentials.from_service_account_info"
+    )
+    def setUp(self, mock_from_service_account_info, mock_build):
+        # fake constants
+        self.fake_calendar_id = "calendar_id"
+        self.fake_event_id = "event_id"
+        self.fake_timezone = "America/Toronto"
+        self.fake_email = "email@email.com"
+
+        # mock functions
+        self.mock_service = MagicMock()
+        self.mock_events = MagicMock()
+        mock_from_service_account_info.return_value = MagicMock()
+
+        # set return values of mocks
+        self.mock_service.events.return_value = self.mock_events
+        mock_build.return_value = self.mock_service
+
+        # create a CalendarAPI object
+        self.calendar_api = CalendarAPI()
+
+    def test_delete_interview_event(self):
+        # call the delete_interview_event method
+        self.calendar_api.delete_interview_event(self.fake_event_id)
+
+        # assertions
+        self.mock_events.delete.assert_called_with(
+            calendarId=INTERVIEW_CALENDAR,
+            eventId=self.fake_event_id,
+            sendUpdates="all",
+        )
+        self.mock_events.delete().execute.assert_called_once()
+
+    def test_get_timezone(self):
+        # create a mock_calendars object
+        mock_calendars = MagicMock()
+
+        # set return values
+        self.mock_service.calendars.return_value = mock_calendars
+        mock_calendars.get().execute.return_value = {
+            "timeZone": self.fake_timezone
+        }
+
+        # call the get_timezone method
+        timezone = self.calendar_api.get_timezone(self.fake_email)
+
+        # assertions
+        mock_calendars.get.assert_called_with(calendarId=self.fake_email)
+        mock_calendars.get().execute.assert_called_once()
+        self.assertEqual(timezone, self.fake_timezone)
+
+    def test_is_on_interview_calendar(self):
+        # call the delete_interview_event method
+        self.calendar_api.is_on_interview_calendar(self.fake_event_id)
+
+        # assertions
+        self.mock_events.get.assert_called_with(
+            calendarId=INTERVIEW_CALENDAR,
+            eventId=self.fake_event_id,
+        )
+        self.mock_events.get().execute.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -523,8 +523,10 @@ def application_withdrawal(token):
         if interview["status"] == "scheduled":
             # can only delete interviews which are on the interview calendar
             # so we check this first
-            can_be_deleted = calendar.is_on_interview_calendar(interview["external_event_id"])
-            if (can_be_deleted):
+            can_be_deleted = calendar.is_on_interview_calendar(
+                interview["external_event_id"]
+            )
+            if can_be_deleted:
                 delete_response = calendar.delete_interview_event(
                     event_id=interview["external_event_id"]
                 )
@@ -565,7 +567,7 @@ def application_withdrawal(token):
             applicant_name=applicant_name,
             interview_date=interview_date,
             position=application["role_name"],
-            can_be_deleted=can_be_deleted
+            can_be_deleted=can_be_deleted,
         )
         all_sent_emails.append(
             {

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -9,6 +9,8 @@ from typing import Dict, List, Tuple
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 from requests.exceptions import HTTPError
+import pytz
+import logging
 
 
 import flask
@@ -18,6 +20,7 @@ from dateutil.parser import parse
 from webapp.greenhouse import Harvest
 from webapp.job_regions import regions
 from webapp.utils.cipher import Cipher, InvalidToken
+from webapp.google_calendar import CalendarAPI
 
 withdrawal_reasons = {
     "27987": "I've accepted another position",
@@ -496,86 +499,91 @@ def application_withdrawal(token):
     ]
     all_sent_emails = []
 
-    # TODO: commenting out for now because env variables for CalendarAPI
-    #       are not working
-    # calendar = CalendarAPI()
-    # for interview in candidate_interviews:
-    #     # get interviewer information
-    #     interviewer = interview["interviewers"][0]
-    #     interviewer_timezone = calendar.get_timezone(interviewer["email"])
+    calendar = CalendarAPI()
+    for interview in candidate_interviews:
+        # get interviewer information
+        interviewer = interview["interviewers"][0]
+        interviewer_timezone = calendar.get_timezone(interviewer["email"])
 
-    #     # convert interview time to interviewer's timezone
-    #     interview_datetime_str = interview["start"]["date_time"]
-    #     interview_datetime_obj = datetime.fromisoformat(
-    #         interview_datetime_str.replace("Z", "+00:00")
-    #     )
-    #     interview_datetime_obj = interview_datetime_obj.astimezone(
-    #         pytz.timezone(interviewer_timezone)
-    #     )
-    #     interview_date = interview_datetime_obj.strftime(
-    #         "%B %d, %Y at %I:%M%p"
-    #     )
+        # convert interview time to interviewer's timezone
+        interview_datetime_str = interview["start"]["date_time"]
+        interview_datetime_obj = datetime.fromisoformat(
+            interview_datetime_str.replace("Z", "+00:00")
+        )
+        interview_datetime_obj = interview_datetime_obj.astimezone(
+            pytz.timezone(interviewer_timezone)
+        )
+        interview_date = interview_datetime_obj.strftime(
+            "%B %d, %Y at %I:%M%p"
+        )
 
-    #     if interview["status"] == "scheduled":
-    #         # if interview still upcoming, delete interview event
-    #         delete_response = calendar.delete_interview_event(
-    #             event_id=interview["external_event_id"]
-    #         )
+        # if interview is still upcoming, we want to try to delete
+        # the interview event
+        can_be_deleted = False
+        if interview["status"] == "scheduled":
+            # can only delete interviews which are on the interview calendar
+            # so we check this first
+            can_be_deleted = calendar.is_on_interview_calendar(interview["external_event_id"])
+            if (can_be_deleted):
+                delete_response = calendar.delete_interview_event(
+                    event_id=interview["external_event_id"]
+                )
 
-    #         # empty response is returned on successful deletion
-    #         # so raise exception if not empty
-    #         if delete_response:
-    #             logging.error(
-    #                 "Delete response not empty, error deleting event:\n"
-    #                 + str(delete_response)
-    #             )
+                # empty response is returned on successful deletion
+                # so log error if not empty
+                if delete_response:
+                    logging.error(
+                        "Delete response not empty, error deleting event:\n"
+                        + str(delete_response)
+                    )
 
-    #         # email template and title for canceled interview
-    #         email_template = (
-    #             "careers/application/_withdrawal"
-    #             + "-interview-canceled-email.html"
-    #         )
-    #         email_title = (
-    #             "Interview Cancelation - "
-    #             + f"Candidate Withdrawal for {applicant_name}"
-    #         )
-    #     else:
-    #         # otherwise, set email template and title for feedback not needed
-    #         email_template = (
-    #             "careers/application/_withdrawal"
-    #             + "-feedback-not-needed-email.html"
-    #         )
-    #         email_title = (
-    #             "Interview Feedback - "
-    #             + f"Candidate Withdrawal for {applicant_name}"
-    #         )
+            # email template and title for canceled interview
+            email_template = (
+                "careers/application/_withdrawal"
+                + "-interview-canceled-email.html"
+            )
+            email_title = (
+                "Interview Cancelation - "
+                + f"Candidate Withdrawal for {applicant_name}"
+            )
+        else:
+            # otherwise, set email template and title for feedback not needed
+            email_template = (
+                "careers/application/_withdrawal"
+                + "-feedback-not-needed-email.html"
+            )
+            email_title = (
+                "Interview Feedback - "
+                + f"Candidate Withdrawal for {applicant_name}"
+            )
 
-    #     # build email to send to interviewer
-    #     email_for_interviewer = flask.render_template(
-    #         email_template,
-    #         interviewer_name=interviewer["name"],
-    #         interview_title=interview["interview"]["name"],
-    #         applicant_name=applicant_name,
-    #         interview_date=interview_date,
-    #         position=application["role_name"],
-    #     )
-    #     all_sent_emails.append(
-    #         {
-    #             "interviewer": interviewer["email"],
-    #             "message": email_for_interviewer,
-    #         }
-    #     )
+        # build email to send to interviewer
+        email_for_interviewer = flask.render_template(
+            email_template,
+            interviewer_name=interviewer["name"],
+            interview_title=interview["interview"]["name"],
+            applicant_name=applicant_name,
+            interview_date=interview_date,
+            position=application["role_name"],
+            can_be_deleted=can_be_deleted
+        )
+        all_sent_emails.append(
+            {
+                "interviewer": interviewer["email"],
+                "message": email_for_interviewer,
+            }
+        )
 
-    #     # send email
-    #     debug_skip_sending = flask.current_app.debug
-    #     if not debug_skip_sending:
-    #         # also sending cancelation/feedback email to TS inbox
-    #         # for tracking from their end.
-    #         _send_mail(
-    #             [interviewer["email"], "talent-mailbox@canonical.com"],
-    #             email_title,
-    #             email_for_interviewer,
-    #         )
+        # send email
+        debug_skip_sending = flask.current_app.debug
+        if not debug_skip_sending:
+            # also sending cancelation/feedback email to TS inbox
+            # for tracking from their end.
+            _send_mail(
+                [interviewer["email"], "talent-mailbox@canonical.com"],
+                email_title,
+                email_for_interviewer,
+            )
 
     # call the Harvest API to reject the application
     response = harvest.reject_application(

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -58,3 +58,20 @@ class CalendarAPI:
         calendar = self.service.calendars().get(calendarId=email).execute()
 
         return calendar["timeZone"]
+
+    def is_on_interview_calendar(self, event_id):
+        try:
+            # if we can successfully get the event from the interview
+            # calendar, then it exists on the interview calendar
+            self.service.events().get(
+                calendarId=INTERVIEW_CALENDAR, eventId=event_id
+            ).execute()
+            return True
+        except HttpError as error:
+            # otherwise, if getting event gives a 404 not found error,
+            # it does not exist on the interview calendar
+            if error.resp.status == 404:
+                return False
+            else:
+                # re-raise the error if it's not a 404
+                raise error


### PR DESCRIPTION
- add new interview deletion logic
- update interview canceled email template to mention whether interview was auto-deleted
- add an is_on_interview_calender() function to google calendar api class
- add tests for application function
- add tests for google calendar

## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
