### PR TITLE
Update AI/ML-ops link on index to point toward internal page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -148,7 +148,7 @@ and a portfolio of enterprise-grade technologies. Founded in 2004, Canonical ope
           <div class="col-3">
             <p class="p-heading--2"><a href="/data">Data&nbsp;&rsaquo;</a></p>
             <hr class="p-rule is-dark u-hide--medium">
-            <p class="p-heading--2"><a href="https://ubuntu.com/ai">AI and MLOps&nbsp;&rsaquo;</a>
+            <p class="p-heading--2"><a href="/solutions/ai">AI and MLOps&nbsp;&rsaquo;</a>
             <p>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Update link on homepage based on [copydoc](https://docs.google.com/document/d/1GNa1FaTkARdrVwYgHXf5H-6sqOLjkJENDistDDcsi4o/edit)

## QA

- Go to https://canonical-com-1229.demos.haus/
- Click the 'AI/ML Ops' link
- See that it redirects to https://canonical-com-1229.demos.haus/solutions/ai  

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9989

## Screenshots

![image](https://github.com/canonical/canonical.com/assets/58276363/f7aebeca-0d93-45c9-8b3f-d1242ab8460f)

