### PR TITLE
Updated cookie policy to v3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cypress:open": "cypress open --config-file tests/cypress/cypress.json --config baseUrl=http://0.0.0.0:${PORT:-8002}/"
   },
   "dependencies": {
-    "@canonical/cookie-policy": "3.5.0",
+    "@canonical/cookie-policy": "3.6.0",
     "@canonical/latest-news": "1.5.0",
     "@canonical/global-nav": "3.6.2",
     "@testing-library/cypress": "9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,10 +316,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.5.0.tgz#1c7e6cc2d5a7218375001b2cff2996a927693e89"
-  integrity sha512-XLCIl8+h+3BRfvqADqFsmAfWdaDGDchY/TPCKtpeQdb4r64SR6arsdNftlOb7vX8EuLCK2QRp6evUy0J+qnQTg==
+"@canonical/cookie-policy@3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.6.0.tgz#6e1f5fa481b7625d5c4401666dfb7503a19bb0c8"
+  integrity sha512-h4gV7vkZS9PDjqiTIn2xFc/3Zo5lds8hcQ6UmwD3yDDWY7CwCwjvBd13Z86PszMf2S8DiCfQ4wWQLvynqP/MiA==
 
 "@canonical/global-nav@3.6.2":
   version "3.6.2"


### PR DESCRIPTION
## Done

- Updated the cookie policy to include google consent mode

## QA

- Open the demo and inspect the source _before_ accepting the preferences
  - The top of `<head>` section should have a `google-consent-mode` script
- Accept one of the cookie preference options
  - The bottom of `<head>` section should have a `google-consent-preferences` script
