### PR TITLE
chore: modify new issues url to use a different url with a default template

### DIFF
--- a/templates/401.html
+++ b/templates/401.html
@@ -6,5 +6,5 @@
 
 {% block error_content %}
   You do not have access to this page.<br>
-  You can <a href="https://github.com/canonical/canonical.com/issues/new">File a bug</a> if this is an error.
+  You can <a href="https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md">File a bug</a> if this is an error.
 {% endblock error_content %}

--- a/templates/401.html
+++ b/templates/401.html
@@ -5,6 +5,6 @@
 {% set error_message = "Unauthorised" %}
 
 {% block error_content %}
-  You do not have access to this page.<br>
+  You do not have access to this page.<br/>
   You can <a href="https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md">File a bug</a> if this is an error.
 {% endblock error_content %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -7,5 +7,5 @@
 {% block error_content %}
   We can't find the page you're looking for.
   <br>
-  <a href="https://github.com/canonical/canonical.com/issues/new">File a bug</a> if you think this might be an error.
+  <a href="https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md">File a bug</a> if you think this might be an error.
 {% endblock error_content %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -6,6 +6,6 @@
 
 {% block error_content %}
   We can't find the page you're looking for.
-  <br>
+  <br/>
   <a href="https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md">File a bug</a> if you think this might be an error.
 {% endblock error_content %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -6,6 +6,6 @@
 
 {% block error_content %}
   We couldn't load this page.<br>
-  Try reloading or <a href="https://github.com/canonical/canonical.com/issues/new">file an issue</a>.<br>
+  Try reloading or <a href="https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md">file an issue</a>.<br>
   Please note, this may be a <a href="https://github.com/canonical/canonical.com/issues">known issue</a> that we are working on.
 {% endblock error_content %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -5,7 +5,7 @@
 {% set error_message = "Server error" %}
 
 {% block error_content %}
-  We couldn't load this page.<br>
-  Try reloading or <a href="https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md">file an issue</a>.<br>
+  We couldn't load this page.<br/>
+  Try reloading or <a href="https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md">file an issue</a>.<br/>
   Please note, this may be a <a href="https://github.com/canonical/canonical.com/issues">known issue</a> that we are working on.
 {% endblock error_content %}

--- a/templates/502.html
+++ b/templates/502.html
@@ -6,5 +6,5 @@
 
 {% block error_content %}
   The proxy server did not get a valid response from an upstream server.<br>
-  You can <a href="https://github.com/canonical/canonical.com/issues/new">File a bug</a> to report this issue.
+  You can <a href="https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md">File a bug</a> to report this issue.
 {% endblock error_content %}

--- a/templates/502.html
+++ b/templates/502.html
@@ -5,6 +5,6 @@
 {% set error_message = "Bad gateway" %}
 
 {% block error_content %}
-  The proxy server did not get a valid response from an upstream server.<br>
+  The proxy server did not get a valid response from an upstream server.<br/>
   You can <a href="https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md">File a bug</a> to report this issue.
 {% endblock error_content %}

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -28,12 +28,12 @@
     </div>
     <div class="col-medium-4 col-start-medium-3 col-6">
       <p>
-        Ubuntu and Canonical are registered trademarks.<br>
+        Ubuntu and Canonical are registered trademarks.<br/>
         All other trademarks are the property of their respective owners.
       </p>
       <hr class="is-dark"/>
       <p>
-        For further information on data collection,<br>
+        For further information on data collection,<br/>
         please refer to our 
         {% if "/careers" in current_path %}
           <a href="https://ubuntu.com/legal/data-privacy/recruitment" target="_blank">recruitment privacy notice</a> and 

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -21,7 +21,7 @@
         {% if "/careers" in current_path %}
           <li class="p-list__item--condensed"><a href="https://ubuntu.com/legal/equal-employment-opportunity-commitment">Equal Employment Opportunity Commitment</a></li>
         {% endif %}
-        <li class="p-list__item--condensed"><a href="https://github.com/canonical/canonical.com/issues/new">Improve this site</a></li>
+        <li class="p-list__item--condensed"><a href="https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md">Improve this site</a></li>
         <li class="p-list__item--condensed"><a href="/projects" >Projects</a></li>
         <li class="p-list__item--condensed"><a class="js-revoke-cookie-manager" href="">Manage your tracker settings</a></li>
       </ul>


### PR DESCRIPTION
## Done

- Modified new issue urls from https://github.com/canonical/canonical.com/issues/new to https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md which uses a default template.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #1227
## Screenshots

[if relevant, include a screenshot]
![Screenshot from 2024-03-30 00-37-20](https://github.com/canonical/canonical.com/assets/48877319/ea5d4bea-30d8-45dc-a192-c885a50cb793)

