### PR TITLE
Update partner portal link across the site

### DIFF
--- a/templates/partial/_standard-navigation.html
+++ b/templates/partial/_standard-navigation.html
@@ -4,19 +4,28 @@
       <div class="p-navigation__tagged-logo">
         <a class="p-navigation__link" href="/">
           <div class="p-navigation__logo-tag">
-            <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="Canonical" width="95" />
+            <img class="p-navigation__logo-icon"
+                 src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg"
+                 alt="Canonical"
+                 width="95" />
           </div>
           <span class="p-navigation__logo-title">Canonical</span>
         </a>
       </div>
-      <a href="#standard-navigation" class="p-navigation__toggle--open p-global-nav-titles" title="Menu">Menu</a>
-      <a href="#standard-navigation-closed" class="p-navigation__toggle--close" title="Close menu">Close menu</a>
+      <a href="#standard-navigation"
+         class="p-navigation__toggle--open p-global-nav-titles"
+         title="Menu">Menu</a>
+      <a href="#standard-navigation-closed"
+         class="p-navigation__toggle--close"
+         title="Close menu">Close menu</a>
     </div>
 
     <nav class="p-navigation__nav col-9" aria-label="Main navigation">
       <ul class="p-navigation__items js-show-nav" style="margin-left: -.75rem;">
         <li class="p-navigation__item--dropdown-toggle" id="company-nav">
-          <a href="/company" aria-controls="company-menu" class="p-navigation__link">Company</a>
+          <a href="/company"
+             aria-controls="company-menu"
+             class="p-navigation__link">Company</a>
           <ul class="p-navigation__dropdown" id="company-menu" aria-hidden="true">
             <li>
               <a href="/blog" class="p-navigation__dropdown-item">Blog</a>
@@ -36,19 +45,38 @@
           <a href="/#products" class="p-navigation__link">Products</a>
         </li>
         <li class="p-navigation__item--dropdown-toggle" id="partners-nav">
-          <a href="/partners" aria-controls="partners-menu" class="p-navigation__link">Partners</a>
+          <a href="/partners"
+             aria-controls="partners-menu"
+             class="p-navigation__link">Partners</a>
           <ul class="p-navigation__dropdown" id="partners-menu" aria-hidden="true">
             <li>
               <a href="/partners" class="p-navigation__dropdown-item">Our partner programs</a>
               <ul class="p-navigation__sub-list">
-                <li><a href="/partners/desktop" class="p-navigation__dropdown-item">Desktop</a></li>
-                <li><a href="/partners/channel-and-reseller" class="p-navigation__dropdown-item">Channel/reseller</a></li>
-                <li><a href="/partners/iot-device" class="p-navigation__dropdown-item">IoT devices</a></li>
-                <li><a href="/partners/ihv-and-oem" class="p-navigation__dropdown-item">IHV/OEM</a></li>
-                <li><a href="/partners/isv-partners" class="p-navigation__dropdown-item">ISVs</a></li>
-                <li><a href="/partners/gsi" class="p-navigation__dropdown-item">Global System Integrators</a></li>
-                <li><a href="/partners/public-cloud" class="p-navigation__dropdown-item">Public cloud</a></li>
-                <li><a href="/partners/silicon" class="p-navigation__dropdown-item">Silicon</a></li>
+                <li>
+                  <a href="/partners/desktop" class="p-navigation__dropdown-item">Desktop</a>
+                </li>
+                <li>
+                  <a href="/partners/channel-and-reseller"
+                     class="p-navigation__dropdown-item">Channel/reseller</a>
+                </li>
+                <li>
+                  <a href="/partners/iot-device" class="p-navigation__dropdown-item">IoT devices</a>
+                </li>
+                <li>
+                  <a href="/partners/ihv-and-oem" class="p-navigation__dropdown-item">IHV/OEM</a>
+                </li>
+                <li>
+                  <a href="/partners/isv-partners" class="p-navigation__dropdown-item">ISVs</a>
+                </li>
+                <li>
+                  <a href="/partners/gsi" class="p-navigation__dropdown-item">Global System Integrators</a>
+                </li>
+                <li>
+                  <a href="/partners/public-cloud" class="p-navigation__dropdown-item">Public cloud</a>
+                </li>
+                <li>
+                  <a href="/partners/silicon" class="p-navigation__dropdown-item">Silicon</a>
+                </li>
               </ul>
             </li>
             <li>
@@ -61,7 +89,8 @@
               <a href="/partners/executive-summit" class="p-navigation__dropdown-item">Partner Executive Summit</a>
             </li>
             <li>
-              <a href="https://partner-portal.canonical.com/" class="p-navigation__dropdown-item">Log into the partner portal</a>
+              <a href="http://partner.canonical.com"
+                 class="p-navigation__dropdown-item">Log into the partner portal</a>
             </li>
           </ul>
         </li>

--- a/templates/partial/_standard-navigation.html
+++ b/templates/partial/_standard-navigation.html
@@ -89,7 +89,7 @@
               <a href="/partners/executive-summit" class="p-navigation__dropdown-item">Partner Executive Summit</a>
             </li>
             <li>
-              <a href="http://partner.canonical.com"
+              <a href="https://partner.canonical.com"
                  class="p-navigation__dropdown-item">Log into the partner portal</a>
             </li>
           </ul>

--- a/templates/partners/channel-and-reseller.html
+++ b/templates/partners/channel-and-reseller.html
@@ -4,115 +4,125 @@
 
 {% block title %}Channel / Reseller Programme | Partners{% endblock %}
 
-{% block meta_description %}Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers.{% endblock %}
+{% block meta_description %}
+  Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers.
+{% endblock %}
 
-{% block body_class %}is-paper{% endblock body_class %}
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
 
-{% with parent_name="Partners", parent_href="/partners", title="Channel / Reseller Programme" %}
-  {% include '/partial/_breadcrumbs.html' %}
-{% endwith %}
+  {% with parent_name="Partners", parent_href="/partners", title="Channel / Reseller Programme" %}
+    {% include '/partial/_breadcrumbs.html' %}
+  {% endwith %}
 
-<section class="p-section">
-  <div class="row--50-50">
-    <div class="col">
-      <h1>Channel&sol;Reseller<br class="u-hide--small"> Programme</h1>
-    </div>
-    <div class="col">
-      <div class="p-block">
-        <p>Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers. Additionally these partners can both resell services and value-added offerings around our technology enabling them to grow their business.</p>
-        <p>Canonical is an industry leader in OpenStack private clouds, the reference platform for all major public clouds, and the open source software operating system that runs from the desktop and all internet connected things. Our success helps our partners build a business around our technology.</p>
+  <section class="p-section">
+    <div class="row--50-50">
+      <div class="col">
+        <h1>
+          Channel&sol;Reseller
+          <br class="u-hide--small" />
+          Programme
+        </h1>
       </div>
-      <a href="https://partner-portal.canonical.com" class="p-button--positive"><span>Login to the partner portal</span></a>
-      <a href="/partners/become-a-partner" class="p-button">Become a partner</a>
-    </div>
-  </div>
-</section>
-
-{% with title="Meet some of our channel/reseller partners", link_text="See all of our channel/reseller partners", link_href="/partners/find-a-partner?filters=channel-reseller" %}
-  {% include '/partners/partial/_partners-logos.html' %}
-{% endwith %}
-
-<section class="p-section">
-  <div class="row p-block">
-    <hr class="p-rule">
-    <h2>What does Canonical's channel partner programme offer?</h2>
-  </div>
-  <div class="row">
-    <div class="col-9 col-start-large-4 col-medium-5 col-start-medium-2">
-      <hr class="p-rule">
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <p class="p-heading--5">
-            Rich portfolio of products
+      <div class="col">
+        <div class="p-block">
+          <p>
+            Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers. Additionally these partners can both resell services and value-added offerings around our technology enabling them to grow their business.
+          </p>
+          <p>
+            Canonical is an industry leader in OpenStack private clouds, the reference platform for all major public clouds, and the open source software operating system that runs from the desktop and all internet connected things. Our success helps our partners build a business around our technology.
           </p>
         </div>
-        <div class="col-6 col-medium-3">
-          <p>Resell the full range of Canonical&rsquo;s portfolio of private and public cloud products: Openstack, Kubernetes, IoT, support, security and compliance for Ubuntu.</p>
-        </div>
-      </div>
-      <hr class="p-rule">
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <p class="p-heading--5">
-            Sales enablement
-          </p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Canonical can help train your field sales and presales teams and provide you with sales collateral and permission to use the Canonical and Ubuntu trademarks in your own materials.</p>
-        </div>
-      </div> 
-      <hr class="p-rule">
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <p class="p-heading--5">
-            Access to Canonical partner portal
-          </p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>We host a partner portal with product and solutions collaterals, agreed pricing, incentives and a deal registration system.</p>
-        </div>
-      </div>
-      <hr class="p-rule">
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <p class="p-heading--5">
-            Training and certification
-          </p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Gain access to technology that is the foundation for digital transformation and expand your business through marketing support and alignment with a trusted brand</p>
-        </div>
-      </div>
-      <hr class="p-rule">
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <p class="p-heading--5">
-            Technical enablement
-          </p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Canonical can help train your technical teams and provide you with access to our technical resources for your labs and customer engagements.</p>
-        </div>
-      </div>
-      <hr class="p-rule">
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <p class="p-heading--5">
-            Go to market with Canonical
-          </p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Working with our dedicated partner team, get new joint marketing opportunities and lead generation.</p>
-        </div>
+        <a href="https://partner.canonical.com" class="p-button--positive"><span>Login to the partner portal</span></a>
+        <a href="/partners/become-a-partner" class="p-button">Become a partner</a>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-{% include '/partners/partial/_co-sell-with-canonical.html' %}
+  {% with title="Meet some of our channel/reseller partners", link_text="See all of our channel/reseller partners", link_href="/partners/find-a-partner?filters=channel-reseller" %}
+    {% include '/partners/partial/_partners-logos.html' %}
+  {% endwith %}
 
-{% include '/partners/partial/_footer.html' %}
+  <section class="p-section">
+    <div class="row p-block">
+      <hr class="p-rule" />
+      <h2>What does Canonical's channel partner programme offer?</h2>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4 col-medium-5 col-start-medium-2">
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <p class="p-heading--5">Rich portfolio of products</p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Resell the full range of Canonical&rsquo;s portfolio of private and public cloud products: Openstack, Kubernetes, IoT, support, security and compliance for Ubuntu.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <p class="p-heading--5">Sales enablement</p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Canonical can help train your field sales and presales teams and provide you with sales collateral and permission to use the Canonical and Ubuntu trademarks in your own materials.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <p class="p-heading--5">Access to Canonical partner portal</p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              We host a partner portal with product and solutions collaterals, agreed pricing, incentives and a deal registration system.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <p class="p-heading--5">Training and certification</p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Gain access to technology that is the foundation for digital transformation and expand your business through marketing support and alignment with a trusted brand
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <p class="p-heading--5">Technical enablement</p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Canonical can help train your technical teams and provide you with access to our technical resources for your labs and customer engagements.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <p class="p-heading--5">Go to market with Canonical</p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>Working with our dedicated partner team, get new joint marketing opportunities and lead generation.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  {% include '/partners/partial/_co-sell-with-canonical.html' %}
+
+  {% include '/partners/partial/_footer.html' %}
 
 {% endblock %}

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -2,146 +2,160 @@
 
 {% block title %}Canonical partner programmes{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1q6dkqQ0zcshrfOmdJA_bAip73EaMSEyXAn8bAD7GqNw/edit{% endblock %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1q6dkqQ0zcshrfOmdJA_bAip73EaMSEyXAn8bAD7GqNw/edit
+{% endblock %}
 
-{% block body_class %}is-paper{% endblock body_class %}
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
 
-<section class="p-strip">
-  <div class="row">
-    <div class="col-medium-4 col-start-medium-3 col-9 col-start-large-4">
-      <h1>Canonical <br class="u-hide--small">partner programmes</h1>
-      <p>At Canonical, we provide the services our partners need to ensure their hardware and software works optimally with the Ubuntu platform.</p>
-      <p>This means working with technology leaders large and small, to provide the software, services, support and certification they need to complement their core competencies. For technology customers, this has created a thriving market of suppliers with Ubuntu expertise.</p>
+  <section class="p-strip">
+    <div class="row">
+      <div class="col-medium-4 col-start-medium-3 col-9 col-start-large-4">
+        <h1>
+          Canonical
+          <br class="u-hide--small" />
+          partner programmes
+        </h1>
+        <p>
+          At Canonical, we provide the services our partners need to ensure their hardware and software works optimally with the Ubuntu platform.
+        </p>
+        <p>
+          This means working with technology leaders large and small, to provide the software, services, support and certification they need to complement their core competencies. For technology customers, this has created a thriving market of suppliers with Ubuntu expertise.
+        </p>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <hr class="p-rule is-fixed-width">
-  <div class="row">
-    <div class="col-medium-2 col-3">
-      <h2 class="p-muted-heading">Login</h2>
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row">
+      <div class="col-medium-2 col-3">
+        <h2 class="p-muted-heading">Login</h2>
+      </div>
+      <div class="col-medium-4 col-9">
+        <p>
+          Existing partner? <a href="https://partner.canonical.com">Log in to the partner portal</a>
+        </p>
+      </div>
     </div>
-    <div class="col-medium-4 col-9">
-      <p>Existing partner? <a href="https://partner-portal.canonical.com">Log in to the partner portal</a></p>
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <hr class="p-rule is-fixed-width">
-  <div class="row">
-    <div class="col-medium-2 col-3">
-      <h2 class="p-muted-heading">Programmes</h2>
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row">
+      <div class="col-medium-2 col-3">
+        <h2 class="p-muted-heading">Programmes</h2>
+      </div>
+      <div class="col-medium-4 col-9">
+        <div class="row">
+          <div class="col-3">
+            <p class="p-heading--5">
+              <a href="/partners/public-cloud">Public cloud&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="col-6">
+            <p>Ubuntu on clouds is optimised, tested and certified by Canonical for performance and security</p>
+          </div>
+        </div>
+        <div class="row">
+          <hr class="p-rule" />
+        </div>
+        <div class="row">
+          <div class="col-3">
+            <p class="p-heading--5">
+              <a href="/partners/ihv-and-oem">IHV/OEM&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="col-6">
+            <p>Certified hardware for efficient data centres from the large-scale core to distributed edge</p>
+          </div>
+        </div>
+        <div class="row">
+          <hr class="p-rule" />
+        </div>
+        <div class="row">
+          <div class="col-3">
+            <p class="p-heading--5">
+              <a href="/partners/silicon">Silicon&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="col-6">
+            <p>Enablement and optimisation of Ubuntu on a wide range of CPUs and chipsets, boards and SOCs</p>
+          </div>
+        </div>
+        <div class="row">
+          <hr class="p-rule" />
+        </div>
+        <div class="row">
+          <div class="col-3">
+            <p class="p-heading--5">
+              <a href="/partners/channel-and-reseller">Channel&sol;Reseller&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="col-6">
+            <p>Channel partners ensure that local experts in Ubuntu and all Canonical products can be found on every continent</p>
+          </div>
+        </div>
+        <div class="row">
+          <hr class="p-rule" />
+        </div>
+        <div class="row">
+          <div class="col-3">
+            <p class="p-heading--5">
+              <a href="/partners/iot-device">IoT Devices&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="col-6">
+            <p>ODM, factory, integration and device management partners get your device to market faster</p>
+          </div>
+        </div>
+        <div class="row">
+          <hr class="p-rule" />
+        </div>
+        <div class="row">
+          <div class="col-3">
+            <p class="p-heading--5">
+              <a href="/partners/isv-partners">ISVs&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="col-6">
+            <p>Use Canonical products like containers, MicroK8s and Ubuntu to power your software and appliances</p>
+          </div>
+        </div>
+        <div class="row">
+          <hr class="p-rule" />
+        </div>
+        <div class="row">
+          <div class="col-3">
+            <p class="p-heading--5">
+              <a href="/partners/gsi">Global System Integrators&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="col-6">
+            <p>Deliver solutions on Ubuntu to drive down costs and accelerate the adoption of open source</p>
+          </div>
+        </div>
+        <div class="row">
+          <hr class="p-rule" />
+        </div>
+        <div class="row">
+          <div class="col-3">
+            <p class="p-heading--5">
+              <a href="/partners/desktop">Desktop&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="col-6">
+            <p>Pre-installed and certified Ubuntu on desktops, laptops and workstations</p>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="col-medium-4 col-9">
-      <div class="row">
-        <div class="col-3">
-          <p class="p-heading--5">
-            <a href="/partners/public-cloud">Public cloud&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-        <div class="col-6">
-          <p>Ubuntu on clouds is optimised, tested and certified by Canonical for performance and security</p>
-        </div>
-      </div>
-      <div class="row">
-        <hr class="p-rule">
-      </div>
-      <div class="row">
-        <div class="col-3">
-          <p class="p-heading--5">
-            <a href="/partners/ihv-and-oem">IHV/OEM&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-        <div class="col-6">
-          <p>Certified hardware for efficient data centres from the large-scale core to distributed edge</p>
-        </div>
-      </div>
-      <div class="row">
-        <hr class="p-rule">
-      </div>
-      <div class="row">
-        <div class="col-3">
-          <p class="p-heading--5">
-            <a href="/partners/silicon">Silicon&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-        <div class="col-6">
-          <p>Enablement and optimisation of Ubuntu on a wide range of CPUs and chipsets, boards and SOCs</p>
-        </div>
-      </div>
-      <div class="row">
-        <hr class="p-rule">
-      </div>
-      <div class="row">
-        <div class="col-3">
-          <p class="p-heading--5">
-            <a href="/partners/channel-and-reseller">Channel&sol;Reseller&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-        <div class="col-6">
-          <p>Channel partners ensure that local experts in Ubuntu and all Canonical products can be found on every continent</p>
-        </div>
-      </div>
-      <div class="row">
-        <hr class="p-rule">
-      </div>
-      <div class="row">
-        <div class="col-3">
-          <p class="p-heading--5">
-            <a href="/partners/iot-device">IoT Devices&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-        <div class="col-6">
-          <p>ODM, factory, integration and device management partners get your device to market faster</p>
-        </div>
-      </div>
-      <div class="row">
-        <hr class="p-rule">
-      </div>
-      <div class="row">
-        <div class="col-3">
-          <p class="p-heading--5">
-            <a href="/partners/isv-partners">ISVs&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-        <div class="col-6">
-          <p>Use Canonical products like containers, MicroK8s and Ubuntu to power your software and appliances</p>
-        </div>
-      </div>
-      <div class="row">
-        <hr class="p-rule">
-      </div>
-      <div class="row">
-        <div class="col-3">
-          <p class="p-heading--5">
-            <a href="/partners/gsi">Global System Integrators&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-        <div class="col-6">
-          <p>Deliver solutions on Ubuntu to drive down costs and accelerate the adoption of open source</p>
-        </div>
-      </div>
-      <div class="row">
-        <hr class="p-rule">
-      </div>
-      <div class="row">
-        <div class="col-3">
-          <p class="p-heading--5">
-            <a href="/partners/desktop">Desktop&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-        <div class="col-6">
-          <p>Pre-installed and certified Ubuntu on desktops, laptops and workstations</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
+  </section>
 
-{% include '/partners/partial/_footer.html' %}
+  {% include '/partners/partial/_footer.html' %}
 
 {% endblock %}

--- a/templates/partners/partial/_co-sell-with-canonical.html
+++ b/templates/partners/partial/_co-sell-with-canonical.html
@@ -1,15 +1,23 @@
 <section class="p-section">
   <div class="row">
-    <hr class="p-rule">
+    <hr class="p-rule" />
   </div>
   <div class="row--50-50">
     <div class="col">
-      <h2>Co-sell with Canonical <br class="u-hide--medium">through the partner portal</h2>
+      <h2>
+        Co-sell with Canonical
+        <br class="u-hide--medium" />
+        through the partner portal
+      </h2>
     </div>
     <div class="col">
-      <p>Open source technology is growing in demand. We want you to benefit from this unique opportunity, and take advantage of the investment Canonical is making in its partner community. We are committed to giving you the tools and programs to succeed, from discounts and financial incentives, to sales and technical support teams.</p>
-      <hr class="p-rule">
-      <p><a href="https://partner-portal.canonical.com/">Login to the partner portal</a></p>
+      <p>
+        Open source technology is growing in demand. We want you to benefit from this unique opportunity, and take advantage of the investment Canonical is making in its partner community. We are committed to giving you the tools and programs to succeed, from discounts and financial incentives, to sales and technical support teams.
+      </p>
+      <hr class="p-rule" />
+      <p>
+        <a href="https://partner.canonical.com">Login to the partner portal</a>
+      </p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updated link as per docs: [1](https://docs.google.com/document/d/12tpcvTBOjwCGzqrGMFC0ucYCGATJJn8Tbl2SHUcgf6k/edit), [2](https://docs.google.com/document/d/1q6dkqQ0zcshrfOmdJA_bAip73EaMSEyXAn8bAD7GqNw/edit)
- Ran djlint

## QA

- View the site locally in your web browser at: 
  - https://canonical-com-1243.demos.haus/partners
  - https://canonical-com-1243.demos.haus/partners/channel-and-reseller
- See that the link has been updated in the above pages as well as on the partners nav

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10539