### PR TITLE
Remove roadmap navigation link

### DIFF
--- a/templates/partial/_microcloud-navigation.html
+++ b/templates/partial/_microcloud-navigation.html
@@ -18,9 +18,6 @@
         <li class="p-navigation__item {% if '/resources' in request.path %}is-selected{% endif %}">
           <a href="/microcloud/resources" class="p-navigation__link">Resources</a>
         </li>
-        <li class="p-navigation__item {% if '/roadshow' in request.path %}is-selected{% endif %}">
-          <a href="/microcloud/roadshow" class="p-navigation__link">Roadshow</a>
-        </li>
         <li class="p-navigation__item">
           <a href="https://canonical-microcloud.readthedocs-hosted.com/en/latest/" class="p-navigation__link">Docs</a>
         </li>


### PR DESCRIPTION
## Done

Remove navigation item according to https://warthogs.atlassian.net/browse/WD-10737

## QA

- Go to https://canonical-com-1253.demos.haus/microcloud and check that navigation item "Roadshow" is removed.
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10737
