### PR TITLE
WD-10997 - replace screenly case study link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -417,7 +417,7 @@ meta_copydoc %}
                     Store.
                   </p>
                   <p>
-                    <a href="https://ubuntu.com/engage/secure-digital-signage-screenly">Read the case
+                    <a href="https://ubuntu.com/engage/screenly-empowers-security-conscious-enterprises">Read the case
                     study&nbsp;&rsaquo;</a>
                   </p>
                 </div>


### PR DESCRIPTION
## Done

Update Screenplay case study link on the homepage

## QA

- [demo link](https://canonical-com-1242.demos.haus/solutions/infrastructure)
- [copy doc](https://docs.google.com/document/d/1GNa1FaTkARdrVwYgHXf5H-6sqOLjkJENDistDDcsi4o/edit)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the link is updated correctly according to the copy doc

## Issue / Card
[WD-10997](https://warthogs.atlassian.net/browse/WD-10997)
