### PR TITLE
Fix tabs on homepage not being scrollable

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -748,10 +748,6 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
     padding-right: $spv--large;
   }
 
-  .p-tabs__list {
-    overflow-x: initial;
-  }
-
   .p-tabs__link {
     @media screen and (max-width: $breakpoint-x-small - 1) {
       padding-left: $spv--medium;

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,7 @@ meta_copydoc %}
 {% endblock %}
 
 {% block body_class %}
-  is-graphite
+  is-dark
 {% endblock body_class %}
 
 {% block content %}


### PR DESCRIPTION
## Done

- This fixes a bug we were having on the c.com home page wherein some tabs were not scroll-able.

## QA

**Note that on the Ubuntu desktop, the mobile view on dev tools doesn't work. I test on android and it does work**
- Go to and scroll down to the section 'Trusted in every industry'
- Adjust the screen size so that the tabs don't fit in the page
- Check they are scrollable

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-11287

## Screenshots

![Screenshot from 2024-05-22 11-53-15](https://github.com/canonical/canonical.com/assets/58276363/7841d4d1-0714-4c36-bef4-c1d6e258c222)

