### PR TITLE
Inherit dark colours on homepage

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -567,12 +567,6 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 }
 
 // new homepage styles
-
-.is-graphite {
-  background: $colors--dark-theme--background-default;
-  color: $colors--dark-theme--text-default;
-}
-
 .p-heading--display {
   font-size: 4rem;
   font-style: normal;

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@ meta_copydoc %}
          border="0"
          alt="Tracking pixel" />
   </noscript>
-  <div class=" p-navigation__overlay">
+  <div class="p-navigation__overlay is-dark">
     <section class="p-strip">
       <div class="row">
         <div class="col-medium-6 col-9 col-start-large-4">
@@ -61,7 +61,7 @@ meta_copydoc %}
     </section>
     <section class="p-section" id="products">
       <div class="u-fixed-width">
-        <hr class="p-rule is-dark" />
+        <hr class="p-rule" />
         <h2 class="u-no-margin--bottom">
           <strong>A broad portfolio</strong>
         </h2>
@@ -76,7 +76,7 @@ meta_copydoc %}
     <section class="p-section">
       <div class="row">
         <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-          <hr class="p-rule is-dark" />
+          <hr class="p-rule" />
           <div class="row">
             <div class="col-6">
               <h3 class="p-heading--2">
@@ -95,11 +95,11 @@ meta_copydoc %}
               <p class="p-heading--2">
                 <a href="https://ubuntu.com/desktop">Ubuntu Desktop&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule is-dark u-hide--medium" />
+              <hr class="p-rule u-hide--medium" />
               <p class="p-heading--2">
                 <a href="https://ubuntu.com/server">Ubuntu Server&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule is-dark u-hide--medium" />
+              <hr class="p-rule u-hide--medium" />
               <p class="p-heading--2">
                 <a href="https://ubuntu.com/download/cloud">Ubuntu on public
                 clouds&nbsp;&rsaquo;</a>
@@ -112,7 +112,7 @@ meta_copydoc %}
     <section class="p-section">
       <div class="row">
         <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-          <hr class="p-rule is-dark" />
+          <hr class="p-rule" />
           <div class="row">
             <div class="col-6">
               <h3 class="p-heading--2">Cloud, your way</h3>
@@ -124,21 +124,21 @@ meta_copydoc %}
             </div>
             <div class="col-3">
               <p class="p-heading--2">
-                <a href="https://ubuntu.com/kubernetes">Kubernetes&nbsp;&rsaquo;</a>
+                <a class="p-link" href="https://ubuntu.com/kubernetes">Kubernetes&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule is-dark u-hide--medium" />
+              <hr class="p-rule u-hide--medium" />
               <p class="p-heading--2">
                 <a href="https://ubuntu.com/openstack">OpenStack&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule is-dark u-hide--medium" />
+              <hr class="p-rule u-hide--medium" />
               <p class="p-heading--2">
                 <a href="https://ubuntu.com/ceph">Ceph&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule is-dark u-hide--medium" />
+              <hr class="p-rule u-hide--medium" />
               <p class="p-heading--2">
                 <a href="/microcloud">MicroCloud&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule is-dark u-hide--medium" />
+              <hr class="p-rule u-hide--medium" />
               <p class="p-heading--2">
                 <a href="https://maas.io/">MAAS&nbsp;&rsaquo;</a>
               </p>
@@ -150,7 +150,7 @@ meta_copydoc %}
     <section class="p-section">
       <div class="row">
         <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-          <hr class="p-rule is-dark" />
+          <hr class="p-rule" />
           <div class="row">
             <div class="col-6">
               <h3 class="p-heading--2">
@@ -176,7 +176,7 @@ meta_copydoc %}
     <section class="p-section">
       <div class="row">
         <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-          <hr class="p-rule is-dark" />
+          <hr class="p-rule" />
           <div class="row">
             <div class="col-6">
               <h3 class="p-heading--2">
@@ -193,7 +193,7 @@ meta_copydoc %}
               <p class="p-heading--2">
                 <a href="https://ubuntu.com/core">Ubuntu Core&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule is-dark u-hide--medium" />
+              <hr class="p-rule u-hide--medium" />
               <p class="p-heading--2">
                 <a href="https://microk8s.io/">MicroK8s&nbsp;&rsaquo;</a>
               </p>
@@ -205,7 +205,7 @@ meta_copydoc %}
     <section class="p-section">
       <div class="row">
         <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-          <hr class="p-rule is-dark" />
+          <hr class="p-rule" />
           <div class="row">
             <div class="col-6">
               <h3 class="p-heading--2">Multi-cloud data and AI</h3>
@@ -218,7 +218,7 @@ meta_copydoc %}
               <p class="p-heading--2">
                 <a href="/data">Data&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule is-dark u-hide--medium" />
+              <hr class="p-rule u-hide--medium" />
               <p class="p-heading--2">
                 <a href="/solutions/ai">AI and MLOps&nbsp;&rsaquo;</a>
               </p>
@@ -230,7 +230,7 @@ meta_copydoc %}
     <section class="p-section">
       <div class="row">
         <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-          <hr class="p-rule is-dark" />
+          <hr class="p-rule" />
           <div class="row">
             <div class="col-6">
               <h3 class="p-heading--2">
@@ -255,14 +255,14 @@ meta_copydoc %}
     </section>
     <section class="p-section">
       <div class="u-fixed-width">
-        <hr class="p-rule is-dark" />
+        <hr class="p-rule" />
         <h2>
           <strong>Trusted in every industry</strong>
         </h2>
       </div>
     </section>
     <section class="p-section">
-      <div class="p-tabs is-dark is-home row">
+      <div class="p-tabs is-home row">
         <div class="p-tabs__list js-tabbed-content col-start-medium-3 col-medium-4 col-start-large-4 col-9 u-no-margin--bottom "
              role="tablist"
              aria-label="Trusted in every industry">
@@ -560,7 +560,7 @@ meta_copydoc %}
     </section>
     <section class="p-section">
       <div class="u-fixed-width">
-        <hr class="p-rule is-dark" />
+        <hr class="p-rule" />
         <h2 class="u-no-margin--bottom">
           <strong>Accelerating innovation</strong>
         </h2>
@@ -574,7 +574,7 @@ meta_copydoc %}
     </section>
     <section class="p-section">
       <div class="row">
-        <hr class="p-rule is-dark" />
+        <hr class="p-rule" />
         <div class="col-3 col-medium-2">
           <h3 class="p-text--small-caps">Cloud</h3>
         </div>
@@ -641,7 +641,7 @@ meta_copydoc %}
         </div>
       </div>
       <div class="row">
-        <hr class="p-rule u-sv-3 is-dark" />
+        <hr class="p-rule u-sv-3" />
         <div class="col-3 col-medium-2">
           <h3 class="p-text--small-caps">Silicon</h3>
         </div>
@@ -698,7 +698,7 @@ meta_copydoc %}
         </div>
       </div>
       <div class="row">
-        <hr class="p-rule u-sv-3 is-dark" />
+        <hr class="p-rule u-sv-3" />
         <div class="col-3 col-medium-2">
           <h3 class="p-text--small-caps">Hardware</h3>
         </div>
@@ -745,7 +745,7 @@ meta_copydoc %}
     </section>
     <section class="p-section">
       <div class="u-fixed-width">
-        <hr class="p-rule is-dark" />
+        <hr class="p-rule" />
         <h2>
           <strong>Get to know Canonical</strong>
         </h2>
@@ -754,7 +754,7 @@ meta_copydoc %}
     <section class="p-section">
       <div class="row">
         <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-          <hr class="p-rule is-dark" />
+          <hr class="p-rule" />
           <div class="row">
             <div class="col-9">
               <div class="p-section--shallow">
@@ -776,7 +776,7 @@ meta_copydoc %}
     <section class="p-section">
       <div class="row">
         <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-          <hr class="p-rule is-dark" />
+          <hr class="p-rule" />
           <div class="row">
             <div class="col-9">
               <div class="p-section--shallow">
@@ -799,7 +799,7 @@ meta_copydoc %}
     <section class="p-strip is-deep u-no-padding--top">
       <div class="row">
         <div class="col-start-medium-3 col-medium-4 col-start-large-4 col-9">
-          <hr class="p-rule is-dark" />
+          <hr class="p-rule" />
           <div class="row">
             <div class="col-9">
               <div class="p-section--shallow">

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@ meta_copydoc %}
          border="0"
          alt="Tracking pixel" />
   </noscript>
-  <div class="p-navigation__overlay is-dark">
+  <div class="p-navigation__overlay">
     <section class="p-strip">
       <div class="row">
         <div class="col-medium-6 col-9 col-start-large-4">
@@ -124,7 +124,7 @@ meta_copydoc %}
             </div>
             <div class="col-3">
               <p class="p-heading--2">
-                <a class="p-link" href="https://ubuntu.com/kubernetes">Kubernetes&nbsp;&rsaquo;</a>
+                <a href="https://ubuntu.com/kubernetes">Kubernetes&nbsp;&rsaquo;</a>
               </p>
               <hr class="p-rule u-hide--medium" />
               <p class="p-heading--2">


### PR DESCRIPTION
## Done

- Remove `is-dark` from hr tags
- Add `is-dark` to parent HTML
  - Links and HR inherit dark theme colours

## QA

- Go to landing page on demo
- Check that links and HR are inhering dark theme colours

## Issue / Card

Fixes [WD-11489](https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/932?selectedIssue=WD-11489)

## Screenshots

[if relevant, include a screenshot]


[WD-11489]: https://warthogs.atlassian.net/browse/WD-11489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ