### PR TITLE
Fix missing requisition ID

### DIFF
--- a/tests/cassettes/TestApplicationPageHelpers.test_job_post_page.yaml
+++ b/tests/cassettes/TestApplicationPageHelpers.test_job_post_page.yaml
@@ -1,0 +1,364 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://harvest.greenhouse.io/v1/job_posts/4754075
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA9xZ224cxxH9lcbmJQGWNElRlEwjD7JCxHkQ8iAJigIBQk9PzU6bPd3jvnC5MAz4
+        H/KU3/OX5FT17I0QYyWBMEkAXXZne6arTp06VdXz48K2i+vLZ08vz549XS60yfaOFtc5Flou3MHn
+        zsaUP46lcTb11H7UeXG9uDi7uDg5x5+nb86fXl9+ff3k7PTq67O/LpaLbLPDzYsbv7KeKFq/Uq+0
+        1yuK6kS9owZrXDA62+AX1z9WMy6fP786f75ceD3wvd+FgVSjE7W45ebVzQvcE7rOGvrIy31xbrn4
+        PjQfxwDbTEk5DB+3D5Ul51fPnl1dHCza/Zo3I233fbLb8W2CeS11MLlV8DQvfvppubA+U/TaLa47
+        7RLAoPvthQoOP75ud3Vx9RT7mYBbPEP0oZydPTH9E/mf6reUY/CreuVNTyoGN/3y1eFP06Xdvb5e
+        GI8eNWqvUt44+v2HRYddT9ZkV32+VpdnZ998WOw3AeRK+xbeJbvyKpMe1DrE26Q0/qihuGxbm4wd
+        nfU6bpT1xpUECkxrbe75BteeGKdTUoWxipRIR9NTTEv19i/T0+XbnU1Fu/0V2X0NK2iiRDqFUWKD
+        MsE53YSomX5uUzcbtN/I3vVWRgmfTAzYPMOjEFfa2yTxrNa2zLIxhraYzLcz2+rNATfE3c68TB58
+        yvhcXPkmjd88+MjBALhHodhC/+9H4gWboz6VFDqrl9oHb412S7UJJcITO3AkAPIYfLKNdTYjMHA/
+        CAIjhdERL1apjGOI2I18KtXBHo/Eqo3SkdQqhjVfRbCPYrBUbeDrd9oV3bgaj6VgtiKETTuEo9d3
+        ci+eQvxQi7w8tPdUsV/KkW5VF6KqLD7cJJPpZakswqXejrKJVik42yLNzS1sLLhkvZjYEqgQxgF5
+        xC4zRVNeYnn1DE7/8vPf4ZlYDUBMD1uxJVXj4W9FUdg70NAI494Dq7V1jn2iSiMBrniGFo+xvnOF
+        vKk/GqRFibRUnTaMvs504EtLLJFxU/ESJgtz9/sG5gRoTauNrKF7MoUJe/qZHHtcOV40oRzE4IsK
+        yG6XGomJTEs1KSM7hN9S6PKayWbCMErycqCqyAguFW7yJwkAGVk37ICfwFRvm+JzUb/8/DdZL5KD
+        SCf1m3NlXCgtP4KVAgxLm5RpOFV/Bt6DTUmUQNIDRIV+1yCOgcXYwsLQqS4S7S0F13gF75z41ymj
+        RDIO5CXVLaB4d6g+STKqJzeyDQ1E0lNKuCy2rm1L1QLIEPuYMhLADtAlMI64flnwa+KD7zVzLYEW
+        kYEQnCoED8XpP2LLuylnKvnbcP35fCnu+Luzv06Yf4lcO/EnFu/ag2yLgFYoSjnapmSUZM6px6Bw
+        9sua+Q7xQdTxg/oBhY2DZUINtWFZJOVprTp8gmCkuaz8AzVlhRxIhWrlq+XwEcM7e8/8nw3Tl1zW
+        Emcn4s0JwrnDlp4cWRrpztJa8vq4kM8I8wDTRdkhJkUyeV/TUbg9N1IIQbMBgSMZdpC7QmGylOew
+        LxMib6uA5nIuf24Sijo7U8t/olztqZVtIMqz8qTmXhMtdTCJRmsmy9JIxkJRq0rLJQQDxMjSMtp0
+        Oxuk77gd6GIYVM9zjKjZyoUGZQi8gcKpSybBFZodQoHkvmk7aEytwvQFfZDPs7nxdg8nl3VH0m4b
+        Dki0ukpMSX3tflgLd4vmsvg7FGbFbSMQfSAXlc3SceM5uusebcO+tJHvJrh2XQKjdg/Fm8ugm66j
+        beXl9D9Aiu6RZXlKMeHxI+MUC4e3gL3eyDFYHnMZoN9SH1w7o3a/rqOSjDFwdtvEc/u3b+0xlZTq
+        MIKk2xYlPe1aPVR6amez/0V7x6cYtUvV7Z00kAPqZPRAe2XdQX97OESNkVsrM/UF3L5uf64xwoNW
+        JE1zHfMOw/uwIQZCu8fNhcO3xbpWLJPBU0/qyiF90DJyaI+mXhQzzJpoiHobZZAxaDt7+VSFQz52
+        iDLPpRUv/JNOWPqAq5wS7ZCdC4D/dSL/kWd0DSZql/vN8vgU6Ih+0xjO45rDxf00uZ00+fhiRiZy
+        Lqo6uKhRIyQcAp4r94cdwsNaRffjzoGYTku3E+lhsn2uW189nNT+2Tgo7ScPstunzz8Ivq8GqVsf
+        1o7aFcnRjnQYWmZ7ET059lhPp5mfErrPhetLmc+TfCgohh1XdLgAVY5QyuJgf62H2hgMDZn9m9Pa
+        HOXkBdSLvvbOEH+GtqF0WC/ASZlVuMeb017Jcom5SrfWuVrJGPM9QTAecBeNESyJiOeehT53xU0T
+        A7nuZAhIVSxu5/SGW6FPo81KXRlycJ44N/hyYKrVtyiUyLQoMytaPfqhAEonp7RevYQeo+xG9VoO
+        uRCN129uXvG6ZAfrNNdNdBezsl4cqafO3NlGMVTg5VJjvWi5tFGH3RP5OwuFnFtg2sg15r9n2NoR
+        eTqUldbQ8LFOO31P6rcv/7RUZWzlzBYdVvB222KFhs9UdX2zsURx7+jEbAyw348QvzvKiDkd/f/S
+        nw6NCBow69uSpBJEQosrRvJJprSQwYWVna+xer99yWP0KM0A+qpII7919HKKtn/TIm8xU2m+J3n3
+        l1mEJL1nZczuLdNEcTnCXENfIsYNICxdbW1kHFZCIPld4L57373Umj8EichXlHMEYUhmT5sg7Xx0
+        JYFAJmgOUcWdJ0kuX1wWHr6lms2LXyfS1IBrKBPXBSzcS9GM5h+ea/LfqkV9fcup2qDW2zc87T8A
+        AAD//8wc7W7bRvJVeDkUTXGWzS9RUoBD4biN6/ijOstp0B4OwYpaS1tTpLok48pFH6jP0Re7mV1S
+        HkpDWbaT6/1KLM3szszOzvcqs13eJDH/3n/8V1KfYPOr8qd1QaHuSVcJIOn1V7FGoTH71jLO9AQP
+        wraq1V96DDsmKGwFhqmi/H/ollWmqSxsawIrITlIGzLtMRxLqVM6WAGX3k5cgC2z/WwjhrrPvSsf
+        j8lW8RpeS10v/ZRUtW3tSwnOWDpmvqm9KbqbKB3Pdb8AfTUr1gEl6Xw3Bg2qJgD8b4T9osKOw5hW
+        i4AIqlxYK4XFHTS6S0jSWkRLyXWeyYJKbRcCUhJz5okwBUO0JXY6Y9WTr+JP7COC4mAJw3ywKm7s
+        O1czMK81d+g/nFjpWDiB69aN9sYCiKFywymYr8p3Gikl0mz3Rov05rrUxR4kGgvsnU9luuecAzPY
+        7zf3a6jFtJR/e7IW7q45QzDH5g4ztYcnSv+Vc5imODU1LsG6FCj37NbUd5E1M3eDXdssLnMcLUF/
+        m9uuvgDzgtMrdsxg/xOy/zDVm6LBNFCmzerVk0UiEzWtZ58w1BBWRAuxrBrDZPhrnKVlLvOd+X8a
+        e5fgkaZwjz8Fd1fN4HCRgSMZJ0tnjG1v8CATaf29tnviMCTYZFMztE3D6kLeVE7+M7N+Ze7js7ke
+        apWZeZchjhIiGwlYF5zdimOsS9/OINi8TpZVpzyvLeRJY+Bo9P2onuwyJdasHoOzd2KmkryoLQis
+        tLNoNm5FY2SqaoM/imOw7CZN1Di/ZK5wjgmKMCdnjKwdTDL9YhzD1GquLJ/7zjdY1s9RWnVsXdVW
+        4H/YAMeyc9UPJ2N01VCKAE0yyZDREVLFsPD2u8q1t9+bJs/CmWl5DfzOimKRvzo4iFeTgGDQD2yH
+        JD+Y1HQfqAmG2cWyqVdPEeTKv22n8ClL44iUxAk0kwvUJKMnMjNTUyy82DRnsUiqkQPnWijdrHfs
+        RuCBeC65O57VJxha/fvZSceGSW1btu/RnF+rvnhxP1P9YTUqbce5TZmIzJeHHbfb8cMrz3vl9l91
+        g/2oF+F8udVudg49CF51+/tR1EO4CdA91WIxU/GHX0qMarL0Qy4LMkFef5y/ePXv315oLGhqOaln
+        u8HyYKVmNfsN4Y1MYM83GDA6Fzg3vhoft0Pyqf3MTpi/yGdgjz4U8tcCPrNtKtjnP0gZ3vKFHYBH
+        Sn7f2333M7GxeSL+R3t/Oxcqud9XVn8+c89qk7ZNhzPIRu43XVR/PnPT7YxeyrykEtb139WuoihE
+        PENb+rhdH2D1KEMjdGYs8/3mMX76Iak/fSYJ2xn/pp4gx2lfYuzATRjvfOIILOKjI8OOUZZCvDJf
+        msIWeJkJ+mlarjBjwODkpkpolc/3TMhiEK+dwxNnNaZjB86xslQZhWpYVeVmGvDabELo2b+Xzupq
+        h34/HPhh715E4yxLpEipfH6z/33xyr3n+SJ7gSKqvvDuv/gRUH5/tkQN8rhyIKTtgI34KYpgfTgQ
+        8xunmpOuiwkMv0GvG7m9qH/PbwIh2Se/Cq30m+z2rfgoRmbxPecKqLD/NwHG6Gg0aid78JnJ/i67
+        BfWZmHAQSIY409T35gKHGUGH4hzfMZjR2DyegaJ83UprLyTmBs4okeBGEgi+WMXy3aDb9fs9okdX
+        2cJx913vi7rCqOUUmSJaV2O5TazuF0ilJZABjwZNcM99AL7XhPcfgo/WyGmD90K3Oxh43gbT23iu
+        kdZ43gHF7TdR8qKcmLiWpc33gl7guT6xs5BIZgUmVpBmc7CEj4sMqzI5tkimxez59qBFMc3tSu38
+        SyLSaYnjdztraPcJGjp4koYOHqeh/UdqaH/tZB/S0P6aRj+koW7wBA2lqrOrhq4JdycNDdu1bhOY
+        MLKmzs/V0CE4TXDR+QzzVqOXdXtXmrY/juqjA6hLEERFa42uXragCioznT3G0pRzju1iyB+lts+s
+        MseO/qexwqdvuXlkldl7kKUd854mj03DuHrwA8kuVgKxSr2HkPq+HuMIrJnYj6sGuYQ0Di8UDiFY
+        Yj5KU6iUONsKXtfQicFdgmXKMp5h32R0eIUYh0dXZnNMsN8enr/eQ+eh7TAPbleh7Tknr1dLyCI2
+        tdxVyQZHuPWyIh4fKE3UtWG/cMZmmMkGOiK3RRyg++cSbjYEPEbwGyLk4h6vH0T9gMQ9n8WhmmdE
+        t7boqLHaYGZBvswh3FsVKeyERyUNcxB2gFhOqs8cdW34NAVe1NklPjfQYlJi8LfFwAWPjfhfNPLR
+        SqVVOlFmftZq9YNkmpmuJMuNqlZkqvsXfHVO+xgxjsyJmnuDC95rNm5hJnPLnEbQhFLu7EO353q+
+        /zjz7w/cQdhvRMDOu/VTbBpbg9IjxnwkyolyDrUYK5E6xxUrI8vKS7cTfsUtQKz7aIHNsBmD6rks
+        LrH0J7kWMlEsLo9MApnRrYJEZh3V60QsYpdEwmURb9LrtdFLrPnRDGdu5SPoJdb9tRZ3KuGl7A1Y
+        7GaoA0gM8jcdp+Mc/oPFJ87rrYBz4mh/0xmxuESt3p1uYF3NlMY3/aaGwuHTkPYNuglOQ3xWaBHR
+        rmOJTmgDtdvxGphe3w0CL4oanjeV9RCvsbkMfEjU6bLMc06+fqfLbRUShXo3Gl3ujEfV6Xh46Lw8
+        KufGFYElxb/7LFbwANaa7tZoRIEMVrjvOiOILuRXm+FF09Ku7Igyj2XXGofGn1YGxgyX3rvDW7HM
+        txtWW7NrM6wn1mRbwweWfOMc65htga2jDKxsbUX3nIV1D5M61Z3VL8iJb1uz1tUPKJip7jIt7Ow9
+        cRHtxvrTuDL7/G1pCyqtVJpmiNTW14BQMGd/jvd6Xz8JMn1hE0lhz9W8MDD9a5DxwjRHHb8TNjrY
+        exj7rp651dP79oWbgxVM08STxS0OG3kd3z6OM9FUNay8UPGNmU9DqdNWdf3THrmtN5mIKlE3+DKi
+        YmztuXrVgDdvX8zZVWCmOfJR5SKvBm3iuGrFACGHNho2y6tqjmX1CwTZfK5MGxYrZ1vimOgzV6dY
+        XUlxKMGIpopraqngCeBw5XyeTaqmBgbP1XgCImiJo+v2BYmzmC1z++sHIKKqcVlfHZwlLzB2wQkZ
+        Z2LLiOYO2Yc2qwoiiq0Oe/GqicXC/giAymMwpXXAszqP3MG2P84IbNXbByqr7+UY7kd7Ga3Xe+yt
+        fHRx90ylN3JykjpDnV3jjHE7Mf3nE7PdWB6DHSjH7QT4zydgpxwzztJrpedO/bseNjHQ5lEXXq+6
+        1ryaIoR841LGulSFuatDXD5egrHHAfpqCsR+NMwSFS85O1zxSCqQDwfNVdZNa1WH8WoY7ODI8vHQ
+        fbR/bPRQS/ujD9hAhcxUJAdwGUVnYRk50Pf81m25dhFsNt4a3catLcHH0fX1h6n4p78feEHghu6+
+        F0SR33PDINz3om6viz/oFEB460W+H0Y+fhoO3F7QC7s1F82T2kbudh9V/WRVHQek2P6HsLH2yxP7
+        3ikuNcYZ+OsS4Lo5E20Tab/3KL0I/V7ou7SW9pOaj8X4thk3WjBaDftJzCF14oBIcPkjmkAOhkSR
+        7yUOFKTOSMyEZhck0dx78NvKGuE3ZVGmHDxN835Qego+/SRPBE6Iv3y3P9r/isPptuO81hAN5jMW
+        zaNosoAjYaBoTvCDTOVdCV4J1gW9+Sg0Bt+X0vw+WQxBGLdNRLcRKYRoJQPVJdu8uxvLG4UpOAdI
+        UtF3upyWYslB0Ug/VRiTjgrjTM9VCm72+7KwUy6VoLgl/LYlsH82lxpMIoMW9jfQTmGjScYJN9wk
+        E7N659u5wo4cRxZND97daAHJLQdFM8EpcMiRGtB6b4nfcUBdClTH3UdCxVm+RXpB0ESDq9R2ooHb
+        BJXcgfq0lg0xd85eX5/2TCDyUZPKmV1lYzHNOAyS2l1l6ZRdtVFPhtBWcILyGtVzdjOPylLNM905
+        Q/vBQdKq90woFDMD5lKpiPROpErsOZUmkXvJodLivfhZtV44Whm/EuqWByLHPVoas2AUuaZhA8Ub
+        DGhBC3KjO6lZLgGySyHlhLHKAORRIKza8IvRJscIvhoLbVXkLdB8Lpbs4tTkjzC8Ru+1Cdao0ZUT
+        RlIAQ5fSyjkT6c2m0gEcEftoAdecgyE3Z5SVxcxp25U2Hy3ksczAU9hfEsE8tsKHP2/RgbfdbFgq
+        XF/q8Jq1hd6AGvVRNhcJc2kBitYHsySbZ+mW7alZHuHzhpRdNBw0wcQND0ZPA/JU0AChC0iCX9qC
+        I74q33RqgBc08KZikWlOIwJKhpJaC+dMZozJBlAqBrnEEn/CeAAApHtLzQUyAERVA9w2RJAMlE/V
+        ghSVOVB67CIDizpfxfz4q0scSz4lwlwvgN00jN6A2s6RmGccAdR4jgSe1Q+wcT1RiSp8DDEmVmBY
+        qVGLatGHeB6Wh3MFgWiy3kw0eNTEWrxzfFYOGlJVSNtUxI3WEc/KmBWtG65DnqqisI72Qn5UHDvu
+        BjvfQaCcgvU/zEEo5qmIcXza2HVnIpyjMp0x2/cHGxy+BpZmf/6RyPmmKwZ4ojSXt2xsAUDktOoq
+        7RtZD2tyCESrL8FWsNe60Te//PMPCATYxWis/y/ImzQHQ3RuWEoNme4lBDUcJDnJIb4lYS9Tvx9S
+        MN799PuEgaEqYqE0xwBt1gxnKlGLBa/XfepPhlJvRiYAQkQ7FPhQg4mZvcbUzFAsSgHKd+scl7Ax
+        dxS04j8U4BFZIJ8CJaZmiK/TbbN5My7x+t3GslyoBTCUZ9ESuQAY2fz7OQtC3cRFpm9ZwdCOAwBh
+        PczaMuC63VP1qY8AtOssuamgGWDqKC5UyVjTPnUQF2qKvwPGQflrUAyM36cwsVUJDo62ZkAXfpKi
+        hXwaIiPkEZz1JOPvsNejsCjNNgl6VIJywd46ap8vRMlegMZIkZgr1sP1BkQq50uRzjmz0RuQUzjP
+        7rCQ8At3XD1q0M4zncWcbelRS4UPqnKMEQoOsNcERJ+u2RW7DcBpxkZdPVqYADDBUtdrUJdMII5y
+        Xm7N9wGH8q1iDdEOWH9wl9b60zSaQ6dm5Vz+ylrkHp1BOxexYGCiAWHwrPxVzsdZqacMIBXYGdZm
+        ed8TUWGcKRnP4Awge+Mi84h2gc/UeMmtFzX2HfP3OaLlE8gWs2LGMdsNKdQYK7YMFLV2Z6L4yG5I
+        m51nEOgNzZPBL3MHf3wzRv8db0nrooDo6elST5d3vHWOArLPaXkrVFPr+9EAe6FEmU6zPPuYPaR/
+        UeBRFHwa/xAGNYcVBuF1xf9Dq5DjPFVajQGbAyMx8alMWc2gFvJU3ImbWYsMqfF7m2k294uo9Xsr
+        dc7UV7zugJyGGTtgYKgJegv+nk36unS25aQQCbcbHQmx8yQcUECB7LPcc5Ywmt2eYNeM81FdepNO
+        tPiFAaGBBYBAkI8Oe040nj/8Ll6a/wIAAP//jF3Lbus2EP0V7XrvogD1SBQvLfl1cRG0QIoCXXRB
+        W7qyEllKKTOBA3TZb+kP9A/yYx1KTnp4fRR0k9WxKJHDmTNnhsz7D9ti9HkMpzwcxWB+92U39TVo
+        bhsrGahhE41xeeMuh/8qfwguTDxcYY0mAfkK7W3TNafgriSh7wrVoE3pBJaR94y51m7h6sDFNHNK
+        MBJvxDGQfZSge19bCddkKhOMriOR/TGr+56RygTp+xTp9XqZ1pI0tHQ3eU1Aa9dedxDiRHBIdgV3
+        KRELJPYghaSpliXbCUoZYybMRkQSKaiy5eaVoN7qcDs2ZISfWW+NbmiqlaA/W+/5UqFpjQ1EbGIx
+        7T0rWJeoGJPPNS/1CChE0JYFzBht4pzuD5KXSwB+EaY2XKjE0rIYO+bOv5Sc8DThF2I0mLfOK1vT
+        mYqvvUe7LloGAkezqidWOcZiyqq+J/ssRs6w0qYrp/dtjF5wpZuHYc+/l6JudfNUt7on/jNG1rA8
+        7uvukU4TusZlf+QJRoxmuZQ1MmwrxyHshOUfskllKXUzme/GqOcsm+BOvkYXHTH3WMHcL6vTI6Hz
+        Ecbb5c7yJ0WoUSy6Q+3K8O0H7CtCVv/2AwJDN7a4r93VKWTtI9SXF6VLiB4ICg+q5C/Ciz96QQzC
+        +enRWGJHEYbhXELR69+M4UdYasvtln1ogsOZTigZQ6H15a//HMug+OHLU1czSTdC3pp3QsycbMSe
+        irQy77qH6Y0TIc3NXc7mMVDgHk7nJPsnQnF0eADBYMUn7w6SkrJX8Y7qODWees9w5g3oaoGfvpal
+        6836PP2dISpp+d5JkwfdT4oiIapgro2XvQjWpwXTkCULrzyMZkOhxpMPpxOac13jo/0WYjjN9cm1
+        vU5/vWcQEnGCX0tTsPdF1jb0ELMPDz3QoTQdC2HfnVWRJJiSToWyRmaNFW5KUOiPBPUgSxKsdE+s
+        TWEakNmm0jS99ZoQMhm2rIOFFq/QC2EidEhh9enc2xAMRLoNftqV+r+wTNiDQi41dnYTEAaxrLNP
+        5XHSQBWqdll37J9pxFa48FnXt+ey26Y0L2XljuDQH+EECmOu3f9DGmpUS+sO69R2rBDcaeb5lPLG
+        bOonp8H83AzFy3Mn5psKe+lQ1AwpeLa3LP1UsxucT+FslhiqmiG3ycqW6CVifWh+4kZeLreFmiFb
+        FlBV20sLcYcrPJRmIUbNsPch02YrAZjC0Dx1WzVCwPs9AYZoCXpvWMFWUMpDSQ7NBkUXPH8p5eXq
+        ezb/N5gDzd1tkmSLKa8uMaBoHVbdIGWdGxZPlSf6z82BFl+Vp+HPTTXc9cdwyC3nAqrsuDHcglBb
+        usFILb/Qxl3ey4AoXc/bytYNScDESV17sI6BPMl3Lsm9IZ1eKkXfeG4Pcn1hrJjpDo0CuOFavkqv
+        PdSW6pIqRbb0+hdybgLGLHH+rdrribacMMUM4lafuiNpVAlTLN7favfPtGpG6VKsxYw4rrKmuH3H
+        SuuEvo5fIsDeXdk5HXzTxHsBSVQJJvbGbkgETNEhCMTdtcNGi/wn6RNN+9LIfyn9zIaMvIUodKX7
+        HS1NoIhzq3djASb45Erj7lxoaYLfbNXJDD19J2f9r0b2sRFzbBE/93O+N/+PFyi5gQrTPRbd8+Ux
+        vd///BcAAP//AwA/Nxf39XQAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Tue, 28 May 2024 16:02:33 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ratelimit-limit:
+      - '50'
+      x-ratelimit-remaining:
+      - '48'
+      x-request-id:
+      - dbf6e22b39bd37c0b88e125e57899baa
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://boards-api.greenhouse.io/v1/boards/Canonical/jobs/4754075?questions=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xb/W4ctxF/FfaKAilwkk6yJMcyisKxnSZAjBiRAjdIA4G3O3vHiEduSK5OhyBA
+        3qF/9fXyJP3NcPduTz3DiiIH3raALa12uSTn6zcfnP1xpKfR2ybRZRPs6Gw0T6mOZwcHU69DGfdn
+        gcjNfRNp3/iDQjvvTKHtwfd+Gg+OH58cTx6fjMajUid9WfhFbY12BY3Ovv1xlFY1Lkazsg4YEeiH
+        xgSKGOUiuTQ6q7SN1HtQB19QjMbN3j4mUMJ9492OId2TmoLx5ejMNdb+9N14RGVTaH6CzayvL33N
+        v7TF1oxLFHB5CaIuDd48PD09Oj05Go+s7978ceT0gsn5zC9ITXWkUu2pl69ePhv9NB4tKGlmgdAt
+        M3x8enR0Mu5eek2+tqQW2ukZLbBPBWJqUGCmxppkKP4V+7jWtqE1QfLXZcvEFWh3Hku10x8/mRwd
+        rqd/Cb77lcz7BblZmm8mG30KLuwlg3G3pmRGW7qMZKlI65lPH5+cnDxez/zcB1LxylgbN3N+O3oG
+        bq0iBb753LsUzLRJnsX8gq7JeogA16+Dn1paqHNvr+XGBRVz562fmZhG393az6KxydzeztHjR08O
+        H51uKL3JolIvqNYhMclRfbSkaTSJ/tzf4huaqn80k8nRKcZGM3O/ZsENA750pKzBD+iGKikWwYji
+        9Dj8zCm6KajVJ+Xr2ofUOJNWqvJBaYXt4dWWLyp5tfThSi1NmhuHx1aHGalEeqF8pb7+u9KuVNcm
+        NpislK2D0XJzPUlU08bYEhJULe15gK7ruH9b0NbDohLdbIh8dDR5cnK80Z/nnVkrnqrHxTux7NHJ
+        x48PTzezfWHcFZWfO/Xax8Rb/IK33WPYK1PunZMzojB30MnDwyenkMlmhU9JpybAAlkoH11oy5p/
+        wQwEcwWFaEsbUmjeZlCgkJdokWw8amrYMZWXGsgyOpocHe9NTvaOji8mj88mH5+dPNqbHJ9NJh2e
+        gV2MJTzDCFvE7WSSFUV1M2gNkAj0vxKzD8ALKCXGALqSQNcoK6hNT+eP8uUsPV3fiylAcuv7F3NS
+        wVtaPz+4NWDzoD+bW9+udyxRa6diWln6S773Q+PT0wr721uSmc3TmTqeTJ72nm1th20s6yVraVZh
+        1m0oI/4p0ZbSxMLALTgdVsq4wjbRXLfqzibAL9hyr7A6RgU3ExgaSYdiDjUfszmsbWC82yrYvKhl
+        d9zHprJ9Fd5aPfUBAA71W+XFgMArWTu/yvzEVRE8Fk+gyIeZdiYK6OfdipHBNcFxpBbA23U9Xgjr
+        lXmYTLyfWaQX9VM3jfXTnX+K+MD8HcLriel9ye4ZE6B2qahOag0GY7XyTQDtZsGy2/JYEGVkY2Oe
+        1dm5YbCKjYDfGbgSm8ySOabEqJXS8CSz4Jd8F+qxJbWxKj3fZxPV8BkiwbFweUYQtLYQ4Fxfy7uY
+        hXhS+LSt/e4rpktZ0qUAbzaP/iKJ/Y/gHA/CrbmpM24qxECmhF8vrrDHBrcAzT3cFt9qslLHNMbw
+        TBmI/uXnf4Ey2TWjzxx7xZKUNw96MxdF3xe0mIqOfgNeLeFUmSbKitfzGpjGuApghUhKHhYwJODd
+        WFW6YO4DoXq0lGSh4WGV+bX2Lb11PSsKDIFmKxlDN1Q0rOL799PGO6DVs6lverL5QEBr4+hElq06
+        jlUbAbYePPoqLVld2ZUIYLCoM7AJZ7PAyO1FsLiQcYu16FpxqK+njUuN+uXnf8p4gTnoSlR/PFSF
+        9U3JUzA6QUfjKiZa7KsvIbGFQQzM6CMGBlW3JmY1qL2EuBxjVKpCYL7ZKbSVR/DKkZ+2Nikw1YO0
+        mJcAyl6bgpEPr87J1ryHKYDZIf7Gbdnr0pSUdwDoYxpjggmZBbAQOktVZQoDDW01ys057sfMBew+
+        tWibWbAbEN+Dzr1pLTKbVunP7q11jd1115p7qt2DqO7anRG7I1303ZpWcLM5CkdUxDb/TiZb88GR
+        +AaaA33EIPUD3DyrUeGzEhYM+aQcLVWVg784RApf0LSZwbJj0wbsObB4C9GVuWGrHqQsn3OoEBmv
+        oKMMGYwmTOXeFpWBrg0tBem2w6mBincBssXTApobwcVNjIVAynEoDNFPVzDYgBzHMh/a/FnCJb9x
+        2+IsZl7bQfLiJXK/BTMih3KRUqYlRykLojRY3c44NQ2GKpBDtSlaqmJNhYFfzL5WbkEJoMxJkg0T
+        rwYpyjccUlbBL9Sci1/icWbWTxGIQNfhhdQxK+4pAmZCiMSxd1dSa8PN9g/E0i4NkgVfb8TY1hc4
+        RCtYEYLRGcqbOM/R96YIgUFDpPYzhISKUx5I8hYsZ+uVbBGT66p6dwrxARL4phXTOrZlad3AKw2R
+        mJdVRV00yDDbkxDdAJFSC0dit28pWjBAc0GuV6Ieb9suhH1Fc2/Lgfrm81yakLIBGNUlzZwsbVJp
+        OQkRZkE5dFkizIzrxAjRJ5WDpP1Zec0HGTkf1OW1pGoLxF/BQcozY3uZZL/gUQdOM4o2VuVEsXuc
+        dQMTzUjS01yS6avV7dQT3F1PN0QefsIFd6FKCky69YCsSrdSL1apreoWAp3gGwT4cxOk3FAgfZvL
+        VQZZuaygXVx/yrzGj7jHLgYygcH2pDJE5v0vG9/fuAaoYT3apvlqvF2X3jKZtszHxRw5clrXmro6
+        lJxgDJIJnzD2qFy0UHxyJ6LnitWmECu2kyOsTamj57TaoV2tqw8u92TJwe46z51KTZKocQGtt/bg
+        i0zfZJLUlfNLS+WMpKwt0a2WqqQ4ESntLtuzn12O457i+CBI5/qlbxAQVRwRgnx4yACv1VjQnmMi
+        XRRI7hPzZqiUpiC1aphUcDlPhRNnkU4p9v0+bE3qEZzXDJVWQU3R07aTIQsxUE+pkcZzxlojRxdn
+        nObssFPV2DazJ1vtLTzgi0+Hh8oJDuF3S5k9btbq3tnRkIUuB2tafYJAC6gUpJaG9IYP7a9zvwBU
+        +zn8KsK2oM7lKANacH7x8hWPi2ZhrOa4ixugBs2EfLLJmWAQIkWsHG5w84lrw/9+1E/u2sCRDRnI
+        y8Bxxn9HMWZtuO1xoaRS3P1myvbvqD56/vlYSetKziq8M11a4ad82qfzqf0YgWVFe8Wq2OpG+/MW
+        AgyVSf/H+Y4TFQJoJB3GlU0UTx8I6aQQyCdoad2GN8xk4puu6aLQtQSoyCUC1dw35OQUZdP5IH1I
+        sZl+T9K9kxjsBQoHq+XrjpHWpOXobAkcD8XcQLKSQebA3GKkNBeGXpa9blAZtugjkcvSTQFKTlLX
+        MhGum48fRAFg+ZpVI8ubq1Rty+WurpThceDdyt8myhoegP0+Bm4gf6Ck98/T+H/G/HnuslKlV8uu
+        BwTX0mVmrfze3B4q5Zbbbto4rSuwdv10bXGp19nYxr8pcEUxUOFDyQqQ2+zMYMV/x+LEzmr2jor0
+        8O0hG8CMUm4f4KpyhJQdcY8BfIHrt68CIHNfK3xG7gEUFna9gffkwW+oojEoVRR6Cz9MCe2dK39F
+        CPJIVQZYcoc2sd8gJHU4mfwJFijrdalXr4twq+2zPU7H1Tl3i6TczizNEhoxf1NnvOcyOru+Fek+
+        73YK7RZJ6r0Sa1w++afc+F9bLYdHjMG5q3bdCdnmZdznBOWd5+8ieoXffXUxh0vr+MD+XhUmFFo9
+        mky69satCfgNE4UngP02ThJ+WpLlPg3aXVVNSGMk/jV3LM7IjdUrEMZdloIPr4OeNfSHdzH111nC
+        vbX0NVyd4NTu2urDy+9MPXOOO+ynDfA1seT8Uk4LmTnScc19ab5oIjcVc4QVc8elBsBy33JuD93/
+        fRh4Tyrfxm4uB5H7jxOF98FmsmbWddLLR0KZ7bVetS1xvY8Ppt41keJ9efrgbPoK0cTMmd+BSxfb
+        aU7t4eandqWm3DgI/15SjgJD3hF/kwevJ6dFuQ2phZurNvT7YFh4Ibj0nrn3Ohgvvdiv+dMaZocF
+        BvOXCQV/Z4mYGClUZVdt32HsPM7nW83w51+ed98tyCGd7z7yyHY/NzamDmcx031Z/BbL39H+3/UM
+        PhCf4F+lRBS4I1/ALXKRQIveiAPLrfbS/8YfMwWzMJk7++oFH2NH5nGXZ7Z1ZP5Gr85dOW1vYO/T
+        kraZWUOPpSAhGtqruubx+Vkbut3B+nfxRat5oKrPk+7z3vWXvPtwoge5yyAelB09B6bkdLJriHqL
+        Vj+wKPqxyd1pfOBN8EcExN9vSB7dsYEjCvmqYMaF5VxeqGvbtnqqSpuwXZO9FykH+r2Tdz89eqiP
+        0v4NAAD//7RdW3PbSHb+K6hJba22ItnEHXhIbVGyJcu6rGJ6JrWppFxNskX2CERzAEJaOrWP+S2p
+        fc8/8B/LOd0AhYPTlCV58jIeS1/fDk6f+2k/tbN/ujw/smb5d7f4rN04+k0eIdiy/thBvGvbzn0/
+        e+zaxvbGXpMcdm6CuJt/UfPa9sbCBDDctH92zeYa+2Lk44xRFKTZbkbTPH7cbx7v95jjHE+tkYZB
+        muIi/UZ7O2gOhFtUYr1Usy+/NWh+AzN2v+z9AHbVb2JuAWB0S+z9P0V3yLsWplm87bmfd+2zt0oW
+        cztFexrjPX0pLbztq1XlutnYbuO249ac4+//ic28Tyx9KV6yciF+t4Xfr4QqnrWobJE/uODNErxz
+        smDb8M9XXLfQH1zxk6yblXx78suzjlkZ9HDVW1VIuurhYES3sXYY/g39g5dt9V3XNYr9eT0B274N
+        4Z17AhOyqKixYkGXYA2utiYADlp0jtZLP0RoGvdAiS+UqFS9OjQGoRl4643PvV15s20yxShy25vd
+        tpCp2nSr3JpFevt58yxKdvfuSxRkUR5E6SN1bCO97UinTe89cv3Xjix/lb3nF3ykYfeba/34i9Hf
+        n0Fg86tpq8N6WWGss1sgRYb9KOgqe22jYxdXe9nxwzRORmmS/TBz7Nu7Cad8FPdiYoYeep9hGfv/
+        xpaanEwmr9py/qNb/qAfgIvmxlaG7YIRbsLyK4G9L8BKsxpbmE33Vz1bal38+TX7TKNXc9YJeJ4a
+        nyMBU7D3RoMf+GEa+qOA8hqGoWrMJpI3RjowYczPeu3Foz/g8ezJHvHBKIzjIEuSIT54Gp8O8f7T
+        +Jzt5yl4OhrC600zN+Y4H+NHozjP/VHGtvSHLu1SyYXqvxPSDvHZMqM33x/ESDt6M9o/qjuR/wyB
+        sIdDzRUrbY1qIcpFg+0Evwerxv9frBq+hFWjl7FqxljvaVbNOF88jX8Zq+avYVXGQt/lOnr7n8mq
+        9Ds8l1Xz57DqTSHBdPbqJTrshkG7ehhparuwxxTVQRf56fFqx9ptkzoymTItelOMVnpXWF8DnrKs
+        7JsL2rM9q+VM4TsYtXlxQdsLocsj0xpfz0yFTdu7D14+hpcx/XKIyOoxSOYJDFXZH7fVSBJ8SrxZ
+        WGlmN3MvTfRbYtMO6F+zT7SrCox9N7MlJjEn4884Ynzy2SyOkYWP46vjQ1Qnla1QxeXaYYfe+fFu
+        CrmZmVTCLlKGvXjVtt08vjUwV7fm+Btvaqp7rQUkahs7g33/2sA9BkvIEJ6R8GWyIPKzMMnCnkH0
+        XPVqnswJZ8aTC2XLEaqcK9PfYpnCnNmQ2/Y/yXn7M0/ddlXb+ARDbb40uE3zxlp1du637eQ/PXKe
+        eVngwca6KwzlmKLCP9Zga+4iQLZU8Bmrm8wESrIt9sTa1eX8ddI0/Glgpz/HO6A0/Lk7gjIPQgzS
+        NIbR2rOZcuBHPnkQ23o/ySaGQ8xMeMbHm4I0N61ETd031Xuf7mWUiKJROvKD4NV65exm7B1Eb0be
+        BBRL/9koPxuFoZ9ERAyeGPhJszLXDb4k/t0fOYaF3x2WOUYRzfTzZPLJO2vJN7HkOwiOYse4uD/u
+        U1PXSpTPHErssDOJUpKNjI/83shgFOSjPEqImjtF4blkI0dHwcgxlGi8ny/YsM9LVWGUxMQk+Hhq
+        rX0Ua1FiunA4y+nRxDGWqEIwK2CM48jvjmD58T87xhOGOK7EV1W4Jhgd+bljNOWLpXJuHMaOHGRL
+        CXu8azYOgvtHvmskYZDJgwJvmo9MHAMJe5zXlZCFevZ+ieE0WWPxhYtFnDsm3DURzVx540pM3aSO
+        HBMQHrvGooi268joLHYRkojivZ+H0p0tkbl9bqeWsq8DbG0M4nHmgXQ0WRVZWakJugN92/1S9tyq
+        FCveAM0O2dlda0wrahC5ndw89NZ2W/POq152b1Xt31z7uJvp0WrKje3g6ylQIrn3hrWGovt3UGIt
+        iUsssjBBn1bXtrvxsHsOy5tXKz1vQ/ZojbXlFjigktjgY3sPvfVyW9u3tVTdJSA7cmHXzAaVF9Yh
+        eXMbsDJ0s+2du1gVkqmzo5C8Yr22D0SpegbyudN4ZoP2IUssTsBKhv12SNfSbWoqjMGI9Qpm16ZK
+        BL722hQNeMFRROpEDtE32D3L0HUU2hcZPIynmlSz3DxgYaV/FNjHHIzR2DYLrdXsztQP48H6ZR5d
+        BLu2lDQHLtQddnp29KcPbLV0x3mk4aIeFbBISdRtcd9s1qbaYCNja/Sb6XFVUwLYvboGH1aZAgSM
+        HL7OlEpebUD8ftG5f7OPeb7wGrUH6FnTz79Ggyj87unOSmPE13vdTrIf38kZiL1m+rrlg9csT+WJ
+        /UuXPt09itzYB80wZQqumije4qO/R+tKAatu34JzVTXKpJT+w04nPz3+CPPxCAMZjV1XNhW1S1DB
+        dRf9pbvLbxNcP7SvP39ZiH8J3oR+GI4i8ODDJAnSURRGb/wkTuMoy5IQFLCfBEGUBPjTKB+lYRrF
+        3Sm6nd/oQs22T233J+atz3R5q6qV1z2XaN2fyvTQ4w3uwvm7omzwqvZTrS3S6m/nha5nyyO9yO4L
+        b/t4titAfXtiD9e7/Ta+5L/ELLCOktEGs6YyrlUnUW3VAerveaXXc/3whI8Kt/ZhqcAe7FTz3LYo
+        t3PiU3GgvV8oG62jHrw+czG+XSzR6AMfr0elKEhB9VOf5dt/F/hxz2v8o2bgmIDHxRRmFQyVDFAL
+        fJ6HoagtPF4BaAZG5USsNAfTWN64nOuq4qg8oaiFLhgoGw1BDegyDgsiCtuIChs1OTBMB0C1aOxj
+        RMeimjZzPiIiJvG4WpimAY6L6aEruIqcjlkyQDVTjqEewBgbkkThmCuLGM6ByonrNf4qq6lQv3Le
+        ymns8lgsxUowpsppMB5QlVB8Lj+nKGB6MM3rJQOGPgXC5uaarxoSsh2D4Vk1HBUNUQvVrBgqHqLU
+        V8lANNNyDN+SH3Lg1Mpq5eCfPCPO6/GycdzrPKd7Ail9r4R3cFOgrbyrK7Mx1ds/DYaDGzkYXgqF
+        b99OwIb03jcYi1WNNRAngjGcPwroN9V12T7Q9UFWX+UCo7qOQYM1N/WDcMBCygm6uQeb20oshqWR
+        HBslYKCY0rNSG/SPz0sTkPjLTMJ/P8uqwm7OLRucDFZoSqm8d8hMtSjEkFf8EY17HDfFQvA75oOY
+        ojAsWRfeqag1h2YDaAM7ZygqG0/EaqrnfN1B5gBgstJ6yF3+IBdmojd8rmAAmmrvF1nNh1cDgBkF
+        bjH45dZBPlhOBGwC9YU3vrXq45NcN1OwSNgwGmA7WQrGLH6cU0iv2mKHSYYYzqA+jZmcLCvQvCD4
+        9vCon9Gd6ZmuvYMLKdHB+tNeMuQxHVXo1ZR/z4CK4BO90hUThoBKKQo0J8P4McN4B/jY5gwTQLMd
+        5dvIBxMpQUBZS+u7fYcLBgyhQd54n7jy9YOQ3L6Tb/8L4mz+x/N7rSr27QKqqU8qDfvmU0aUa7k6
+        BQjdXlOJb/8jOMWotXSyXXMN4wcJXe6rBONxHxMHVIe8k+VKVHcMRcOy735V2I7FJEJAY4rv9EqV
+        LhJngQu2/6YFVB69nzWgfyuGysmXe7/YrjdDTDgiB3kP+koU967ZQmrUvf+tEdh6D3LhrFGlZIcK
+        fYoH2V45UAE5+vt6o7kBBg4d4ev3m6XSaxeMcN+pKO76prZ3cAVnA2lSs4sTUiV2Kiot992ckNqW
+        p+pX9t3DmG5ElS6pFCaE9qcmGcpBdKo299Aoh9oOqW3TYsF73JaydpArdU09AUZeyupRHyvJSUCN
+        2DNQO0x/hblPMS7ZGVIReyZ1teCoiEpYm7lhZgIYZAS1dFAo8smRz9QUFBu4HQxH2fIMfHf+aaIg
+        H4Kc3zmi6hRwLlUeUS/xDK60LHSz5stSWwqAzAKKqLV8honXlWAemD/I8Jw18N1rySlLxZj7vkcD
+        njCgo2MFNlrDsZRyzdb1ragP9EEoLmAjaoJ/kKLqrrsxha9m79AI3+dt+zG1xT7AVfEmkpE8pqz1
+        QZdzUEh8Nj8awBbehTYF1RRHrbYPTQkGKqN6HBCGOJ9JF3PFVDQai5photEAo50CIaZS8BwEkneA
+        lFtR24OJz5iqYRj4G4NQJXxeuU9DpR2sbbI8V8z58mOaXrTpOg6iOb2NKDiZs0GGdSUcKjqmlVEm
+        D8swVN9+lJXjLiW0PumjruZ8poTy24X4Ku6WjtCSn1B5diHLLdt6Qh3FC1WpqeBXKaHsdqHxVYm+
+        8Wn/bTcTtdzPCQk1K9tZnhxBgwkXutb3eu+QLMmxUIF8+4vmAWQDn5d8jYtttdh+ddKQWg2XQj8e
+        1WF7s+H00lyKzT2/WQm1GS7lFKPADBXTqWStN0tm8yb0Jl2qqSP2B6h4gHJwBhX/lwoM440s641k
+        cRPA0hNg2sIRmfSTjK7b/E2CG9xUTAgmVLxfiRk371MaIgGMnKN96B1gqBjr3GTl/bVZaJBR90/y
+        ZUpF8xUo4IWoZ1zzp/S2gMUoHthdSYNgCNo65GkaDLZfYN8ZUxspvQEA4wuGw5k2fLVosKmqxidw
+        9qm+QVT6Ch9/LNVvDVN+aTRYG//hG9enT+OAAxX3x9I4obit3mz4stQ6vpJ/UzPOIDQye6VmlVVt
+        3sGpnLetDiYCVzu5giqRK13M9f135FVKL8IV2BeOfVGP7go9eR4MBlg8gMH1k4vKMV86BNZgngsm
+        9dJssLtKzxzbywfn/orWuevb05DWFdhpK8edoVbYNdgLDls/o5rvGtiDGYYZVXzXci2YUs98WgFt
+        HkVwsnhGteO1fPBORGFFCMNSmwyx/y6Fy0YZpC2uwVrAxxQcM1KqqIVklMvCgGEce6MOxLXiHyqj
+        EdtrXd3q4m5POCyjJXsAth7fFYZJS7FPYmQ0vgfDHgSzbwaZl7+suMLNqJy4EXeutBnAYgoruCMx
+        yN8AxpRqYBS9DbuzEclg8RIMPg4aTLtuhIcs4XZ9MhpwvrH8wElDpc2NdPA/zdjdLFWh1musnONI
+        ukW1mQlVcSJmdGvayQ/UdbvBl1oWjotHo6g34C1uNMYMmXwZ9AX8q3C42INegE/f/tGUittEGQ0j
+        fNIrl+rJqEDrykJbHeCcltaRPgBZHLPSqj6BmZljUJTLb/8o5Ip/4Dzn+A+yAH//0BvXMzCtMNeN
+        junnyvC8NxfeSVMu2dKDvJ6d6kJtNjYhdC3vFWOJnHZ72DGXzYyTK6exPIu0FgAoThsHwqZhpvzy
+        keOENwpUka1YuEIlUnBy577jOL+octa9AoD2nA2MuJg9p4FxV/4aMIMySivPSsacObXwJmDvf8Z2
+        ZWErLvCfrmLiNQ8GpH2s0eRQyjSo0PldykO6CVm5pqK+/URusR6/cNCHKogJfhDhXUrbVTuA0i+o
+        yoVYax7Jz6mOmFgOAZ6QwCK2HtfNIdSsnBRgUN05jkbVBMIcmXc/p6pigikYvTdvlVPDcgKywmF0
+        5TQHZeKdbW6LQWnm0ULbIOWObe1Pgd/mD1iVYvb2fwAAAP//fF3NboMwDH6VPsBWoUiT2vO0HbZW
+        OwCt1qmHoKI1o8CEQKhIe/fZEHX9YndnPicmcfwfUHjDzIYn6pTgf4m1hfhbluoJg4w1brayVSFf
+        IOiG1ufD9RiL16UUCPRVY3qYcbaNl+FlPGznXI6NhiDuuTisWKAlavm4J8UtB0OdHfeuHSbPTyLx
+        lc7s14zn9VYYb6LgPpd1vVgqAuF9OvvlVN+FgHiRzlYDm6077rTmkOQqwJCkeEfuaLUVMxFq1MSV
+        dXO/Iu8n3DhCwrIltSg8EmSBkCKXzpaJ0EVOKKgJBY5/JA4YkiV38C1wSZ1ZZW6D12PJC5ChNHeh
+        I6opRG7NRKhUGcT9POoGoWpl6GRZH63j4rB+ivkSH5LxUwmC1Uw/Fd/CRJiTTQvuyJF7hzG9l55R
+        kJ9Kx+GtZBEVsCd5JT1/qMNCAYEXCvgSMM98y5gge9DY8mRrsrnN7K1rpy8u3VpJ9O7TplNcZkLB
+        OUqHLL9x4FCpb2zV2VbuDKbONmSbB/JXKOIfm3fG8Oe/NBINgNO4vK1E+cUEDSgbR/biYrRorqn7
+        RQ6OyjokS+fxXKEBhrb2dHKTID93bSeKKibCxMSWFUbDHYFHK5r9CAwMvXPfusTA8d1pZT4CAZc7
+        V2Y266W0+9ux+7+PxVx/5OVj//MLAAD//wMAFFhlY8aFAAA=
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 May 2024 16:02:33 GMT
+      ETag:
+      - W/"18e20ee6c8433d1f51880d5d51312db6"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Origin
+      X-Download-Options:
+      - noopen
+      X-Farm-Id:
+      - us
+      X-Request-Id:
+      - 8979d9ba815350157492abfe7e8fc1ba
+      X-Runtime:
+      - '0.012105'
+      X-XSS-Protection:
+      - 1; mode=block
+      vary:
+      - Accept-Encoding
+      - Origin
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -139,6 +139,18 @@ class TestApplicationPageHelpers(VCRTestCase):
         result = _get_employee_directory_data("1234")
         self.assertDictEqual(fake_directory_data, result)
 
+    def test_job_post_page(self):
+        """
+        When given the /careers/<id> URL,
+        we should return a 200 status code
+        check requisition id is contained
+        """
+        response = self.client.get("/careers/4754075")
+        self.assertEqual(response.status_code, 200)
+        html_content = response.data.decode("utf-8")
+        # Test Requistion ID is in the page
+        self.assertIn("<p>Requisition ID: 613</p>", html_content)
+
 
 class TestGetGiaFeedback(unittest.TestCase):
     def test_gia_feedback_is_found_correctly(self):

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -260,11 +260,17 @@ def careers_rss():
     "/careers/<regex('[0-9]+'):job_id>/<job_title>", methods=["GET", "POST"]
 )
 def job_details(job_id, job_title):
+    """
+    job_title is not used, but is included in the route to avoid
+    breaking existing links
+    """
     context = {"bleach": bleach}
 
     try:
         # Greenhouse job board API (get_vacancy) doesn't show inactive roles
         context["job"] = harvest.get_job_post(job_id)
+        job_post = greenhouse.get_vacancy(job_id)
+        context["job"]["content"] = job_post.content
     except HTTPError as error:
         if error.response.status_code == 404:
             flask.abort(404)
@@ -287,8 +293,6 @@ def job_details(job_id, job_title):
                 "title": f"Error {response.status_code}",
                 "text": f"{response.reason}. Please try again!",
             }
-
-        return flask.render_template("/careers/job-detail.html", **context)
 
     return flask.render_template("/careers/job-detail.html", **context)
 


### PR DESCRIPTION
## Done

Append back the original content with Requisition ID, as requested.

#### Rationale
Originally this was changed to [show active/inactive roles](https://github.com/canonical/canonical.com/pull/1100), but looks like there is no way to get the Requisition ID with only the Harvest Job board API, so had to put back the old greenhouse API.

Also, since it looks like role description looks the same, so I directly assigned the old `job["content"]`.

## QA

- Go to https://canonical-com-1260.demos.haus/careers/4754075 and check that "Requisition ID" shows up now, at the end of the page (before the application button).
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Anything else you may think could be breaking with this change.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8203
