### PR TITLE
Add is-muted to hr

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -95,11 +95,11 @@ meta_copydoc %}
               <p class="p-heading--2">
                 <a href="https://ubuntu.com/desktop">Ubuntu Desktop&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule u-hide--medium" />
+              <hr class="p-rule u-hide--medium is-muted" />
               <p class="p-heading--2">
                 <a href="https://ubuntu.com/server">Ubuntu Server&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule u-hide--medium" />
+              <hr class="p-rule u-hide--medium is-muted" />
               <p class="p-heading--2">
                 <a href="https://ubuntu.com/download/cloud">Ubuntu on public
                 clouds&nbsp;&rsaquo;</a>
@@ -126,19 +126,19 @@ meta_copydoc %}
               <p class="p-heading--2">
                 <a href="https://ubuntu.com/kubernetes">Kubernetes&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule u-hide--medium" />
+              <hr class="p-rule u-hide--medium is-muted" />
               <p class="p-heading--2">
                 <a href="https://ubuntu.com/openstack">OpenStack&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule u-hide--medium" />
+              <hr class="p-rule u-hide--medium is-muted" />
               <p class="p-heading--2">
                 <a href="https://ubuntu.com/ceph">Ceph&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule u-hide--medium" />
+              <hr class="p-rule u-hide--medium is-muted" />
               <p class="p-heading--2">
                 <a href="/microcloud">MicroCloud&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule u-hide--medium" />
+              <hr class="p-rule u-hide--medium is-muted" />
               <p class="p-heading--2">
                 <a href="https://maas.io/">MAAS&nbsp;&rsaquo;</a>
               </p>
@@ -193,7 +193,7 @@ meta_copydoc %}
               <p class="p-heading--2">
                 <a href="https://ubuntu.com/core">Ubuntu Core&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule u-hide--medium" />
+              <hr class="p-rule u-hide--medium is-muted" />
               <p class="p-heading--2">
                 <a href="https://microk8s.io/">MicroK8s&nbsp;&rsaquo;</a>
               </p>
@@ -218,7 +218,7 @@ meta_copydoc %}
               <p class="p-heading--2">
                 <a href="/data">Data&nbsp;&rsaquo;</a>
               </p>
-              <hr class="p-rule u-hide--medium" />
+              <hr class="p-rule u-hide--medium is-muted" />
               <p class="p-heading--2">
                 <a href="/solutions/ai">AI and MLOps&nbsp;&rsaquo;</a>
               </p>


### PR DESCRIPTION
## Done

- Add `is-muted` to `hr`s inside top level section, from design comment: https://github.com/canonical/canonical.com/pull/1258#issuecomment-2129355465

## QA

- Go to demo landing page
- Check that `hr`s inside top level sections are muted

## Issue / Card

Fixes #

## Screenshots

<img width="348" alt="Screenshot 2024-05-29 at 8 27 18 AM" src="https://github.com/canonical/canonical.com/assets/62298176/b28f0e29-9252-4992-b306-27d6b0cd3571">

