### PR TITLE
chore: Bump canonicalwebteam.discourse to 5.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.blog==6.4.2
 canonicalwebteam.http==1.0.4
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.discourse==5.4.9
+canonicalwebteam.discourse==5.5.0
 canonicalwebteam.search==1.3.0
 bleach==5.0.1
 markdown==3.5.2


### PR DESCRIPTION
## Done

- Bump canonicalwebteam.discourse to 5.5.0

## QA

- Go to https://canonical-com-1275.demos.haus/data/docs/postgresql/k8s
- Use chrome dev tools to see that the anchor link in heading don't have trailing numbers
