### PR TITLE
Fixed Naming for templates

### DIFF
--- a/templates/careers/company-culture/diversity.html
+++ b/templates/careers/company-culture/diversity.html
@@ -1,174 +1,227 @@
-{% extends '/base_index.html' %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1l1UGJToc0ErHUMN9W8hELvF5sDyVRO7N0xDzncqA2SQ{% endblock meta_copydoc %}
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1l1UGJToc0ErHUMN9W8hELvF5sDyVRO7N0xDzncqA2SQ
+{% endblock meta_copydoc %}
 
 {% block title %}Company Culture | Careers{% endblock %}
 
-{% block meta_description %}Diversity is part of our strength. At Canonical, we believe your identity has no intrinsic bearing on your ability. We hire in every corner of the world and make every appointment based on merit.{% endblock %}
-{% block body_class %}is-paper{% endblock body_class %}
+{% block meta_description %}
+  Diversity is part of our strength. At Canonical, we believe your identity has no intrinsic bearing on your ability. We hire in every corner of the world and make every appointment based on merit.
+{% endblock %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
 {% block content %}
-<div class="u-fixed-width">
-  <nav class="p-breadcrumbs" aria-label="Breadcrumbs">
-    <ol class="p-breadcrumbs__items p-text--x-small-capitalised">
-        <li class="p-breadcrumbs__item "><a href="/careers">Careers</a></li>
-        <li class="p-breadcrumbs__item "><a href="/careers/company-culture">Company culture</a></li>
+  <div class="u-fixed-width">
+    <nav class="p-breadcrumbs" aria-label="Breadcrumbs">
+      <ol class="p-breadcrumbs__items p-text--x-small-capitalised">
+        <li class="p-breadcrumbs__item ">
+          <a href="/careers">Careers</a>
+        </li>
+        <li class="p-breadcrumbs__item ">
+          <a href="/careers/company-culture">Company culture</a>
+        </li>
         <li class="p-breadcrumbs__item ">Diversity</li>
-    </ol>
-  </nav>
-  <h1 class="p-text--x-small-capitalised u-hide">Careers</h1>
-  <hr class="p-rule">
-</div>
-<div class="p-strip--diversity u-no-padding--bottom u-no-padding--top">
-  <section class="p-section--deep">
-    <div class="row">
-      <div class="col-6">
-        <h1 class="p-heading--2"><strong>Diversity</strong></h1>
-      </div>
-      <div class="col-6">
+      </ol>
+    </nav>
+    <h1 class="p-text--x-small-capitalised u-hide">Careers</h1>
+    <hr class="p-rule" />
+  </div>
+  <div class="p-strip--diversity u-no-padding--bottom u-no-padding--top">
+    <section class="p-section--deep">
+      <div class="row">
+        <div class="col-6">
+          <h1 class="p-heading--2">
+            <strong>Diversity</strong>
+          </h1>
+        </div>
+        <div class="col-6">
           <h2>We believe that talent is evenly distributed around the world</h2>
           <p>
             <a class="p-button--positive" href="/careers/all">See all roles</a>
             <a class="p-button" href="/careers/career-explorer">Career explorer&nbsp;&rsaquo;</a>
           </p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--diversity u-no-padding--top">
-  <div class="u-fixed-width">
-    <hr class="u-no-margin--bottom u-hide--medium u-hide--small">
-  </div>
-  <div class="row">
-    <div class="col-medium-6 col-6">
-      <h3 class="p-muted-heading">Equal opportunities</h3>
-    </div>
-    <div class="col-medium-6 col-6">
-        <p>At Canonical, we are proud to provide equal opportunities to everyone regardless of gender, sexual orientation, race, ethnicity, religion, veteran status, disability or any other protected characteristic.</p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--diversity u-no-padding--bottom u-no-padding--top">
-  <div class="p-equal-opportunities u-fixed-width">
-    <p class="p-heading--2">No matter your background or location, we will give your application fair consideration.</p>
-  </div>
-</section>
-
-<section class="p-strip--diversity">
-  <div class="row">
-    <div class="col-start-large-7 col-6">
-      <p>Diversity is a strength. What unifies us isn’t our background or our culture, it’s our vision of the future and our dedication to delivering the best of the future for our customers and our colleagues. We are unified in our pursuit of company and personal excellence and our commitment to teamwork.</p>
-      <a href="/careers/diversity/identity">Read our statement on personal identity at Canonical&nbsp;&rsaquo;</a>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--diversity u-no-padding--top u-no-padding--bottom">
-  <div class="u-fixed-width">
-    <hr class="u-no-margin--bottom">
-  </div>
-  <div class="row" style="padding-bottom: 1.5rem;">
-    <div class="col-medium-3 col-6">
-      <h3 class="p-muted-heading">Fostering participation</h3>
-    </div>
-    <div class="col-medium-3 col-6 u-no-margin--bottom">
-			<p>Working with a diverse community is part of our DNA. It’s been embedded in our culture since the early days of the Ubuntu project.</p>
-    </div>
-  </div>
-	<div class="u-fixed-width">
-    <img src="https://assets.ubuntu.com/v1/da3fbf74-summit2022_crowd.png" width="100%" alt="Canonical employees at Ubuntu Summit 2022" />
-	</div>
-</section>
-
-<section class="p-strip--diversity">
-  <div class="u-fixed-width">
-    <hr class="u-no-margin--bottom">
-  </div>
-  <div class="row">
-    <div class="col-medium-2 col-3">
-      <h3 class="p-muted-heading">Team member <br class="u-hide--small" /> resource groups</h3>
-    </div>
-    <div class="col-medium-4 col-9">
-      <div class="row p-strip--diversity u-no-padding--top" style="padding-bottom: 1.5rem;">
-        <div class="col-3 col-medium-1 col-small-1">
-          &nbsp;
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Internal resource groups are dedicated to making Canonical a diverse and inclusive workplace.</p>
-        </div>
-      </div>
-      <hr class="u-no-margin--bottom">
-      <div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
-        <div class="col-3 col-medium-1 col-small-1">
-          <p><strong>Accessibility awareness</strong></p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Our Accessibility Awareness Resource Group aims to improve employees’ quality of life, be it physical, cognitive, or mental. We host awareness events and, at times, suggest changes to company-wide policy.</p>
-        </div>
-      </div>
-      <hr class="u-no-margin--bottom">
-      <div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
-        <div class="col-3 col-medium-1 col-small-1">
-          <p><strong>Working parents</strong></p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>The Working Parents Resource Group is a forum where parents come together to celebrate the successes of their children, seek support for child-rearing at all ages, and offer a global community of shared experiences.</p>
-        </div>
-      </div>
-      <hr class="u-no-margin--bottom">
-
-      <div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
-        <div class="col-3 col-medium-1 col-small-1">
-          <p><strong>Canonical pride</strong></p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Canonical pride provides support and guidance for members of the LGBTQIA+ community, their allies, friends, family and managers.</p>
-        </div>
-      </div>
-      <hr class="u-no-margin--bottom">
-			<div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
-        <div class="col-3 col-medium-1 col-small-1">
-          <p><strong>Women's resource group</strong></p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Canonical’s Women Resource Group promotes the growth of women, personally and professionally, within the workplace.</p>
-        </div>
-      </div>
-      <hr class="u-no-margin--bottom">
-			<div class="row p-strip--diversity u-no-padding--top" style="padding-bottom: 1.5rem;">
-        <div class="col-3 col-medium-1 col-small-1">
-          <p><strong>Culture and identity</strong></p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>The Culture and Identity working group supports our team members by conducting data-driven assessments of company culture, and inclusive naming initiatives.</p>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-
-<div class="p-strip--diversity u-no-padding--top u-no-padding--bottom">
-  <div class="u-fixed-width">
-    <hr class="u-no-margin--bottom">
-  </div>
-  <div class="row">
-    <div class="col-medium-2 col-3">
-      <h3 class="p-muted-heading">Our hiring process</h3>
+  <section class="p-strip--diversity u-no-padding--top">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom u-hide--medium u-hide--small" />
     </div>
-    <div class="col-medium-4 col-9">
-      <div class="row">
-        <div class="col-3 col-medium-1 col-small-1"></div>
-        <div class="col-6 col-medium-3 col-small-3">
-          <div class="p-strip--diversity is-shallow u-no-padding--top">
-            <p>We understand that if we are to offer opportunities fairly across the globe we need an equally fair and consistent process that assesses our people on merit and removes the ability to make decisions based on familiarity or local knowledge. We work hard to assess the ability and potential of every candidate whilst minimising bias associated with personal identity.</p>
+    <div class="row">
+      <div class="col-medium-6 col-6">
+        <h3 class="p-muted-heading">Equal opportunities</h3>
+      </div>
+      <div class="col-medium-6 col-6">
+        <p>
+          At Canonical, we are proud to provide equal opportunities to everyone regardless of gender, sexual orientation, race, ethnicity, religion, veteran status, disability or any other protected characteristic.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip--diversity u-no-padding--bottom u-no-padding--top">
+    <div class="p-equal-opportunities u-fixed-width">
+      <p class="p-heading--2">No matter your background or location, we will give your application fair consideration.</p>
+    </div>
+  </section>
+
+  <section class="p-strip--diversity">
+    <div class="row">
+      <div class="col-start-large-7 col-6">
+        <p>
+          Diversity is a strength. What unifies us isn’t our background or our culture, it’s our vision of the future and our dedication to delivering the best of the future for our customers and our colleagues. We are unified in our pursuit of company and personal excellence and our commitment to teamwork.
+        </p>
+        <a href="/careers/diversity/identity">Read our statement on personal identity at Canonical&nbsp;&rsaquo;</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip--diversity u-no-padding--top u-no-padding--bottom">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom" />
+    </div>
+    <div class="row" style="padding-bottom: 1.5rem;">
+      <div class="col-medium-3 col-6">
+        <h3 class="p-muted-heading">Fostering participation</h3>
+      </div>
+      <div class="col-medium-3 col-6 u-no-margin--bottom">
+
+        <p>
+          Working with a diverse community is part of our DNA. It’s been embedded in our culture since the early days of the Ubuntu project.
+        </p>
+      </div>
+    </div>
+
+    <div class="u-fixed-width">
+      <img src="https://assets.ubuntu.com/v1/da3fbf74-summit2022_crowd.png"
+           width="100%"
+           alt="Canonical employees at Ubuntu Summit 2022" />
+
+    </div>
+  </section>
+
+  <section class="p-strip--diversity">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom" />
+    </div>
+    <div class="row">
+      <div class="col-medium-2 col-3">
+        <h3 class="p-muted-heading">
+          Team member
+          <br class="u-hide--small" />
+          resource groups
+        </h3>
+      </div>
+      <div class="col-medium-4 col-9">
+        <div class="row p-strip--diversity u-no-padding--top"
+             style="padding-bottom: 1.5rem">
+          <div class="col-3 col-medium-1 col-small-1">&nbsp;</div>
+          <div class="col-6 col-medium-3">
+            <p>Internal resource groups are dedicated to making Canonical a diverse and inclusive workplace.</p>
+          </div>
+        </div>
+        <hr class="u-no-margin--bottom" />
+        <div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
+          <div class="col-3 col-medium-1 col-small-1">
+            <p>
+              <strong>Accessibility awareness</strong>
+            </p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Our Accessibility Awareness Resource Group aims to improve employees’ quality of life, be it physical, cognitive, or mental. We host awareness events and, at times, suggest changes to company-wide policy.
+            </p>
+          </div>
+        </div>
+        <hr class="u-no-margin--bottom" />
+        <div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
+          <div class="col-3 col-medium-1 col-small-1">
+            <p>
+              <strong>Working parents</strong>
+            </p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              The Working Parents Resource Group is a forum where parents come together to celebrate the successes of their children, seek support for child-rearing at all ages, and offer a global community of shared experiences.
+            </p>
+          </div>
+        </div>
+        <hr class="u-no-margin--bottom" />
+
+        <div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
+          <div class="col-3 col-medium-1 col-small-1">
+            <p>
+              <strong>Canonical pride</strong>
+            </p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Canonical pride provides support and guidance for members of the LGBTQIA+ community, their allies, friends, family and managers.
+            </p>
+          </div>
+        </div>
+        <hr class="u-no-margin--bottom" />
+
+        <div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
+          <div class="col-3 col-medium-1 col-small-1">
+            <p>
+              <strong>Women's resource group</strong>
+            </p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Canonical’s Women Resource Group promotes the growth of women, personally and professionally, within the workplace.
+            </p>
+          </div>
+        </div>
+        <hr class="u-no-margin--bottom" />
+
+        <div class="row p-strip--diversity u-no-padding--top"
+             style="padding-bottom: 1.5rem">
+          <div class="col-3 col-medium-1 col-small-1">
+            <p>
+              <strong>Culture and identity</strong>
+            </p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              The Culture and Identity working group supports our team members by conducting data-driven assessments of company culture, and inclusive naming initiatives.
+            </p>
           </div>
         </div>
       </div>
-      <hr class="u-no-margin--bottom">
-      <div class="row">
-        <div class="col-3 col-medium-1 col-small-1">
-          {{
+    </div>
+  </section>
+
+  <div class="p-strip--diversity u-no-padding--top u-no-padding--bottom">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom" />
+    </div>
+    <div class="row">
+      <div class="col-medium-2 col-3">
+        <h3 class="p-muted-heading">Our hiring process</h3>
+      </div>
+      <div class="col-medium-4 col-9">
+        <div class="row">
+          <div class="col-3 col-medium-1 col-small-1"></div>
+          <div class="col-6 col-medium-3 col-small-3">
+            <div class="p-strip--diversity is-shallow u-no-padding--top">
+              <p>
+                We understand that if we are to offer opportunities fairly across the globe we need an equally fair and consistent process that assesses our people on merit and removes the ability to make decisions based on familiarity or local knowledge. We work hard to assess the ability and potential of every candidate whilst minimising bias associated with personal identity.
+              </p>
+            </div>
+          </div>
+        </div>
+        <hr class="u-no-margin--bottom" />
+        <div class="row">
+          <div class="col-3 col-medium-1 col-small-1">
+            {{
             image (
             url="https://assets.ubuntu.com/v1/7046a786-Hanna 1.png",
             alt="",
@@ -178,75 +231,106 @@
             loading="lazy",
             attrs={"class": "u-image-margin--top"}
             ) | safe
-          }}
-        </div>
-        <div class="col-6 col-medium-3 col-small-3">
-          <blockquote class="p-pull-quote--small u-no-margin--top u-stack u-no-padding--left">
-            <h4><em>"I am particularly proud to work for an organisation that holds diversity and equal opportunity at the heart of its business. Our global reach allows us to consider people from all over the world for each open role we have. This presents an immense opportunity for talent in the open source community."</em></h4>
-            <span class="p-pull-quote__citation u-no-margin--bottom"><strong>Hanna Neuborn</strong><br /> Global Head of Talent Science</span>
-          </blockquote>
+            }}
+          </div>
+          <div class="col-6 col-medium-3 col-small-3">
+            <blockquote class="p-pull-quote--small u-no-margin--top u-stack u-no-padding--left">
+              <h4>
+                <em>"I am particularly proud to work for an organisation that holds diversity and equal opportunity at the heart of its business. Our global reach allows us to consider people from all over the world for each open role we have. This presents an immense opportunity for talent in the open source community."</em>
+              </h4>
+              <span class="p-pull-quote__citation u-no-margin--bottom"><strong>Hanna Neuborn</strong>
+                <br />
+              Global Head of Talent Science</span>
+            </blockquote>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
 
-<div class="p-strip--diversity">
-  <div class="u-fixed-width">
-    <hr class="u-no-margin--bottom">
-  </div>
-  <div class="row">
-    <div class="col-3 col-medium-2">
-      <h3 class="p-muted-heading">Behind the process</h3>
+  <div class="p-strip--diversity">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom" />
     </div>
-    <div class="col-9 col-medium-10">
-			<div class="row p-strip--diversity u-no-padding--top">
-				<div class="col-12">
-					<p class="p-heading--2">We dedicate a huge amount of time to our talent process, specifically ensuring that we are making the best and most fair decisions on how we choose to select our people.</p>
-				</div>
-			</div>
-      <hr class="u-no-margin--bottom">
-      <div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
-        <div class="col-3 col-medium-3">
-          <p><strong>Informed decision-making</strong></p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>We have a professionally trained set of Hiring Leads that steer our recruitment processes. This set of individuals make their hiring decisions based on multiple information points collected throughout the application process. </p>
-        </div>
+    <div class="row">
+      <div class="col-3 col-medium-2">
+        <h3 class="p-muted-heading">Behind the process</h3>
       </div>
+      <div class="col-9 col-medium-10">
 
-      <hr class="u-no-margin--bottom">
-      <div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
-        <div class="col-3 col-medium-3">
-          <p><strong>Bias mitigation</strong></p>
+        <div class="row p-strip--diversity u-no-padding--top">
+
+          <div class="col-12">
+
+            <p class="p-heading--2">
+              We dedicate a huge amount of time to our talent process, specifically ensuring that we are making the best and most fair decisions on how we choose to select our people.
+            </p>
+
+          </div>
+
         </div>
-        <div class="col-6 col-medium-3">
-          <p>Our written assessment is reviewed anonymously so that the grader cannot see any personal details associated with the submitter. This gives our candidates an opportunity to show what they can do on objective grounds, and removes any prejudice that may present itself at this stage.</p>
+        <hr class="u-no-margin--bottom" />
+        <div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
+          <div class="col-3 col-medium-3">
+            <p>
+              <strong>Informed decision-making</strong>
+            </p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              We have a professionally trained set of Hiring Leads that steer our recruitment processes. This set of individuals make their hiring decisions based on multiple information points collected throughout the application process.
+            </p>
+          </div>
         </div>
+
+        <hr class="u-no-margin--bottom" />
+        <div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
+          <div class="col-3 col-medium-3">
+            <p>
+              <strong>Bias mitigation</strong>
+            </p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Our written assessment is reviewed anonymously so that the grader cannot see any personal details associated with the submitter. This gives our candidates an opportunity to show what they can do on objective grounds, and removes any prejudice that may present itself at this stage.
+            </p>
+          </div>
+        </div>
+
+        <hr class="u-no-margin--bottom" />
+        <div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
+          <div class="col-3 col-medium-3">
+            <p>
+              <strong>Diverse viewpoints</strong>
+            </p>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              We are also committed to building diverse interview panels to ensure that we invite differing viewpoints to make a truly fair assessment, whilst allowing our candidates to feel comfortable during the process and have the opportunity to meet a broad range of our people during the recruitment process.
+            </p>
+          </div>
+        </div>
+
       </div>
-
-			<hr class="u-no-margin--bottom">
-      <div class="row p-strip--diversity u-no-padding--top u-no-padding--bottom">
-        <div class="col-3 col-medium-3">
-          <p><strong>Diverse viewpoints</strong></p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>We are also committed to building diverse interview panels to ensure that we invite differing viewpoints to make a truly fair assessment, whilst allowing our candidates to feel comfortable during the process and have the opportunity to meet a broad range of our people during the recruitment process.</p>
-        </div>
-      </div>
-
-  </div>
-  </div>
-</div>
-
-<div class="p-strip is-deep">
-  <div class="row">
-    <div class="col-9 col-start-large-4">
-    <h2>Interested in building an even more <br class="u-hide--small" />inclusive culture at Canonical?</h2>
-		<br class="u-hide--medium u-hide--small">
-		<h4><a href="/careers/all?filter=People">Join our People team</a></h4>
     </div>
   </div>
-</div>
+
+  <div class="p-strip is-deep">
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <h2>
+          Interested in building an even more
+          <br class="u-hide--small" />
+          inclusive culture at Canonical?
+        </h2>
+
+        <br class="u-hide--medium u-hide--small" />
+
+        <h4>
+          <a href="/careers/all?filter=People">Join our People team</a>
+        </h4>
+      </div>
+    </div>
+  </div>
 
 {% endblock %}

--- a/templates/careers/company-culture/identity.html
+++ b/templates/careers/company-culture/identity.html
@@ -1,82 +1,138 @@
-{% extends '/base_index.html' %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1_-EhhObUF8vl95CypcJEpFcMdvDU4N8ak9kCLvZMtyw{% endblock meta_copydoc %}
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1_-EhhObUF8vl95CypcJEpFcMdvDU4N8ak9kCLvZMtyw
+{% endblock meta_copydoc %}
 
 {% block title %}Personal identity at Canonical{% endblock %}
 
 {% block meta_description %}{% endblock %}
-{% block body_class %}is-paper{% endblock body_class %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
 {% block content %}
-<section class="p-strip is-shallow u-no-padding--bottom">
+  <section class="p-strip is-shallow u-no-padding--bottom">
     <div class="row--50-50 p-section">
       <div class="col">
-        <h1 class="p-heading--2"><strong>Personal identity <br/> at Canonical</strong></h1>
+        <h1 class="p-heading--2">
+          <strong>Personal identity
+            <br />
+          at Canonical</strong>
+        </h1>
       </div>
       <div class="col">
-        <p>At Canonical we believe your identity has no intrinsic bearing on your ability. As humans, we all have elements of our identity which we did not choose. Our name. Our skin colour. Our nationality of birth. Our sexuality. Our gender. We may be neurodiverse, or have a disability. Some of these attributes may not be obvious.</p>
-        <p> Whatever your identity, you are welcome as a colleague if you share our values, our mission, our work ethic and our skills.</p>
-        <p>We have many outstanding colleagues who represent a wide spectrum of humanity. We treasure their contributions, and we stand for their right to pursue their ambitions as equals in the company.</p>
-        <p>We explicitly choose to reject discriminatory views which link identity with ability. Those who espouse such views are unwelcome at Canonical.</p>
-        <p>We work as a global team to ensure this value is consistently true. We leave no grey areas for equivocation. We expect each and every member of the company to stand clearly behind this position, and to share the responsibility of removing those who undermine it.</p>
+        <p>
+          At Canonical we believe your identity has no intrinsic bearing on your ability. As humans, we all have elements of our identity which we did not choose. Our name. Our skin colour. Our nationality of birth. Our sexuality. Our gender. We may be neurodiverse, or have a disability. Some of these attributes may not be obvious.
+        </p>
+        <p>
+          Whatever your identity, you are welcome as a colleague if you share our values, our mission, our work ethic and our skills.
+        </p>
+        <p>
+          We have many outstanding colleagues who represent a wide spectrum of humanity. We treasure their contributions, and we stand for their right to pursue their ambitions as equals in the company.
+        </p>
+        <p>
+          We explicitly choose to reject discriminatory views which link identity with ability. Those who espouse such views are unwelcome at Canonical.
+        </p>
+        <p>
+          We work as a global team to ensure this value is consistently true. We leave no grey areas for equivocation. We expect each and every member of the company to stand clearly behind this position, and to share the responsibility of removing those who undermine it.
+        </p>
         <p>The Ubuntu Code of Conduct is a founding document for the company. It says:</p>
-        <div class="p-strip">        
+        <div class="p-strip">
           <div class="p-highlight--vertical">
-            <p class="p-heading--5">Ubuntu is about showing humanity to one another: the word itself captures the spirit of being human.</p>
-            <p>We want a productive, happy and agile community that can welcome new ideas in a complex field, improve every process every year, and foster collaboration between groups with very different needs, interests and skills.</p>
-            <p>We gain strength from diversity, and actively seek participation from those who enhance it. This code of conduct exists to ensure that diverse groups collaborate to mutual advantage and enjoyment. We will challenge prejudice that could jeopardise the participation of any person in the project.</p>
+            <p class="p-heading--5">
+              Ubuntu is about showing humanity to one another: the word itself captures the spirit of being human.
+            </p>
+            <p>
+              We want a productive, happy and agile community that can welcome new ideas in a complex field, improve every process every year, and foster collaboration between groups with very different needs, interests and skills.
+            </p>
+            <p>
+              We gain strength from diversity, and actively seek participation from those who enhance it. This code of conduct exists to ensure that diverse groups collaborate to mutual advantage and enjoyment. We will challenge prejudice that could jeopardise the participation of any person in the project.
+            </p>
           </div>
         </div>
         <p>This statement is as true of Canonical as it is of the Ubuntu project.</p>
-        <p>We did not set out to create the world’s most profitable software company at any cost. We set out to bring the benefits of open source to all humanity by making it easier and cheaper to consume and easier to improve, to level the playing field for innovators, entrepreneurs, students and digital consumers all across the globe.</p>
-        <p>We also set out to create a productive work environment for those who want to contribute to the open source revolution we are creating &ndash; living and working wherever they prefer, regardless of their identity. We continue to seek ways to improve on these fronts.</p>
+        <p>
+          We did not set out to create the world’s most profitable software company at any cost. We set out to bring the benefits of open source to all humanity by making it easier and cheaper to consume and easier to improve, to level the playing field for innovators, entrepreneurs, students and digital consumers all across the globe.
+        </p>
+        <p>
+          We also set out to create a productive work environment for those who want to contribute to the open source revolution we are creating &ndash; living and working wherever they prefer, regardless of their identity. We continue to seek ways to improve on these fronts.
+        </p>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
+  <section class="p-section">
     <div class="row--50-50">
-      <hr class="p-rule"/>
+      <hr class="p-rule" />
       <div class="col">
         <h2>Impact on our hiring process</h2>
       </div>
       <div class="col">
-        <p>As a candidate to join the company, we will work hard to assess your relevant ability, minimising bias associated with identity.</p>
-        <p>Because we are open to hiring in every corner of the world, we must have a hiring process that does not depend too much on understanding local context. A resume is difficult to interpret without context &ndash; is that a good university trajectory, or a poor one? Was that a competitive placement, or not? We want to hire the best from every corner of the globe, and we cannot possibly have local context across the board.</p>
-        <p>In addition, underlying patterns of prejudice and privilege mean that people who come from the same place with different identities may not have had the same opportunity to reflect their ability in their resume. We should not amplify and reinforce local prejudice through our own hiring decisions.</p>
-        <p>For these reasons, we expect hiring leads to be more willing to move forward candidates from under-represented groups into the standard assessment stage, which is anonymous. This gives those candidates an opportunity to show what they can do on objective grounds, rather than relying on our own flawed ability to interpret a resume.</p>
-        <p>Many candidates who were previously rejected based on their resumes applying for a team, do very well in this assessment process and ultimately get strong positive feedback from that team during interviews.</p>
+        <p>
+          As a candidate to join the company, we will work hard to assess your relevant ability, minimising bias associated with identity.
+        </p>
+        <p>
+          Because we are open to hiring in every corner of the world, we must have a hiring process that does not depend too much on understanding local context. A resume is difficult to interpret without context &ndash; is that a good university trajectory, or a poor one? Was that a competitive placement, or not? We want to hire the best from every corner of the globe, and we cannot possibly have local context across the board.
+        </p>
+        <p>
+          In addition, underlying patterns of prejudice and privilege mean that people who come from the same place with different identities may not have had the same opportunity to reflect their ability in their resume. We should not amplify and reinforce local prejudice through our own hiring decisions.
+        </p>
+        <p>
+          For these reasons, we expect hiring leads to be more willing to move forward candidates from under-represented groups into the standard assessment stage, which is anonymous. This gives those candidates an opportunity to show what they can do on objective grounds, rather than relying on our own flawed ability to interpret a resume.
+        </p>
+        <p>
+          Many candidates who were previously rejected based on their resumes applying for a team, do very well in this assessment process and ultimately get strong positive feedback from that team during interviews.
+        </p>
       </div>
     </div>
-</section>
+  </section>
 
-<section class="p-section">
+  <section class="p-section">
     <div class="row--50-50">
-      <hr class="p-rule"/>
+      <hr class="p-rule" />
       <div class="col">
         <h2>Proactive appointments</h2>
       </div>
       <div class="col">
         <p>We must attract the best colleagues from around the world.</p>
-        <p>‘Best’ is always a complex calculation that weighs many factors. People are not mechanical &ndash; they have strengths and weaknesses, and we weigh those up in making hiring decisions. Do we hire a developer with more experience in the language we use? Or a better track record of documenting their work? Or more familiarity with open source and community? Or a better track record of learning quickly? We often have candidates who are the best in one of those elements but not all of them. The ‘best’ candidate is usually the one who will round out and strengthen the team.</p>
-        <p>When making appointments, we often consider the impact a choice might have on future applicants and the flow of talent into the business. We might rationalise hiring a well known specialist in a particular field on the grounds that other outstanding but less well known people will be attracted to the company to work with them.</p>
-        <p>It is proven that candidates from under-represented groups feel more confident in pursuing roles in environments where they see others like them being successful. For this reason it is logical to consider the impact that an appointment might have in reassuring and attracting exceptional talent &ndash; the best talent &ndash; from that group.</p>
-        <p>We have no demographic quotas to fill, and every single appointment will be made individually on merit. In order to attract talent from every group, we strive to reflect the best of every group in our company.</p>
+        <p>
+          ‘Best’ is always a complex calculation that weighs many factors. People are not mechanical &ndash; they have strengths and weaknesses, and we weigh those up in making hiring decisions. Do we hire a developer with more experience in the language we use? Or a better track record of documenting their work? Or more familiarity with open source and community? Or a better track record of learning quickly? We often have candidates who are the best in one of those elements but not all of them. The ‘best’ candidate is usually the one who will round out and strengthen the team.
+        </p>
+        <p>
+          When making appointments, we often consider the impact a choice might have on future applicants and the flow of talent into the business. We might rationalise hiring a well known specialist in a particular field on the grounds that other outstanding but less well known people will be attracted to the company to work with them.
+        </p>
+        <p>
+          It is proven that candidates from under-represented groups feel more confident in pursuing roles in environments where they see others like them being successful. For this reason it is logical to consider the impact that an appointment might have in reassuring and attracting exceptional talent &ndash; the best talent &ndash; from that group.
+        </p>
+        <p>
+          We have no demographic quotas to fill, and every single appointment will be made individually on merit. In order to attract talent from every group, we strive to reflect the best of every group in our company.
+        </p>
       </div>
     </div>
-</section>
+  </section>
 
-<section class="p-section--deep">
+  <section class="p-section--deep">
     <div class="row--50-50">
-      <hr class="p-rule"/>
+      <hr class="p-rule" />
       <div class="col">
         <h2>On language at work</h2>
       </div>
       <div class="col">
-        <p>Generalisations and stereotypes are common in everyday culture and conversation &ndash; whether those are observations on enthusiastic British queuing or Irish charm.</p>
-        <p>We have all been the subject of teasing on one basis or another, and at a human level it’s healthy to learn to be gracious in the face of it. All the same, “I was only joking” is not a defence when offence has been given, and in the workplace we must be professionally mindful of the impact such statements have on the confidence and enjoyment of others. To dismiss a decision or a point of view or a perspective on the grounds of an element of identity is very likely unacceptable in the workplace. In many cases &ndash; gender, race, sexuality, religion &ndash; it is  absolutely unacceptable. The fine line between those cases is not worth walking on.</p>
-        <p>Regardless of intention, if someone causes offence through an identity generalisation, then they are in the wrong. All of us will do better to avoid this risk entirely, and no person, regardless of seniority, will be allowed to ignore this with impunity.</p>
-        <p>It is not acceptable to claim that a given prejudice is normal in one’s culture. We offer opportunities globally on the condition of adherence to our chosen values. We will not accept that a statement was a ‘poor attempt at humour’. We also do not entertain intellectual debate on the science of demographic ability &ndash; our position is a choice to treat every person as if they have the potential to be successful, and to focus on actual evidence in our decisions.</p>
+        <p>
+          Generalisations and stereotypes are common in everyday culture and conversation &ndash; whether those are observations on enthusiastic British queuing or Irish charm.
+        </p>
+        <p>
+          We have all been the subject of teasing on one basis or another, and at a human level it’s healthy to learn to be gracious in the face of it. All the same, “I was only joking” is not a defence when offence has been given, and in the workplace we must be professionally mindful of the impact such statements have on the confidence and enjoyment of others. To dismiss a decision or a point of view or a perspective on the grounds of an element of identity is very likely unacceptable in the workplace. In many cases &ndash; gender, race, sexuality, religion &ndash; it is  absolutely unacceptable. The fine line between those cases is not worth walking on.
+        </p>
+        <p>
+          Regardless of intention, if someone causes offence through an identity generalisation, then they are in the wrong. All of us will do better to avoid this risk entirely, and no person, regardless of seniority, will be allowed to ignore this with impunity.
+        </p>
+        <p>
+          It is not acceptable to claim that a given prejudice is normal in one’s culture. We offer opportunities globally on the condition of adherence to our chosen values. We will not accept that a statement was a ‘poor attempt at humour’. We also do not entertain intellectual debate on the science of demographic ability &ndash; our position is a choice to treat every person as if they have the potential to be successful, and to focus on actual evidence in our decisions.
+        </p>
       </div>
     </div>
-</section>
+  </section>
 {% endblock %}

--- a/templates/careers/company-culture/index.html
+++ b/templates/careers/company-culture/index.html
@@ -1,60 +1,86 @@
-{% extends '/base_index.html' %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1PAeP_ZO4JzSBCi-fRp6F7SYtSSRY-4DcWLUf9HJaMxs/edit{% endblock meta_copydoc %}
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1PAeP_ZO4JzSBCi-fRp6F7SYtSSRY-4DcWLUf9HJaMxs/edit
+{% endblock meta_copydoc %}
 
 {% block title %}Company Culture | Careers{% endblock %}
 
-{% block meta_description %}Canonical's work culture is built on trust and enriched by our commitment to excellence. If you value teamwork and are committed to being a good counterpart to colleagues around the world, you will love working here.{% endblock %}
-
+{% block meta_description %}
+  Canonical's work culture is built on trust and enriched by our commitment to excellence. If you value teamwork and are committed to being a good counterpart to colleagues around the world, you will love working here.
+{% endblock %}
 
 {% block content %}
-<div class="p-strip">
-  <div class="row">
-    <div class="col-start-large-4 col-8">
-      <h1 class="p-heading--2 u-no-margin--bottom"><strong>Company culture</strong></h1>
-      <p class="p-heading--2">We believe that talent is evenly distributed around the world.  Diversity is part of our strength. What unifies us isn’t our background,  it’s our mission to amplify open source.</p>
+  <div class="p-strip">
+    <div class="row">
+      <div class="col-start-large-4 col-8">
+        <h1 class="p-heading--2 u-no-margin--bottom">
+          <strong>Company culture</strong>
+        </h1>
+        <p class="p-heading--2">
+          We believe that talent is evenly distributed around the world.  Diversity is part of our strength. What unifies us isn’t our background,  it’s our mission to amplify open source.
+        </p>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="p-strip u-no-padding--top">
-  <div class="u-fixed-width">
-    <hr class="u-no-margin--bottom u-hide--medium u-hide--small">
-  </div>
-  <div class="row">
-    <div class="col-medium-3 col-3">
-      <h3 class="p-muted-heading">We're Canonical</h3>
+  <div class="p-strip u-no-padding--top">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom u-hide--medium u-hide--small" />
     </div>
-    <div class="col-medium-6 col-9">
-      <hr class="u-no-margin--bottom u-hide--large u-hide--small">
-      <div class="row">
-        <div class="col-medium-2 col-3">
-          <h4 class="p-heading--2 u-data-border--top"><strong>1,000+</strong><br>People</h4>
-        </div>
-        <div class="col-medium-2 col-3">
-          <h4 class="p-heading--2 u-data-border--top"><strong>70&plus;</strong><br>Countries</h4>
-        </div>
-        <div class="col-medium-2 col-3">
-          <h4 class="p-heading--2 u-data-border--top"><strong>75&plus;</strong><br>Nationalities</h4>
-        </div>
-        <div class="col-medium-6 col-9">
-          <p>The future is already here, as open source. Canonical delivers it to the world. We bring the benefits of open source to more people and more industries than ever before. This means bringing new work opportunities to people regardless of their location too.</p>
+    <div class="row">
+      <div class="col-medium-3 col-3">
+        <h3 class="p-muted-heading">We're Canonical</h3>
+      </div>
+      <div class="col-medium-6 col-9">
+        <hr class="u-no-margin--bottom u-hide--large u-hide--small" />
+        <div class="row">
+          <div class="col-medium-2 col-3">
+            <h4 class="p-heading--2 u-data-border--top">
+              <strong>1,000+</strong>
+              <br />
+              People
+            </h4>
+          </div>
+          <div class="col-medium-2 col-3">
+            <h4 class="p-heading--2 u-data-border--top">
+              <strong>70&plus;</strong>
+              <br />
+              Countries
+            </h4>
+          </div>
+          <div class="col-medium-2 col-3">
+            <h4 class="p-heading--2 u-data-border--top">
+              <strong>75&plus;</strong>
+              <br />
+              Nationalities
+            </h4>
+          </div>
+          <div class="col-medium-6 col-9">
+            <p>
+              The future is already here, as open source. Canonical delivers it to the world. We bring the benefits of open source to more people and more industries than ever before. This means bringing new work opportunities to people regardless of their location too.
+            </p>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
-<div class="p-strip u-no-padding--top">
-  <div class="u-fixed-width">
-    <hr class="u-no-margin--bottom">
-  </div>
-  <div class="row">
-    <div class="col-medium-2 col-3">
-      <h3 class="p-muted-heading">Fully distributed <br class="u-hide--small" />since 2004</h3>
+  <div class="p-strip u-no-padding--top">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom" />
     </div>
-    <div class="col-medium-4 col-9">
-      <div class="row">
-        <div class="col-3 col-medium-1 col-small-1">
-          {{
+    <div class="row">
+      <div class="col-medium-2 col-3">
+        <h3 class="p-muted-heading">
+          Fully distributed
+          <br class="u-hide--small" />
+          since 2004
+        </h3>
+      </div>
+      <div class="col-medium-4 col-9">
+        <div class="row">
+          <div class="col-3 col-medium-1 col-small-1">
+            {{
             image (
             url="https://assets.ubuntu.com/v1/dc07a3ff-Canonical2022_092-1.jpg",
             alt="",
@@ -64,34 +90,41 @@
             loading="lazy",
             attrs={"class": "u-image-margin--top"}
             ) | safe
-          }}
-        </div>
-        <div class="col-6 col-medium-3 col-small-3">
-          <blockquote class="p-pull-quote--small u-no-margin--top u-stack u-no-padding--left">
-            <h4><em>"We're a remote-first international company. <br class="u-hide--small">
-              I get to work every day with people from all over the world, which is just amazing".</em></h4>
-            <span class="p-pull-quote__citation u-no-margin--bottom"><strong>Ken VanDine</strong><br /> Engineering Manager, Ubuntu Desktop</span>
-          </blockquote>
+            }}
+          </div>
+          <div class="col-6 col-medium-3 col-small-3">
+            <blockquote class="p-pull-quote--small u-no-margin--top u-stack u-no-padding--left">
+              <h4>
+                <em>"We're a remote-first international company.
+                  <br class="u-hide--small" />
+                I get to work every day with people from all over the world, which is just amazing".</em>
+              </h4>
+              <span class="p-pull-quote__citation u-no-margin--bottom"><strong>Ken VanDine</strong>
+                <br />
+              Engineering Manager, Ubuntu Desktop</span>
+            </blockquote>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
-<div class="p-strip u-no-padding--top">
-  <div class="u-fixed-width">
-    <hr class="u-no-margin--bottom">
-  </div>
-  <div class="row">
-    <div class="col-medium-2 col-3">
-      <h3 class="p-muted-heading">Built on trust</h3>
+  <div class="p-strip u-no-padding--top">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom" />
     </div>
-    <div class="col-medium-4 col-9">
-      <div class="p-strip is-shallow u-no-padding--top">
-        <p>As a remote-first organisation, trust is our currency. We hire and invest in people who are organised, self-driven and effective. If you value teamwork and are committed to being a good counterpart to colleagues around the world, you will love working here.</p>
+    <div class="row">
+      <div class="col-medium-2 col-3">
+        <h3 class="p-muted-heading">Built on trust</h3>
       </div>
-      <div class="row">
-        <div class="col-3 col-medium-1 col-small-1">
-          {{
+      <div class="col-medium-4 col-9">
+        <div class="p-strip is-shallow u-no-padding--top">
+          <p>
+            As a remote-first organisation, trust is our currency. We hire and invest in people who are organised, self-driven and effective. If you value teamwork and are committed to being a good counterpart to colleagues around the world, you will love working here.
+          </p>
+        </div>
+        <div class="row">
+          <div class="col-3 col-medium-1 col-small-1">
+            {{
             image (
             url="https://assets.ubuntu.com/v1/ba5ab6d7-thibaut.jpg",
             alt="",
@@ -101,35 +134,43 @@
             loading="lazy",
             attrs={"class": "u-image-margin--top"}
             ) | safe
-          }}
-        </div>
-        <div class="col-6 col-medium-3 col-small-3">
-          <blockquote class="p-pull-quote--small u-no-margin--top u-stack u-no-padding--left">
-            <h4><em>"Our organisation trusts people. At Canonical, you have the space to innovate and deliver on excellence".</em></h4>
-            <span class="p-pull-quote__citation u-no-margin--bottom"><strong>Thibaut Rouffineau</strong><br /> VP of Marketing</span>
-          </blockquote>
+            }}
+          </div>
+          <div class="col-6 col-medium-3 col-small-3">
+            <blockquote class="p-pull-quote--small u-no-margin--top u-stack u-no-padding--left">
+              <h4>
+                <em>"Our organisation trusts people. At Canonical, you have the space to innovate and deliver on excellence".</em>
+              </h4>
+              <span class="p-pull-quote__citation u-no-margin--bottom"><strong>Thibaut Rouffineau</strong>
+                <br />
+              VP of Marketing</span>
+            </blockquote>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
-<div class="p-strip u-no-padding--top">
-  <div class="u-fixed-width">
-    <hr class="u-no-margin--bottom">
-  </div>
-  <div class="row">
-    <div class="col-medium-2 col-3">
-      <h3 class="p-muted-heading">Committed <br class="u-hide--small">
-        to excellence</h3>
+  <div class="p-strip u-no-padding--top">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom" />
     </div>
-    <div class="col-medium-4 col-9">
-      <div class="p-strip is-shallow u-no-padding--top">
-        <p>We aspire to lead on the global stage. Most of us are avid students of greatness &dash; we are interested in how the latest technologies work, how the best organisations work and how the smartest teams collaborate. We aim to hold our own in that crowd. We pursue engineering excellence and love to engineer excellence in all aspects of our work. From releasing the world's most popular Linux reliably to trailblazing <a href="/documentation">documentation</a>.
-        </p>
+    <div class="row">
+      <div class="col-medium-2 col-3">
+        <h3 class="p-muted-heading">
+          Committed
+          <br class="u-hide--small" />
+          to excellence
+        </h3>
       </div>
-      <div class="row">
-        <div class="col-3 col-medium-1 col-small-1">
-          {{
+      <div class="col-medium-4 col-9">
+        <div class="p-strip is-shallow u-no-padding--top">
+          <p>
+            We aspire to lead on the global stage. Most of us are avid students of greatness &dash; we are interested in how the latest technologies work, how the best organisations work and how the smartest teams collaborate. We aim to hold our own in that crowd. We pursue engineering excellence and love to engineer excellence in all aspects of our work. From releasing the world's most popular Linux reliably to trailblazing <a href="/documentation">documentation</a>.
+          </p>
+        </div>
+        <div class="row">
+          <div class="col-3 col-medium-1 col-small-1">
+            {{
             image (
             url="https://assets.ubuntu.com/v1/6f044836-alison.jpg",
             alt="",
@@ -139,76 +180,101 @@
             loading="lazy",
             attrs={"class": "u-image-margin--top"}
             ) | safe
-          }}
-        </div>
-        <div class="col-6 col-medium-3 col-small-3">
-          <blockquote class="p-pull-quote--small u-no-margin--top u-stack u-no-padding--left">
-            <h4><em>"This is a company where intelligence and learning are<br class="u-hide--large u-hide--medium"> highly valued".</em></h4>
-            <span class="p-pull-quote__citation u-no-margin--bottom"><strong>Alyson Richens</strong><br /> Customer Success Manager</span>
-          </blockquote>
+            }}
+          </div>
+          <div class="col-6 col-medium-3 col-small-3">
+            <blockquote class="p-pull-quote--small u-no-margin--top u-stack u-no-padding--left">
+              <h4>
+                <em>"This is a company where intelligence and learning are
+                  <br class="u-hide--large u-hide--medium" />
+                highly valued".</em>
+              </h4>
+              <span class="p-pull-quote__citation u-no-margin--bottom"><strong>Alyson Richens</strong>
+                <br />
+              Customer Success Manager</span>
+            </blockquote>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
-<div class="p-strip--light is-deep">
-  <div class="row">
-    <div class="col-9 col-start-large-4">
-    <h2>What kind of excellent are you?
-      <br class="u-hide--medium u-hide--small">
-       <a href="/careers/career-explorer">Explore careers</a>
-    </h2>
+  <div class="p-strip--light is-deep">
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <h2>
+          What kind of excellent are you?
+          <br class="u-hide--medium u-hide--small" />
+          <a href="/careers/career-explorer">Explore careers</a>
+        </h2>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="p-strip">
-  <div class="u-fixed-width">
-    <hr class="u-no-margin--bottom">
-  </div>
-  <div class="row">
-    <div class="col-3 col-medium-2">
-      <h3 class="p-muted-heading">Life at Canonical</h3>
+  <div class="p-strip">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom" />
     </div>
-    <div class="col-9 col-medium-10">
-      <div class="row p-strip u-no-padding--top">
-        <div class="col-3 col-medium-3">
-          <h2><a href="/careers/company-culture/remote-work">Remote work</a></h2>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>We are remote but we meet each other at least twice a year during in-person sprints. Find out how we collaborate.</p>
-        </div>
+    <div class="row">
+      <div class="col-3 col-medium-2">
+        <h3 class="p-muted-heading">Life at Canonical</h3>
       </div>
-      <hr class="u-no-margin--bottom">
-      <div class="row p-strip u-no-padding--top">
-        <div class="col-3 col-medium-3">
-          <h2><a href="/careers/diversity">Diversity <br class="u-hide--small">and hiring</a></h2>
+      <div class="col-9 col-medium-10">
+        <div class="row p-strip u-no-padding--top">
+          <div class="col-3 col-medium-3">
+            <h2>
+              <a href="/careers/company-culture/remote-work">Remote work</a>
+            </h2>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              We are remote but we meet each other at least twice a year during in-person sprints. Find out how we collaborate.
+            </p>
+          </div>
         </div>
-        <div class="col-6 col-medium-3">
-          <p>We believe that talent is evenly distributed around the world. No matter where you were born, what you look like or how you like to dress, we will give your application fair consideration.</p>
+        <hr class="u-no-margin--bottom" />
+        <div class="row p-strip u-no-padding--top">
+          <div class="col-3 col-medium-3">
+            <h2>
+              <a href="/careers/diversity">Diversity
+                <br class="u-hide--small" />
+              and hiring</a>
+            </h2>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              We believe that talent is evenly distributed around the world. No matter where you were born, what you look like or how you like to dress, we will give your application fair consideration.
+            </p>
+          </div>
         </div>
-      </div>
-      <hr class="u-no-margin--bottom">
+        <hr class="u-no-margin--bottom" />
 
-      <div class="row p-strip u-no-padding--top">
-        <div class="col-3 col-medium-3">
-          <h2><a href="/careers/progression">Progression</a></h2>
+        <div class="row p-strip u-no-padding--top">
+          <div class="col-3 col-medium-3">
+            <h2>
+              <a href="/careers/progression">Progression</a>
+            </h2>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Your career at Canonical can progress in many ways. We celebrate growth in level of responsibility, interests and depth of expertise. We encourage colleagues to find their passion and invest in that.
+            </p>
+          </div>
         </div>
-        <div class="col-6 col-medium-3">
-          <p>Your career at Canonical can progress in many ways. We celebrate growth in level of responsibility, interests and depth of expertise. We encourage colleagues to find their passion and invest in that.</p>
+        <hr class="u-no-margin--bottom" />
+        <div class="row p-strip u-no-padding--top">
+          <div class="col-3 col-medium-3">
+            <h2>
+              <a href="/careers/sustainability">Sustainability</a>
+            </h2>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              We know our work and our products have an environmental impact.  Optimising our products and operations to minimise our impact is important to us.
+            </p>
+          </div>
         </div>
       </div>
-      <hr class="u-no-margin--bottom">
-      <div class="row p-strip u-no-padding--top">
-        <div class="col-3 col-medium-3">
-          <h2><a href="/careers/sustainability">Sustainability</a></h2>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>We know our work and our products have an environmental impact.  Optimising our products and operations to minimise our impact is important to us.</p>
-        </div>
-      </div>
+    </div>
   </div>
-</div>
-</div>
 
 {% endblock %}

--- a/templates/careers/company-culture/progression.html
+++ b/templates/careers/company-culture/progression.html
@@ -1,73 +1,116 @@
-{% extends '/base_index.html' %}
+{% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1NqSg2dt5wbmSY6IwWKo9gbxzOuyKL_gUZnFlAux1RU8{% endblock meta_copydoc %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1NqSg2dt5wbmSY6IwWKo9gbxzOuyKL_gUZnFlAux1RU8
+{% endblock meta_copydoc %}
 
 {% block title %}Progression | Careers{% endblock %}
 
-{% block meta_description %}Canonical prefers internal promotion and encourages high-performing colleagues to pursue diverse roles at the company over the course of their career, to develop a well-rounded perspective.{% endblock %}
+{% block meta_description %}
+  Canonical prefers internal promotion and encourages high-performing colleagues to pursue diverse roles at the company over the course of their career, to develop a well-rounded perspective.
+{% endblock %}
 
 {% block content %}
-<div class="p-strip--careers-progression u-no-padding--top">
-  <div class="u-fixed-width">
-    <nav class="p-breadcrumbs" aria-label="Breadcrumbs">
-      <ol class="p-breadcrumbs__items p-text--x-small-capitalised">
-          <li class="p-breadcrumbs__item"><a class="p-link is-dark" href="/careers">Careers</a></li>
-          <li class="p-breadcrumbs__item"><a class="p-link is-dark" href="/careers/company-culture">Company culture</a></li>
-          <li class="p-breadcrumbs__item">Progression</li>
-      </ol>
-    </nav>
-    <h1 class="p-text--x-small-capitalised u-hide">Careers</h1>
-    <hr class="p-rule is-dark">
-  </div>
-</div>
-<div class="u-fix-overflow">
-  <section class="p-strip--careers-progression is-hero">
+  <div class="p-strip--careers-progression u-no-padding--top">
     <div class="u-fixed-width">
-      <h1 class="p-strip--hero-title">
-        <span class="u-animation--slide-right" style="animation-delay: 0.25s">We hire for talent,</span>
-        <span class="u-animation--slide-right u-hide--small" style="animation-delay: 0.50s">passion, and work ethic</span>
-        <!-- Mobile view -->
-        <span class="u-animation--slide-right u-hide--medium u-hide--large" style="animation-delay: 0.50s">passion, and work</span>
-        <span class="u-animation--slide-right u-hide--medium u-hide--large" style="animation-delay: 0.50s">ethic</span>
-      </h1>
+      <nav class="p-breadcrumbs" aria-label="Breadcrumbs">
+        <ol class="p-breadcrumbs__items p-text--x-small-capitalised">
+          <li class="p-breadcrumbs__item">
+            <a class="p-link is-dark" href="/careers">Careers</a>
+          </li>
+          <li class="p-breadcrumbs__item">
+            <a class="p-link is-dark" href="/careers/company-culture">Company culture</a>
+          </li>
+          <li class="p-breadcrumbs__item">Progression</li>
+        </ol>
+      </nav>
+      <h1 class="p-text--x-small-capitalised u-hide">Careers</h1>
+      <hr class="p-rule is-dark" />
     </div>
-    <div class="u-fixed-width u-extra-space">
-      <hr class="p-careers-progression-separator u-animation--slide-right-separator"/>
-      <p class="u-animation--slide-from-bottom" style="max-width: 373px; animation-delay: 1s; animation-duration: 0.25s;">Your career at Canonical can progress in many ways.</p>
-    </div>
-    <div class="u-fixed-width u-hug-right__container">
-      <video id="introductory-video" class="u-hug-right__element" aria-hidden="true" autoplay muted loop controls>
-        <source src="https://assets.ubuntu.com/v1/fe470e29-Generic Video.mp4" type="video/mp4">
-      </video>
-    </div>
-  </section>
-
-  <section class="p-strip">
-    <div class="row">
-      <div class="col-4">
-        <h2>We value people who love to learn</h2>
-        <p>Not just how to be better engineers but how to be better speakers, how to be better designers, better organisers, better partners, and better vendors.</p>
+  </div>
+  <div class="u-fix-overflow">
+    <section class="p-strip--careers-progression is-hero">
+      <div class="u-fixed-width">
+        <h1 class="p-strip--hero-title">
+          <span class="u-animation--slide-right" style="animation-delay: 0.25s">We hire for talent,</span>
+          <span class="u-animation--slide-right u-hide--small"
+                style="animation-delay: 0.50s">passion, and work ethic</span>
+          <!-- Mobile view -->
+          <span class="u-animation--slide-right u-hide--medium u-hide--large"
+                style="animation-delay: 0.50s">passion, and work</span>
+          <span class="u-animation--slide-right u-hide--medium u-hide--large"
+                style="animation-delay: 0.50s">ethic</span>
+        </h1>
       </div>
-      <div class="col-8 p-collage__container">
-        <img class="p-collage--1" data-animation="u-animation--slide-from-bottom" src="https://assets.ubuntu.com/v1/5b3cb508-Image_1.png" alt="Talks" />
-        <img class="p-collage--2" data-animation="u-animation--slide-from-bottom" src="https://assets.ubuntu.com/v1/ae1b866a-Image_2.jpg" alt="Employees working together on same laptop" style="animation-delay: 0.25s"/>
-        <img class="p-collage--3" data-animation="u-animation--slide-from-bottom" src="https://assets.ubuntu.com/v1/90651b21-Image_3.png" alt="Employees working together on different laptops" style="animation-delay: 0.50s" />
-        <img class="p-collage--4" data-animation="u-animation--slide-from-bottom" src="https://assets.ubuntu.com/v1/c707c1cb-Image 4.png" alt="Employee looking at her coworker while smiling" style="animation-delay: 0.75s" />
+      <div class="u-fixed-width u-extra-space">
+        <hr class="p-careers-progression-separator u-animation--slide-right-separator" />
+        <p class="u-animation--slide-from-bottom"
+           style="max-width: 373px;
+                  animation-delay: 1s;
+                  animation-duration: 0.25s">Your career at Canonical can progress in many ways.</p>
       </div>
-    </div>
-  </section>
+      <div class="u-fixed-width u-hug-right__container">
+        <video id="introductory-video"
+               class="u-hug-right__element"
+               aria-hidden="true"
+               autoplay
+               muted
+               loop
+               controls>
+          <source src="https://assets.ubuntu.com/v1/fe470e29-Generic Video.mp4"
+                  type="video/mp4" />
+        </video>
+      </div>
+    </section>
 
-  <section class="p-strip--careers-progression p-careers-progression__dividers">
-    <div class="row" style="border-left: 1px solid rgba(255, 255, 255, 0.25); padding-left: 1.375rem;">
-      <div class="col-4 col-medium-3" data-animation="u-animation--slide-from-bottom">
-        <div class="p-careers-progression-roles">
-          <div>
-            <h2>Explore diverse roles</h2>
-            <p>We encourage team members to experience diverse roles at Canonical over the course of their career to build deep awareness of company culture,  establish best practices in leadership and grow their technical expertise.</p>
-            <p>In fact, flexibility in exploring new roles is one of main reasons people love to work here.</p>
-          </div>
-          <div class="p-strip--careers-progression u-no-padding--bottom">
-            {{
+    <section class="p-strip">
+      <div class="row">
+        <div class="col-4">
+          <h2>We value people who love to learn</h2>
+          <p>
+            Not just how to be better engineers but how to be better speakers, how to be better designers, better organisers, better partners, and better vendors.
+          </p>
+        </div>
+        <div class="col-8 p-collage__container">
+          <img class="p-collage--1"
+               data-animation="u-animation--slide-from-bottom"
+               src="https://assets.ubuntu.com/v1/5b3cb508-Image_1.png"
+               alt="Talks" />
+          <img class="p-collage--2"
+               data-animation="u-animation--slide-from-bottom"
+               src="https://assets.ubuntu.com/v1/ae1b866a-Image_2.jpg"
+               alt="Employees working together on same laptop"
+               style="animation-delay: 0.25s" />
+          <img class="p-collage--3"
+               data-animation="u-animation--slide-from-bottom"
+               src="https://assets.ubuntu.com/v1/90651b21-Image_3.png"
+               alt="Employees working together on different laptops"
+               style="animation-delay: 0.50s" />
+          <img class="p-collage--4"
+               data-animation="u-animation--slide-from-bottom"
+               src="https://assets.ubuntu.com/v1/c707c1cb-Image 4.png"
+               alt="Employee looking at her coworker while smiling"
+               style="animation-delay: 0.75s" />
+        </div>
+      </div>
+    </section>
+
+    <section class="p-strip--careers-progression p-careers-progression__dividers">
+      <div class="row"
+           style="border-left: 1px solid rgba(255, 255, 255, 0.25);
+                  padding-left: 1.375rem">
+        <div class="col-4 col-medium-3"
+             data-animation="u-animation--slide-from-bottom">
+          <div class="p-careers-progression-roles">
+            <div>
+              <h2>Explore diverse roles</h2>
+              <p>
+                We encourage team members to experience diverse roles at Canonical over the course of their career to build deep awareness of company culture,  establish best practices in leadership and grow their technical expertise.
+              </p>
+              <p>In fact, flexibility in exploring new roles is one of main reasons people love to work here.</p>
+            </div>
+            <div class="p-strip--careers-progression u-no-padding--bottom">
+              {{
               image (
               url="https://assets.ubuntu.com/v1/0e6df09f-image-1.png",
               alt="",
@@ -76,19 +119,25 @@
               hi_def=True,
               loading="lazy"
               ) | safe
-            }}
+              }}
+            </div>
           </div>
         </div>
-      </div>
-      <div class="col-4 col-medium-3" style="animation-delay: 0.25s" data-animation="u-animation--slide-from-bottom">
-        <div class="p-careers-progression-roles">
-          <div>
-            <h2>Finding your passion</h2>
-            <p>We also explicitly encourage team members to find their passion and invest in that, recognising the benefit to your team and the company when you become a more effective team player.</p>
-            <p>We offer a generous annual allowance in support of this effort so that individuals are able to invest in their own learning and development, and we partner with high-quality content providers to make sure our people get access to the best possible training materials, and the time to benefit from them.</p>
-          </div>
-          <div class="p-strip--careers-progression u-no-padding--bottom">
-            {{
+        <div class="col-4 col-medium-3"
+             style="animation-delay: 0.25s"
+             data-animation="u-animation--slide-from-bottom">
+          <div class="p-careers-progression-roles">
+            <div>
+              <h2>Finding your passion</h2>
+              <p>
+                We also explicitly encourage team members to find their passion and invest in that, recognising the benefit to your team and the company when you become a more effective team player.
+              </p>
+              <p>
+                We offer a generous annual allowance in support of this effort so that individuals are able to invest in their own learning and development, and we partner with high-quality content providers to make sure our people get access to the best possible training materials, and the time to benefit from them.
+              </p>
+            </div>
+            <div class="p-strip--careers-progression u-no-padding--bottom">
+              {{
               image (
               url="https://assets.ubuntu.com/v1/11c97848-image-2.png",
               alt="",
@@ -98,18 +147,22 @@
               loading="lazy",
               attrs={"style": "width: 100%"}
               ) | safe
-            }}
+              }}
+            </div>
           </div>
         </div>
-      </div>
-      <div class="col-4 col-medium-3" data-animation="u-animation--slide-from-bottom" style="animation-delay: 0.50s">
-        <div class="p-careers-progression-roles" style="border-right: 0;">
-          <div>
-            <h2>Path to management</h2>
-            <p>Management is important to us and we like to develop those skills in people who enjoy it. Being a manager at Canonical offers the chance to lead some of the brightest people in tech to design, build, sell and support a growing range of technology products at every level of the stack.</p>
-          </div>
-          <div class="p-strip--careers-progression u-no-padding--bottom">
-            {{
+        <div class="col-4 col-medium-3"
+             data-animation="u-animation--slide-from-bottom"
+             style="animation-delay: 0.50s">
+          <div class="p-careers-progression-roles" style="border-right: 0;">
+            <div>
+              <h2>Path to management</h2>
+              <p>
+                Management is important to us and we like to develop those skills in people who enjoy it. Being a manager at Canonical offers the chance to lead some of the brightest people in tech to design, build, sell and support a growing range of technology products at every level of the stack.
+              </p>
+            </div>
+            <div class="p-strip--careers-progression u-no-padding--bottom">
+              {{
               image (
               url="https://assets.ubuntu.com/v1/11e3f88f-image-3.png",
               alt="",
@@ -119,85 +172,107 @@
               loading="lazy",
               attrs={"style": "width: 100%"}
               ) | safe
-            }}
+              }}
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-
-  <section class="p-strip u-hug-right__container">
-    <div class="p-careers-progression--opensource u-hug-right__element">
-      <div class="p-stack">
-        <div class="p-careers-progression-carousel">
-          <div class="p-careers-progression-carousel__slides">
-            <div class="p-careers-progression-carousel__slide--text" role="group" aria-label="slide 1 of 4">
-              <h2>We touch every aspect of open source technology, and so we offer a wide range of technology and business careers.</h2>
+    <section class="p-strip u-hug-right__container">
+      <div class="p-careers-progression--opensource u-hug-right__element">
+        <div class="p-stack">
+          <div class="p-careers-progression-carousel">
+            <div class="p-careers-progression-carousel__slides">
+              <div class="p-careers-progression-carousel__slide--text"
+                   role="group"
+                   aria-label="slide 1 of 4">
+                <h2>
+                  We touch every aspect of open source technology, and so we offer a wide range of technology and business careers.
+                </h2>
+              </div>
+              <div class="p-careers-progression-carousel__slide--text"
+                   role="group"
+                   aria-label="slide 2 of 4">
+                <h2>You might start out as a product developer.</h2>
+              </div>
+              <div class="p-careers-progression-carousel__slide--text"
+                   role="group"
+                   aria-label="slide 3 of 4">
+                <h2>Then choose to get more travel and focus on customer operations.</h2>
+              </div>
+              <div class="p-careers-progression-carousel__slide--text"
+                   role="group"
+                   aria-label="slide 4 of 4">
+                <h2>Then take on a role in tech leadership and management.</h2>
+              </div>
             </div>
-            <div class="p-careers-progression-carousel__slide--text" role="group" aria-label="slide 2 of 4">
-              <h2>You might start out as a product developer.</h2>
+          </div>
+          <div class="u-hide--large">{% include 'careers/_careers-progression-slides.html' %}</div>
+          <div class="p-careers-progression-carousel__controls">
+            <div>
+              <ul class="p-careers-progression-carousel__navigation">
+                <li>
+                  <button type="button"
+                          aria-current="true"
+                          class="p-careers-progression-carousel__selector"
+                          tabindex="0"
+                          aria-current="true">
+                    <span class="u-off-screen">Go to slide 1</span>
+                  </button>
+                </li>
+                <li>
+                  <button type="button"
+                          aria-current="false"
+                          class="p-careers-progression-carousel__selector"
+                          tabindex="1"
+                          aria-current="false">
+                    <span class="u-off-screen">Go to slide 2</span>
+                  </button>
+                </li>
+                <li>
+                  <button type="button"
+                          aria-current="false"
+                          class="p-careers-progression-carousel__selector"
+                          tabindex="2"
+                          aria-current="false">
+                    <span class="u-off-screen">Go to slide 3</span>
+                  </button>
+                </li>
+                <li>
+                  <button type="button"
+                          aria-current="false"
+                          class="p-careers-progression-carousel__selector"
+                          tabindex="3"
+                          aria-current="false">
+                    <span class="u-off-screen">Go to slide 4</span>
+                  </button>
+                </li>
+              </ul>
             </div>
-            <div class="p-careers-progression-carousel__slide--text" role="group" aria-label="slide 3 of 4">
-              <h2>Then choose to get more travel and focus on customer operations.</h2>
-            </div>
-            <div class="p-careers-progression-carousel__slide--text" role="group" aria-label="slide 4 of 4">
-              <h2>Then take on a role in tech leadership and management.</h2>
+            <div class="p-carousel-buttons__group">
+              <button type="button" class="p-careers-progression-carousel__previous">
+                <span class="u-off-screen">Previous slides</span>
+              </button>
+              <button type="button" class="p-careers-progression-carousel__next">
+                <span class="u-off-screen">Next slides</span>
+              </button>
             </div>
           </div>
         </div>
-        <div class="u-hide--large">
-          {% include 'careers/_careers-progression-slides.html' %}
-        </div>
-        <div class="p-careers-progression-carousel__controls">
-          <div>
-            <ul class="p-careers-progression-carousel__navigation">
-              <li>
-                <button type="button" aria-current="true" class="p-careers-progression-carousel__selector" tabindex="0" aria-current="true">
-                  <span class="u-off-screen">Go to slide 1</span>
-                </button>
-              </li>
-              <li>
-                <button type="button" aria-current="false" class="p-careers-progression-carousel__selector" tabindex="1" aria-current="false">
-                  <span class="u-off-screen">Go to slide 2</span>
-                </button>
-              </li>
-              <li>
-                <button type="button" aria-current="false" class="p-careers-progression-carousel__selector" tabindex="2" aria-current="false">
-                  <span class="u-off-screen">Go to slide 3</span>
-                </button>
-              </li>
-              <li>
-                <button type="button" aria-current="false" class="p-careers-progression-carousel__selector" tabindex="3" aria-current="false">
-                  <span class="u-off-screen">Go to slide 4</span>
-                </button>
-              </li>
-            </ul>
-          </div>
-          <div class="p-carousel-buttons__group">
-            <button type="button" class="p-careers-progression-carousel__previous">
-              <span class="u-off-screen">Previous slides</span>
-            </button>
-            <button type="button" class="p-careers-progression-carousel__next">
-              <span class="u-off-screen">Next slides</span>
-            </button>
-          </div>
-        </div>
+        <div class="u-hide--medium u-hide--small">{% include 'careers/_careers-progression-slides.html' %}</div>
       </div>
-      <div class="u-hide--medium u-hide--small">
-      {% include 'careers/_careers-progression-slides.html' %}
-      </div>
-    </div>
-  </section>
+    </section>
 
-  <section class="p-strip--careers-progression">
-    <div class="u-fixed-width" data-animation="u-animation--slide-from-bottom">
-      <p>Our mission in action</p>    
-    <h3 class="p-heading--2 p-strip--careers-progression u-no-padding--top">See what's new at Canonical</h3>
-    </div>
-    <div class="row u-extra-space" data-animation="u-animation--slide-from-bottom">
-      <div class="col-6 col-medium-3">
-        {{
+    <section class="p-strip--careers-progression">
+      <div class="u-fixed-width" data-animation="u-animation--slide-from-bottom">
+        <p>Our mission in action</p>
+        <h3 class="p-heading--2 p-strip--careers-progression u-no-padding--top">See what's new at Canonical</h3>
+      </div>
+      <div class="row u-extra-space"
+           data-animation="u-animation--slide-from-bottom">
+        <div class="col-6 col-medium-3">
+          {{
           image (
           url="https://assets.ubuntu.com/v1/d26fcfb0-elektrobit-cover.png",
           alt="",
@@ -206,17 +281,18 @@
           hi_def=True,
           loading="lazy"
           ) | safe
-        }}
+          }}
+        </div>
+        <div class="col-6 col-medium-3">
+          <small>21 February 2023</small>
+          <h3>Elektrobit and Canonical announces EB corbos Linux &dash; built on Ubuntu</h3>
+          <small><a href="https://ubuntu.com/blog/elektrobit-and-canonical-announce-eb-corbos-linux-built-on-ubuntu">Read more&nbsp;&rsaquo;</a></small>
+        </div>
       </div>
-      <div class="col-6 col-medium-3">
-        <small>21 February 2023</small>
-        <h3>Elektrobit and Canonical announces EB corbos Linux &dash; built on Ubuntu</h3>
-        <small><a href="https://ubuntu.com/blog/elektrobit-and-canonical-announce-eb-corbos-linux-built-on-ubuntu">Read more&nbsp;&rsaquo;</a></small>
-      </div>
-    </div>
-    <div class="row u-extra-space" data-animation="u-animation--slide-from-bottom">
-      <div class="col-6 col-medium-3">
-        {{
+      <div class="row u-extra-space"
+           data-animation="u-animation--slide-from-bottom">
+        <div class="col-6 col-medium-3">
+          {{
           image (
           url="https://assets.ubuntu.com/v1/058ff4a7-nvidia.png",
           alt="",
@@ -225,17 +301,18 @@
           hi_def=True,
           loading="lazy"
           ) | safe
-        }}
+          }}
+        </div>
+        <div class="col-6 col-medium-3">
+          <small>20 September 2022</small>
+          <h3>Ubuntu Core is set to redefine industrial computing with new edge AI platform NVIDIA IGX</h3>
+          <small><a href="https://ubuntu.com/blog/ubuntu-core-set-to-redefine-industrial-computing-with-new-edge-ai-platform-nvidia-igx">Read more&nbsp;&rsaquo;</a></small>
+        </div>
       </div>
-      <div class="col-6 col-medium-3">
-        <small>20 September 2022</small>
-        <h3>Ubuntu Core is set to redefine industrial computing with new edge AI platform NVIDIA IGX</h3>
-        <small><a href="https://ubuntu.com/blog/ubuntu-core-set-to-redefine-industrial-computing-with-new-edge-ai-platform-nvidia-igx">Read more&nbsp;&rsaquo;</a></small>
-      </div>
-    </div>
-    <div class="row u-extra-space" data-animation="u-animation--slide-from-bottom">
-      <div class="col-6 col-medium-3">
-        {{
+      <div class="row u-extra-space"
+           data-animation="u-animation--slide-from-bottom">
+        <div class="col-6 col-medium-3">
+          {{
           image (
           url="https://assets.ubuntu.com/v1/b12ab769-virgin-media-cover.png",
           alt="",
@@ -244,117 +321,139 @@
           hi_def=True,
           loading="lazy"
           ) | safe
-        }}
+          }}
+        </div>
+        <div class="col-6 col-medium-3">
+          <small>7 December 2022</small>
+          <h3>Virgin Media O2 deploys Charmed OSM to accelerate network function virtualisation for cloud workloads</h3>
+          <small><a href="https://ubuntu.com/blog/virgin-media-o2-deploys-charmed-osm-to-accelerate-network-functions-virtualisation-for-cloud-workloads">Read more&nbsp;&rsaquo;</a></small>
+        </div>
       </div>
-      <div class="col-6 col-medium-3">
-        <small>7 December 2022</small>
-        <h3>Virgin Media O2 deploys Charmed OSM to accelerate network function virtualisation for cloud workloads</h3>
-        <small><a href="https://ubuntu.com/blog/virgin-media-o2-deploys-charmed-osm-to-accelerate-network-functions-virtualisation-for-cloud-workloads">Read more&nbsp;&rsaquo;</a></small>
+    </section>
+
+    <section>
+      <div class="p-strip">
+        <div class="u-fixed-width">
+          <h2>What team members say</h2>
+        </div>
       </div>
-    </div>
-  </section>
 
-
-  <section>
-    <div class="p-strip">
-      <div class="u-fixed-width">
-        <h2>What team members say</h2>
-      </div>
-    </div>
-
-    <div class="p-careers-progression__testimonials p-careers-progression__testimonials--mobile">
-      <div class="p-3d-carousel u-hide--small u-hide--medium">       
-        <div class="p-3d-carousel__container">    
-          <div class="p-3d-carousel__item" aria-current="true">
+      <div class="p-careers-progression__testimonials p-careers-progression__testimonials--mobile">
+        <div class="p-3d-carousel u-hide--small u-hide--medium">
+          <div class="p-3d-carousel__container">
+            <div class="p-3d-carousel__item" aria-current="true">
+              <p>"At Canonical, every day is different. I am able to learn a lot. The people are consistently amazing."</p>
+            </div>
+            <div class="p-3d-carousel__item" aria-current="false">
+              <p>
+                "Going into management added another dimension to explore which was also fun for self-development. It transformed me deeply".
+              </p>
+            </div>
+            <div class="p-3d-carousel__item" aria-current="false">
+              <p>"I love to work for a mission-driven company that is democratising technology".</p>
+            </div>
+          </div>
+        </div>
+        <div class="u-fixed-width u-hide--large">
+          <div class="p-careers-progression-cards">
             <p>"At Canonical, every day is different. I am able to learn a lot. The people are consistently amazing."</p>
           </div>
-          <div class="p-3d-carousel__item" aria-current="false">
-            <p>"Going into management added another dimension to explore which was also fun for self-development. It transformed me deeply".</p>
+          <div class="p-careers-progression-cards">
+            <p>
+              "Going into management added another dimension to explore which was also fun for self-development. It transformed me deeply".
+            </p>
           </div>
-          <div class="p-3d-carousel__item" aria-current="false">
+          <div class="p-careers-progression-cards">
             <p>"I love to work for a mission-driven company that is democratising technology".</p>
           </div>
         </div>
       </div>
-      <div class="u-fixed-width u-hide--large">
-        <div class="p-careers-progression-cards">
-          <p>"At Canonical, every day is different. I am able to learn a lot. The people are consistently amazing."</p>
-        </div>
-        <div class="p-careers-progression-cards">
-          <p>"Going into management added another dimension to explore which was also fun for self-development. It transformed me deeply".</p>
-        </div>
-        <div class="p-careers-progression-cards">
-          <p>"I love to work for a mission-driven company that is democratising technology".</p>
-        </div>
-      </div>
-    </div>
-  </section>
+    </section>
 
-  <div class="u-fixed-width u-no-padding--top u-hide--small u-hide--medium" style="max-width: 525px; padding-left: 0; padding-right: 0;">
-    <div class="p-careers-progression-carousel__controls">
-      <div style="display: flex;">
-        <button aria-current="true" class="js-go-to-slide p-careers-progression-carousel__selector" data-target="0" type="button">
-          <span class="u-off-screen">Go to slide 1</span>
-        </button>
-        <button aria-current="false" class="js-go-to-slide p-careers-progression-carousel__selector" data-target="1" type="button">
-          <span class="u-off-screen">Go to slide 2</span>
-        </button>
-        <button aria-current="false" class="js-go-to-slide p-careers-progression-carousel__selector" data-target="2" type="button">
-          <span class="u-off-screen">Go to slide 3</span>
-        </button>
-      </div>
-      
-      <div class="p-carousel-buttons__group">
-        <button id="previous-testimonial" class="p-careers-progression-carousel__previous">
-          <span class="u-off-screen">Previous slides</span>
-        </button>
-        <button id="next-testimonial" class="p-careers-progression-carousel__next">
-          <span class="u-off-screen">Next slides</span>
-        </button>
-      </div>
-    </div>
-  </div>
+    <div class="u-fixed-width u-no-padding--top u-hide--small u-hide--medium"
+         style="max-width: 525px;
+                padding-left: 0;
+                padding-right: 0">
+      <div class="p-careers-progression-carousel__controls">
+        <div style="display: flex;">
+          <button aria-current="true"
+                  class="js-go-to-slide p-careers-progression-carousel__selector"
+                  data-target="0"
+                  type="button">
+            <span class="u-off-screen">Go to slide 1</span>
+          </button>
+          <button aria-current="false"
+                  class="js-go-to-slide p-careers-progression-carousel__selector"
+                  data-target="1"
+                  type="button">
+            <span class="u-off-screen">Go to slide 2</span>
+          </button>
+          <button aria-current="false"
+                  class="js-go-to-slide p-careers-progression-carousel__selector"
+                  data-target="2"
+                  type="button">
+            <span class="u-off-screen">Go to slide 3</span>
+          </button>
+        </div>
 
-  <section class="p-strip">
-    <div class="u-fixed-width u-sv3">
-      <h2>Be a part of open source</h2>
-      <div class="row">
-        <div class="col-6">
-          {% if vacancies %}
-          {% include "careers/_search.html" %}
-          {% endif %}
+        <div class="p-carousel-buttons__group">
+          <button id="previous-testimonial"
+                  class="p-careers-progression-carousel__previous">
+            <span class="u-off-screen">Previous slides</span>
+          </button>
+          <button id="next-testimonial" class="p-careers-progression-carousel__next">
+            <span class="u-off-screen">Next slides</span>
+          </button>
         </div>
       </div>
     </div>
-  </section>
 
-  {% if departments_overview %}
-  <section class="p-strip u-extra-space">
-    <div class="u-fixed-width">
-      <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Departments</h2>
-      <hr>
-    </div>
-    <div class="row">
-      {% for dept in departments_overview %}
-      <div class="col-3 col-medium-2 col-small-2">
-        <div class="p-heading-icon--small">
-          <div class="p-heading-icon__header">
-            <img src="https://assets.ubuntu.com/v1/{{dept.icon}}" class="p-heading-icon__img" style="width: 32px; height: 32px; position: relative; top: 7px;" alt="">
-            <p class="p-heading-icon__title">
-              <a href="/careers/{{dept.slug}}"><strong>{{ dept.name }}</strong></a><br />
-              <span>{{ dept.count }} roles</span>
-            </p>
+    <section class="p-strip">
+      <div class="u-fixed-width u-sv3">
+        <h2>Be a part of open source</h2>
+        <div class="row">
+          <div class="col-6">
+            {% if vacancies %}
+              {% include "careers/_search.html" %}
+            {% endif %}
           </div>
         </div>
       </div>
-      {% if loop.index % 4 == 0 and not loop.last  %}
-      <hr class="u-hide u-show--large"/>
-      {% endif %}
-      {% endfor %}
-    </div>
-  </section>
-</div>
-{% endif %}
+    </section>
 
-<script type="text/javascript" src="{{ versioned_static('js/careers-progression.js') }}"></script>
+    {% if departments_overview %}
+      <section class="p-strip u-extra-space">
+        <div class="u-fixed-width">
+          <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Departments</h2>
+          <hr />
+        </div>
+        <div class="row">
+          {% for dept in departments_overview %}
+            <div class="col-3 col-medium-2 col-small-2">
+              <div class="p-heading-icon--small">
+                <div class="p-heading-icon__header">
+                  <img src="https://assets.ubuntu.com/v1/{{ dept.icon }}"
+                       class="p-heading-icon__img"
+                       style="width: 32px;
+                              height: 32px;
+                              position: relative;
+                              top: 7px"
+                       alt="" />
+                  <p class="p-heading-icon__title">
+                    <a href="/careers/{{ dept.slug }}"><strong>{{ dept.name }}</strong></a>
+                    <br />
+                    <span>{{ dept.count }} roles</span>
+                  </p>
+                </div>
+              </div>
+            </div>
+            {% if loop.index % 4 == 0 and not loop.last %}<hr class="u-hide u-show--large" />{% endif %}
+          {% endfor %}
+        </div>
+      </section>
+    </div>
+  {% endif %}
+
+  <script type="text/javascript"
+          src="{{ versioned_static('js/careers-progression.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Done

- Removed "/" from names of templates in extended clause
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check if all the changed pages are working properly and resembles the original site
- Links to Demo Pages
   -  [Divesrity Page in Careers](https://canonical-com-1282.demos.haus/careers/company-culture/diversity)
   -  [Identity Page in Careers](https://canonical-com-1282.demos.haus/careers/company-culture/identity)
   - [Company Culture Careers](https://canonical-com-1282.demos.haus/careers/company-culture)
   - [Progression Page in Careers](https://canonical-com-1282.demos.haus/careers/company-culture/progression)
- Links to Original Pages at canonical.com
   -  [Diversity Page in Careers](https://canonical.com/careers/company-culture/diversity)
   -  [Identity Page in Careers](https://canonical.com/careers/company-culture/identity)
   - [Company Culture Careers](https://canonical.com/careers/company-culture)
   - [Progression Page in Careers](https://canonical.com/careers/company-culture/progression)
## Issue / Card

Fixes # [WD-12280](https://warthogs.atlassian.net/browse/WD-12280)

## Screenshots

[if relevant, include a screenshot]


[WD-12280]: https://warthogs.atlassian.net/browse/WD-12280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ