### PR TITLE
bug: Fix broken link to jaas.ai on '/projects'

### DIFF
--- a/templates/projects/index.html
+++ b/templates/projects/index.html
@@ -1,34 +1,48 @@
 {% extends 'base_index.html' %}
 
 {% block title %}Projects and technologies{% endblock %}
-{% block meta_description %}Canonical guides and contributes to the development of many open source projects in addition to Ubuntu. They include MIR, a next-generation display server, and Juju, a leading service orchestration tool.{% endblock %}
-{% block body_class %}is-paper{% endblock body_class %}
+
+{% block meta_description %}
+  Canonical guides and contributes to the development of many open source projects in addition to Ubuntu. They include MIR, a next-generation display server, and Juju, a leading service orchestration tool.
+{% endblock %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
 
-<section class="p-strip">
-  <div class="row p-block">
-    <div class="col-8 col-start-large-4">
-      <h1>Open source is what we do</h1>
-      <p class="p-heading--2">We believe in the power of open source software. As well as driving our own projects, we contribute staff, code and funding to many more.</p>
+  <section class="p-strip">
+    <div class="row p-block">
+      <div class="col-8 col-start-large-4">
+        <h1>Open source is what we do</h1>
+        <p class="p-heading--2">
+          We believe in the power of open source software. As well as driving our own projects, we contribute staff, code and funding to many more.
+        </p>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row">
-    <h2 class="p-muted-heading">Contribute to open source</h2>
-    <hr class="p-rule--highlight">
-  </div>
-  <div class="row p-section">
-    <div class="col-6 col-medium-3">
-      <h3 class="p-heading--2"><a href="https://ubuntu.com">Ubuntu</a></h3>
-      <p>Ubuntu is one of the world's biggest and most influential open source projects. With new features continually being developed, there is plenty of opportunity to get involved.</p>
-      <p><a href="https://discourse.ubuntu.com/t/contribute/26">Contribute to Ubuntu&nbsp;&rsaquo;</a></p>
+  <section class="p-section">
+    <div class="row">
+      <h2 class="p-muted-heading">Contribute to open source</h2>
+      <hr class="p-rule--highlight" />
     </div>
-    <div class="col-6 col-medium-3">
-      <div class="p-image-wrapper">
-        {{ image (
+    <div class="row p-section">
+      <div class="col-6 col-medium-3">
+        <h3 class="p-heading--2">
+          <a href="https://ubuntu.com">Ubuntu</a>
+        </h3>
+        <p>
+          Ubuntu is one of the world's biggest and most influential open source projects. With new features continually being developed, there is plenty of opportunity to get involved.
+        </p>
+        <p>
+          <a href="https://discourse.ubuntu.com/t/contribute/26">Contribute to Ubuntu&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+      <div class="col-6 col-medium-3">
+        <div class="p-image-wrapper">
+          {{ image (
           url="https://assets.ubuntu.com/v1/38ce93a4-Frame 2816.jpg",
           alt="",
           width="1620",
@@ -36,98 +50,132 @@
           hi_def=True,
           loading="auto|lazy"
           ) | safe
-        }}
+          }}
+        </div>
       </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-3 col-medium-3 p-section">
-      <hr class="p-rule--highlight">
-      <div class="p-block">
-        <h3 class="p-heading--2"><a href="https://ubuntu.com/openstack">OpenStack</a></h3>
+    <div class="row">
+      <div class="col-3 col-medium-3 p-section">
+        <hr class="p-rule--highlight" />
+        <div class="p-block">
+          <h3 class="p-heading--2">
+            <a href="https://ubuntu.com/openstack">OpenStack</a>
+          </h3>
+        </div>
+        <p>
+          Cloud computing needed an open source, enterprise-scale infrastructure platform. Thanks to the work of Canonical and many other contributors, we have OpenStack.
+        </p>
       </div>
-      <p>Cloud computing needed an open source, enterprise-scale infrastructure platform. Thanks to the work of Canonical and many other contributors, we have OpenStack.</p>
-    </div>
-    <div class="col-3 col-medium-3 p-section">
-      <hr class="p-rule--highlight">
-      <div class="p-block">
-        <h3 class="p-heading--2"><a href="https://jaas.ai/jaas">Juju</a></h3>
+      <div class="col-3 col-medium-3 p-section">
+        <hr class="p-rule--highlight" />
+        <div class="p-block">
+          <h3 class="p-heading--2">
+            <a href="https://jaas.ai">Juju</a>
+          </h3>
+        </div>
+        <p>
+          Deploying services into cloud and hyperscale environments used to be complex, error-prone and time-consuming - until now. Juju is the Ubuntu project's service orchestration tool, which simplifies the installation and management of cloud applications.
+        </p>
       </div>
-      <p>Deploying services into cloud and hyperscale environments used to be complex, error-prone and time-consuming - until now. Juju is the Ubuntu project's service orchestration tool, which simplifies the installation and management of cloud applications.</p>
-    </div>
-    <div class="col-3 col-medium-3 p-section">
-      <hr class="p-rule--highlight">
-      <div class="p-block">
-        <h3 class="p-heading--2"><a href="https://maas.io">MAAS</a></h3>
+      <div class="col-3 col-medium-3 p-section">
+        <hr class="p-rule--highlight" />
+        <div class="p-block">
+          <h3 class="p-heading--2">
+            <a href="https://maas.io">MAAS</a>
+          </h3>
+        </div>
+        <p>
+          Installing and deploying cloud computing at datacentre scale is often complicated and time consuming. Metal as a Service (MAAS) lets you treat physical servers like virtual machines in the cloud, turning your bare metal into an elastic, cloud-like resource.
+        </p>
       </div>
-      <p>Installing and deploying cloud computing at datacentre scale is often complicated and time consuming. Metal as a Service (MAAS) lets you treat physical servers like virtual machines in the cloud, turning your bare metal into an elastic, cloud-like resource.</p>
-    </div>
-    <div class="col-3 col-medium-3 p-section">
-      <hr class="p-rule--highlight">
-      <div class="p-block">
-        <h3 class="p-heading--2"><a href="https://mir-server.io/">Mir</a></h3>
+      <div class="col-3 col-medium-3 p-section">
+        <hr class="p-rule--highlight" />
+        <div class="p-block">
+          <h3 class="p-heading--2">
+            <a href="https://mir-server.io/">Mir</a>
+          </h3>
+        </div>
+        <p>
+          A cross-platform client interface needs a cross-platform graphics stack. Mir is the next generation display server used by Ubuntu for its mobile and desktop form factors.
+        </p>
       </div>
-      <p>A cross-platform client interface needs a cross-platform graphics stack. Mir is the next generation display server used by Ubuntu for its mobile and desktop form factors.</p>
-    </div>
-    <div class="col-3 col-medium-3 p-section">
-      <hr class="p-rule--highlight">
-      <div class="p-block">
-        <h3 class="p-heading--2"><a href="https://www.launchpad.net/">Launchpad</a></h3>
+      <div class="col-3 col-medium-3 p-section">
+        <hr class="p-rule--highlight" />
+        <div class="p-block">
+          <h3 class="p-heading--2">
+            <a href="https://www.launchpad.net/">Launchpad</a>
+          </h3>
+        </div>
+        <p>
+          Launchpad enables developers to track and manage open source projects. Its features include code hosting, bug tracking and translation. Ubuntu is one of many projects that use Launchpad.
+        </p>
       </div>
-      <p>Launchpad enables developers to track and manage open source projects. Its features include code hosting, bug tracking and translation. Ubuntu is one of many projects that use Launchpad.</p>
-    </div>
-    <div class="col-3 col-medium-3 p-section">
-      <hr class="p-rule--highlight">
-      <div class="p-block">
-        <h3 class="p-heading--2"><a href="https://cloud-init.io/">Cloud-init</a></h3>
+      <div class="col-3 col-medium-3 p-section">
+        <hr class="p-rule--highlight" />
+        <div class="p-block">
+          <h3 class="p-heading--2">
+            <a href="https://cloud-init.io/">Cloud-init</a>
+          </h3>
+        </div>
+        <p>
+          In cloud environments, image-sprawl can quickly become a problem. Cloud-init is a system initialisation program that imports data from the provider (e.g. Amazon EC2 or Microsoft Azure) which can be used to configure new images with greater control.
+        </p>
       </div>
-      <p>In cloud environments, image-sprawl can quickly become a problem. Cloud-init is a system initialisation program that imports data from the provider (e.g. Amazon EC2 or Microsoft Azure) which can be used to configure new images with greater control.</p>
-    </div>
-    <div class="col-3 col-medium-3 p-section">
-      <hr class="p-rule--highlight">
-      <div class="p-block">
-        <h3 class="p-heading--2"><a href="https://ubuntu.com/community/debian">Debian</a></h3>
+      <div class="col-3 col-medium-3 p-section">
+        <hr class="p-rule--highlight" />
+        <div class="p-block">
+          <h3 class="p-heading--2">
+            <a href="https://ubuntu.com/community/debian">Debian</a>
+          </h3>
+        </div>
+        <p>
+          Debian is one of the world's largest free software communities, famed for its philosophy of collaborative development. A firmly established Linux distribution, it shares much of its underlying architecture with Ubuntu.
+        </p>
       </div>
-      <p>Debian is one of the world's largest free software communities, famed for its philosophy of collaborative development. A firmly established Linux distribution, it shares much of its underlying architecture with Ubuntu.</p>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row">
-    <hr class="p-rule">
-    <div class="col-3 col-medium-6">
-      <h2 class="p-muted-heading">Learn more</h2>
+  <section class="p-section">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-6">
+        <h2 class="p-muted-heading">Learn more</h2>
+      </div>
+      <div class="col-9">
+        <div class="row p-block">
+          <div class="col-6 col-medium-3">
+            <h3 class="p-heading--2">
+              <a href="/projects/directory">View Canonical project directory</a>
+            </h3>
+          </div>
+          <div class="col-3 col-medium-3">
+            <p>See an overview of open source projects set up by Canonical, with contact information for each project.</p>
+          </div>
+        </div>
+        <hr class="p-rule" />
+        <div class="row p-block">
+          <div class="col-6 col-medium-3">
+            <h3 class="p-heading--2">
+              <a href="https://www.ubuntu.com">Explore ubuntu.com</a>
+            </h3>
+          </div>
+          <div class="col-3 col-medium-3">
+            <p>On ubuntu.com, you&rsquo;ll find out more about the platform, our management services and our partner programs.</p>
+          </div>
+        </div>
+        <hr class="p-rule" />
+        <div class="row p-block">
+          <div class="col-6 col-medium-3">
+            <h3 class="p-heading--2">
+              <a href="https://www.ubuntu.com/support">Contact us today</a>
+            </h3>
+          </div>
+          <div class="col-3 col-medium-3">
+            <p>Interested in Ubuntu Pro? Talk to us today for more information.</p>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="col-9">
-      <div class="row p-block">
-        <div class="col-6 col-medium-3">
-          <h3 class="p-heading--2"><a href="/projects/directory">View Canonical project directory</a></h3>
-        </div>
-        <div class="col-3 col-medium-3">
-          <p>See an overview of open source projects set up by Canonical, with contact information for each project.</p>
-        </div>
-      </div>
-      <hr class="p-rule">
-      <div class="row p-block">
-        <div class="col-6 col-medium-3">
-          <h3 class="p-heading--2"><a href="https://www.ubuntu.com">Explore ubuntu.com</a></h3>
-        </div>
-        <div class="col-3 col-medium-3">
-          <p>On ubuntu.com, you&rsquo;ll find out more about the platform, our management services and our partner programs. </p>
-        </div>
-      </div>
-      <hr class="p-rule">
-      <div class="row p-block">
-        <div class="col-6 col-medium-3">
-          <h3 class="p-heading--2"><a href="https://www.ubuntu.com/support">Contact us today</a></h3>
-        </div>
-        <div class="col-3 col-medium-3">
-          <p>Interested in Ubuntu Pro? Talk to us today for more information.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
+  </section>
 
 {% endblock %}


### PR DESCRIPTION
## Done

- Fixes the Jaas link on /projects

## QA

- Go to https://canonical-com-1283.demos.haus/projects
- Click the link for Jaas and see that it takes you to jaas.ai

