### PR TITLE
WD-12940 - update canonicalwebteam.discourse to 5.6.1 and vanilla to …

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sass": "1.70.0",
-    "vanilla-framework": "4.11.0"
+    "vanilla-framework": "4.14.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.blog==6.4.2
 canonicalwebteam.http==1.0.4
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.discourse==5.5.0
+canonicalwebteam.discourse==5.6.0
 canonicalwebteam.search==1.3.0
 bleach==5.0.1
 markdown==3.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.blog==6.4.2
 canonicalwebteam.http==1.0.4
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.discourse==5.6.0
+canonicalwebteam.discourse==5.6.1
 canonicalwebteam.search==1.3.0
 bleach==5.0.1
 markdown==3.5.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -4960,10 +4960,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@4.11.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.11.0.tgz#81636d58bacbd3320a4eb6bf5bef00409cfdc008"
-  integrity sha512-S0AAHNVphn3YJ7BQhyHmvKhrqiZcncQBPedwMan18uavB4VfAT8UN0dwgrHQvY/ypUuJiq/GPA0Xe1xcd+E7dg==
+vanilla-framework@4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
+  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

Bump canonicalwebteam.discourse to 5.6.1 and vanilla to 4.14.0

## QA

- Check that the changes in vanilla have not broken anything

## Issue / Card
[WD-12940](https://warthogs.atlassian.net/browse/WD-12940)

[WD-12940]: https://warthogs.atlassian.net/browse/WD-12940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ