### PR TITLE
feat: Build secondary-navigation.yaml for dynamically building the secondary nav items

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -1,0 +1,57 @@
+# -- Format example --
+#
+# page-name:
+#   title: Page title
+#   path: /page-url
+#
+#   children:
+#     - title: Overview
+#       path: /page-url (note this is the same as the page's url)
+#     - title: Child page
+#       path: /child-page-url
+
+data:
+  title: Data
+  path: /data
+
+  children:
+    - title: Overview
+      path: /data
+    - title: PostgreSQL
+      path: /data/postgresql
+    - title: MySQL
+      path: /data/mysql
+    - title: MongoDB
+      path: /data/mongodb
+    - title: Spark
+      path: /data/spark
+    - title: Kafka
+      path: /data/kafka
+    - title: OpenSearch
+      path: /data/opensearch
+    - title: Docs
+      path: /data/docs
+
+microcloud:
+  title: MicroCloud
+  path: /microcloud
+
+  children:
+    - title: Resources
+      path: /microcloud/resources
+    - title: Docs
+      path: https://canonical-microcloud.readthedocs-hosted.com/en/latest
+
+lxd:
+  title: LXD
+  path: /lxd
+
+  children:
+    - title: Install
+      path: /lxd/install
+    - title: Manage
+      path: /lxd/manage
+    - title: Docs
+      path: https://documentation.ubuntu.com/lxd/en/latest/?_ga=2.91941594.1329653141.1700868845-1063360542.1700868845
+    - title: Forum
+      path: https://discourse.ubuntu.com/c/lxd/126?_ga=2.69179345.1978494405.1700868870-354120313.1700868870


### PR DESCRIPTION
## Done

- Build secondary-navigation.yaml

## QA

- There is no copydoc (as far as I know) so this was built using the previously existing secondary navigations
[microcloud](https://github.com/canonical/canonical.com/blob/main/templates/partial/_microcloud-navigation.html)
[data](https://github.com/canonical/canonical.com/blob/main/templates/partial/_data-navigation.html)
[lxd](https://github.com/canonical/canonical.com/blob/main/templates/partial/_lxd-navigation.html)
- Open the [secondary-navigation.yaml](https://github.com/canonical/canonical.com/pull/1289/files#diff-99fde9a38b5f2b5f5c54ee70c9d160a0f7771bd55895ba02ade9863dc01bce08) and check it contains the same navigaiton data as listed above. It following the same pattern and will use the same logic as found on u.com: https://github.com/canonical/ubuntu.com/blob/main/navigation.yaml

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12993
