### PR TITLE
WD-13399 Removed Duplicate Text

### DIFF
--- a/templates/solutions/secure-open-source/index.html
+++ b/templates/solutions/secure-open-source/index.html
@@ -139,7 +139,7 @@
         </div>
         <div class="p-section--shallow col-6 col-start-large-7 col-medium-4">
           <p>
-            Consume secure open source from Canonical with Ubuntu Pro on public clouds. Access hardening and compliance standards like FIPS, DISA-STIG and others. Consume secure open source from Canonical with Ubuntu Pro on public clouds. Access hardening and compliance standards like FIPS, DISA-STIG and others.
+            Consume secure open source from Canonical with Ubuntu Pro on public clouds. Access hardening and compliance standards like FIPS, DISA-STIG and others. 
           </p>
           <hr class="p-rule is-muted" />
           <p>


### PR DESCRIPTION
## Done

- Removed duplicate text in the /solutions/secure-open-source page (Public cloud section)
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- See the demo [here](https://canonical-com-1303.demos.haus/solutions/secure-open-source).
- Please find [copydoc](https://docs.google.com/document/d/1mrvhkrVjCCJE39h96CPG_b_ZHWVN0GHzZ_6TdoudeYs/edit#heading=h.oy44zuppmsv2) here.


## Issue / Card

Fixes # [WD-13399](https://warthogs.atlassian.net/browse/WD-13399)

## Screenshots

Previously
![image](https://github.com/user-attachments/assets/3f37f0e5-adc9-4dc9-8ec4-fa1ed6f96034)
New
![image](https://github.com/user-attachments/assets/a23551ef-7c9e-44a6-844e-0b51c386f238)


[WD-13399]: https://warthogs.atlassian.net/browse/WD-13399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ