### PR TITLE
Remove chevron custom stylings

### DIFF
--- a/static/sass/_pattern_careers-progression.scss
+++ b/static/sass/_pattern_careers-progression.scss
@@ -244,22 +244,20 @@
     }
 
     .p-careers-progression-carousel__previous {
-      @extend .p-icon--chevron-up;
+      @extend .p-icon--chevron-left;
 
       border: 0;
       height: 44px;
-      transform: rotate(90deg);
       width: 44px;
     }
 
     .p-careers-progression-carousel__next {
-      @extend .p-icon--chevron-up;
+      @extend .p-icon--chevron-right;
 
       border: 0;
       height: 44px;
       // Fix rotation spacing
       margin-top: 2%;
-      transform: rotate(-90deg);
       width: 44px;
     }
   }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -664,12 +664,6 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   }
 }
 
-.p-icon--chevron-right {
-  @extend .p-icon--chevron-up;
-
-  transform: rotate(-90deg);
-}
-
 .p-engineering-fast-track {
   margin-bottom: $spv--large;
 


### PR DESCRIPTION
## Done

- Remove custom stylings for right chevron
- Use new Vanilla icons (left and right chevron) for careers progression carousel controls

## QA

- Go to /careers/company-culture/progression
- Scroll to image carousel section, check that the left and right chevrons look the same as the chevrons on [live](https://www.canonical.com/careers/company-culture/progression)

## Issue / Card

Fixes #1269 and [WD-11919](https://warthogs.atlassian.net/browse/WD-11919)

## Screenshots

[if relevant, include a screenshot]


[WD-11919]: https://warthogs.atlassian.net/browse/WD-11919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ