### PR TITLE
Implement logic to fetch and auto fill career roles

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -589,28 +589,40 @@ careers:
     links:
       - title: Engineering
         url: /careers/engineering
+        slug: engineering
       - title: Support
         url: /careers/support-engineering
+        slug: support-engineering
       - title: Marketing
         url: /careers/marketing
+        slug: marketing
       - title: Web and Design
         url: /careers/web-and-design
+        slug: web-and-design
       - title: Project management
         url: /careers/project-management
+        slug: project-management
       - title: Operations
         url: /careers/commercial-operations
+        slug: commercial-operations
       - title: Product
         url: /careers/product
+        slug: product
       - title: Sales
         url: /careers/sales
+        slug: sales
       - title: Finance
         url: /careers/finance
+        slug: finance
       - title: Legal
         url: /careers/legal
+        slug: legal
       - title: Administration
         url: /careers/administration
+        slug: administration
       - title: People
         url: /careers/people
+        slug: people
 
   secondary_links:
     title: Working here

--- a/static/js/navigation/careers/Worker_populate-careers.js
+++ b/static/js/navigation/careers/Worker_populate-careers.js
@@ -6,11 +6,7 @@ self.onmessage = function (e) {
   fetch("/careers/roles.json")
     .then((response) => response.json())
     .then((departments) => {
-      const processedData = departments.map((dpt) => ({
-        slug: dpt.slug,
-        count: dpt.count,
-      }));
-      self.postMessage(processedData);
+      self.postMessage(departments);
     })
     .catch((error) => {
       console.error(`Unable to load careers navigation roles: ${error}`);

--- a/static/js/navigation/careers/populate-careers-roles.js
+++ b/static/js/navigation/careers/populate-careers-roles.js
@@ -21,7 +21,7 @@ function updateHtmlWithRoles(departments, target) {
  */
 function fecthAvailableRolesWithWebWorkers() {
   const worker = new Worker(
-    "static/js/navigation/careers-roles/Worker_populate-careers.js"
+    "static/js/navigation/careers/Worker_populate-careers.js"
   );
   // trigger the web worker by calling it with an empty string
   worker.postMessage("");

--- a/static/js/navigation/careers/populate-careers-roles.js
+++ b/static/js/navigation/careers/populate-careers-roles.js
@@ -21,7 +21,7 @@ function updateHtmlWithRoles(departments, target) {
  */
 function fecthAvailableRolesWithWebWorkers() {
   const worker = new Worker(
-    "static/js/navigation/careers/Worker_populate-careers.js"
+    "/static/js/navigation/careers/Worker_populate-careers.js"
   );
   // trigger the web worker by calling it with an empty string
   worker.postMessage("");

--- a/static/js/navigation/careers/populate-careers-roles.js
+++ b/static/js/navigation/careers/populate-careers-roles.js
@@ -1,0 +1,55 @@
+import { navigation } from "../elements";
+
+/**
+ * Populate available roles for careers roles.
+ * @param {String} target - the class to target
+ */
+function updateHtmlWithRoles(departments, target) {
+  departments.forEach((dpt) => {
+    const departmentElements = navigation.querySelectorAll(
+      `[data-id="${dpt.slug}"]`
+    );
+    departmentElements.forEach((element) => {
+      element.innerText = `${dpt.count} roles`;
+      element.classList.add("u-animation--slide-from-top");
+    });
+  });
+}
+
+/**
+ * Primary: Fetch careers roles data uses a web worker and then populate the fields
+ */
+function fecthAvailableRolesWithWebWorkers() {
+  const worker = new Worker(
+    "static/js/navigation/careers-roles/Worker_populate-careers.js"
+  );
+  // trigger the web worker by calling it with an empty string
+  worker.postMessage("");
+  // once it has the data back populate the fields
+  worker.onmessage = function (e) {
+    updateHtmlWithRoles(e.data);
+  };
+}
+
+/**
+ * Fallback: Fetch careers roles data and then populate the fields
+ */
+function fecthAvailableRoles() {
+  // fallback for older browsers that dont have access to web workers
+  fetch("/careers/roles.json")
+    .then((response) => response.json())
+    .then((departments) => {
+      updateHtmlWithRoles(departments);
+    })
+    .catch((error) => {
+      console.error(`Unable to load careers navigation roles: ${error}`);
+    });
+}
+
+export default function populateCareersRoles() {
+  if (window.Worker) {
+    fecthAvailableRolesWithWebWorkers();
+  } else {
+    fecthAvailableRoles();
+  }
+}

--- a/static/js/navigation/fetch-careers-roles.js
+++ b/static/js/navigation/fetch-careers-roles.js
@@ -1,0 +1,18 @@
+/**
+ * Function that is consumed by a webworker to fetch careers roles data
+ * @param {Event} e
+ */
+self.onmessage = function (e) {
+  fetch("/careers/roles.json")
+    .then((response) => response.json())
+    .then((departments) => {
+      const processedData = departments.map((dpt) => ({
+        slug: dpt.slug,
+        count: dpt.count,
+      }));
+      self.postMessage(processedData);
+    })
+    .catch((error) => {
+      console.error(`Unable to load careers navigation roles: ${error}`);
+    });
+};

--- a/static/js/navigation/main.js
+++ b/static/js/navigation/main.js
@@ -180,12 +180,6 @@ function toggleSection(e) {
       tabLink.classList.remove("is-active");
     }
   });
-
-  const firstLink = el.querySelector("a");
-  setTimeout(function () {
-    toggleIsActiveState(el, true);
-    firstLink.focus();
-  }, 1);
 }
 
 /**
@@ -208,6 +202,35 @@ function closeAllNavigationItems({ exception } = {}) {
     }
   }
 }
+
+/**
+ * Fetch careers roles data uses a web worker and populate the fields
+ */
+function populateCareersRoles() {
+  if (window.Worker) {
+    const worker = new Worker("static/js/navigation/fetch-careers-roles.js");
+    // trigger the web worker by calling it with an empty string
+    worker.postMessage("");
+    // once it has the data back populate the fields
+    worker.onmessage = function (e) {
+      const departments = e.data;
+      departments.forEach((dpt) => {
+        const departmentElements = navigation.querySelectorAll(
+          `[data-id="${dpt.slug}"]`
+        );
+        departmentElements.forEach((element) => {
+          element.innerText = `${dpt.count} roles`;
+          element.classList.add("u-animation--slide-from-top");
+        });
+      });
+    };
+  } else {
+    console.error(
+      "Unable to fetch roles. Your browser doesn't support web workers."
+    );
+  }
+}
+populateCareersRoles();
 
 // throttle util (for window resize event)
 var throttle = function (fn, delay) {

--- a/static/js/navigation/main.js
+++ b/static/js/navigation/main.js
@@ -4,6 +4,7 @@ import { closeSearch, toggleSearch } from "./search";
 import closeSecondaryNavigation from "./secondary-navigation";
 import setFocusable from "./keyboard-navigation";
 import { toggleMenu, closeMenu, goBackOneLevel } from "./mobile";
+import populateCareersRoles from "./careers/populate-careers-roles";
 
 const ANIMATION_SNAP_DURATION = 100;
 
@@ -204,35 +205,12 @@ function closeAllNavigationItems({ exception } = {}) {
 }
 
 /**
- * Fetch careers roles data uses a web worker and populate the fields
+ * Throttle util (for window resize event)
+ * @param {Function} fn
+ * @param {Int} delay
  */
-function populateCareersRoles() {
-  if (window.Worker) {
-    const worker = new Worker("static/js/navigation/fetch-careers-roles.js");
-    // trigger the web worker by calling it with an empty string
-    worker.postMessage("");
-    // once it has the data back populate the fields
-    worker.onmessage = function (e) {
-      const departments = e.data;
-      departments.forEach((dpt) => {
-        const departmentElements = navigation.querySelectorAll(
-          `[data-id="${dpt.slug}"]`
-        );
-        departmentElements.forEach((element) => {
-          element.innerText = `${dpt.count} roles`;
-          element.classList.add("u-animation--slide-from-top");
-        });
-      });
-    };
-  } else {
-    console.error(
-      "Unable to fetch roles. Your browser doesn't support web workers."
-    );
-  }
-}
-populateCareersRoles();
 
-// throttle util (for window resize event)
+//
 var throttle = function (fn, delay) {
   var timer = null;
   return function () {
@@ -247,5 +225,8 @@ var throttle = function (fn, delay) {
 
 // hide side navigation drawer when screen is resized
 window.addEventListener("resize", throttle(closeAllNavigationItems, 10));
+
+// Update careers dropdown with latest avaiable roles
+populateCareersRoles();
 
 export default closeAllNavigationItems;

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -58,7 +58,7 @@ $navigation-heading-color: #fff9;
 }
 
 @mixin canonical-p-navigation-dropdown-content {
-  .p-navigation__dropdown-content--sliding,
+  .p-navigation__dropdown-content-mobile,
   .p-navigation__content-panel--full-width,
   .p-navigation__content-panel {
     a {

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -58,9 +58,8 @@ $navigation-heading-color: #fff9;
 }
 
 @mixin canonical-p-navigation-dropdown-content {
-  .p-navigation__dropdown-content-mobile,
-  .p-navigation__content-panel--full-width,
-  .p-navigation__content-panel {
+  .p-navigation__dropdown-content--sliding,
+  .p-navigation__content-panel--full-width {
     a {
       display: block;
       font-weight: 400;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -817,4 +817,3 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 }
 
 // Custom styles for meganav
-

--- a/templates/navigation/_dropdown.html
+++ b/templates/navigation/_dropdown.html
@@ -10,7 +10,6 @@
            href="#{{ id }}-content-back"
            data-level="1">Back</a>
       </li>
-      
       {% if "side_nav_sections" in section %}
         {% for nav_section in section.side_nav_sections %}
           <li class="p-navigation__item--dropdown-toggle"

--- a/templates/navigation/partials/_list-item.html
+++ b/templates/navigation/partials/_list-item.html
@@ -6,7 +6,7 @@
     <span>{{ link.title }}</span>
     <br />
     {% if id == "careers" %}
-    <span class="is-muted js-available-roles" data-id="{{ link.title | slug }}"><i class="p-icon--spinner u-animation--spin"></i></span>
+    <small class="is-muted js-available-roles" data-id="{{ link.slug }}"><i class="p-icon--spinner u-animation--spin"></i></small>
     {% elif link.description %}
     <small class="is-muted">{{ link.description }}</small>
     {% endif %}


### PR DESCRIPTION
to be merged to https://github.com/canonical/canonical.com/pull/1322 or if that has already been merged, to `canonical-navigation`

## Done

- Implements a web worker and associated script (`fetch-careers-roles.js`) to fetch career data in the background on page load (this is because it was quite delayed when fetching on dropdown opening)
- Adds 'slug' value to 'careers' in navigation.yaml to associate with the careers data
- some minor html and scss changes

## QA

- Open 'careers' navigation, see that each job role has an associated number of roles. eg. 'Engineering', '20 roles'. You can compare to the live page https://canonical.com/
- Check both mobile and desktop

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-13581

## Screenshots

![image](https://github.com/user-attachments/assets/e5581632-7f81-4983-a22f-d32906f850e2)

![image](https://github.com/user-attachments/assets/8f7abc93-0418-4487-b18b-a713ffa1face)

