### PR TITLE
update link to MicroCloud documentation

### DIFF
--- a/templates/microcloud/index.html
+++ b/templates/microcloud/index.html
@@ -286,7 +286,7 @@
       </ul>
       <hr class="p-rule"/>
       <p>
-        <a href="https://canonical-microcloud.readthedocs-hosted.com/en/latest/tutorial/get_started/">Deploy your own MicroCloud following this tutorial&nbsp;&rsaquo;</a>
+        <a href="https://canonical-microcloud.readthedocs-hosted.com/en/stable/tutorial/">Deploy your own MicroCloud following this tutorial&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>

--- a/templates/partial/_microcloud-navigation.html
+++ b/templates/partial/_microcloud-navigation.html
@@ -19,7 +19,7 @@
           <a href="/microcloud/resources" class="p-navigation__link">Resources</a>
         </li>
         <li class="p-navigation__item">
-          <a href="https://canonical-microcloud.readthedocs-hosted.com/en/latest/" class="p-navigation__link">Docs</a>
+          <a href="https://canonical-microcloud.readthedocs-hosted.com/" class="p-navigation__link">Docs</a>
         </li>
       </ul>
       <ul class="p-navigation__items global-nav"></ul>


### PR DESCRIPTION
The default link is now the stable documentation, not the latest.

## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
