### PR TITLE
WD-13887 Add "Distributor" to programme filter of partners

### DIFF
--- a/templates/partners/partial/_partner-filters/_programme-filters.html
+++ b/templates/partners/partial/_partner-filters/_programme-filters.html
@@ -7,12 +7,20 @@
   <span class="p-checkbox__label" id="desktop">Desktop</span>
 </label>
 <label class="p-checkbox">
+  <input type="checkbox" class="p-checkbox__input js-find-a-partner__filter" name="distributor" aria-labelledby="distributor" />
+  <span class="p-checkbox__label" id="distributor">Distributor</span>
+</label>
+<label class="p-checkbox">
   <input type="checkbox" class="p-checkbox__input js-find-a-partner__filter" name="global-system-integrators" aria-labelledby="global-system-integrators" />
   <span class="p-checkbox__label" id="global-system-integrators">Global System Integrators</span>
 </label>
 <label class="p-checkbox">
   <input type="checkbox" class="p-checkbox__input js-find-a-partner__filter" name="ihv-oem" aria-labelledby="ihv-oem" />
   <span class="p-checkbox__label" id="ihv-oem">IHV / OEM</span>
+</label>
+<label class="p-checkbox">
+  <input type="checkbox" class="p-checkbox__input js-find-a-partner__filter" name="odm" aria-labelledby="odm" />
+  <span class="p-checkbox__label" id="odm">ODM</span>
 </label>
 <label class="p-checkbox">
   <input type="checkbox" class="p-checkbox__input js-find-a-partner__filter" name="public-cloud" aria-labelledby="public-cloud" />
@@ -29,8 +37,4 @@
 <label class="p-checkbox">
   <input type="checkbox" class="p-checkbox__input js-find-a-partner__filter" name="internet-of-things" aria-labelledby="internet-of-things" />
   <span class="p-checkbox__label" id="internet-of-things">IoT Devices</span>
-</label>
-<label class="p-checkbox">
-  <input type="checkbox" class="p-checkbox__input js-find-a-partner__filter" name="odm" aria-labelledby="odm" />
-  <span class="p-checkbox__label" id="odm">ODM</span>
 </label>


### PR DESCRIPTION
## Done
-  Added "Distributor" to programme filter of partners

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [Demo](https://canonical-com-1331.demos.haus/partners/find-a-partner)
- [Copydoc](https://docs.google.com/document/d/1R3s-aiSrFvbNrHjdfblYo_XX1f_EQ989DkmPS41seZc/edit)
- Partners need to have "distributor" in "data-filter" attribute to get filtered.

## Issue / Card

Fixes # [WD-13887](https://warthogs.atlassian.net/browse/WD-13887)

## Screenshots

[if relevant, include a screenshot]


[WD-13887]: https://warthogs.atlassian.net/browse/WD-13887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ