### PR TITLE
WD-13370 Bumped cookie-policy to v3.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "cypress:open": "cypress open --config-file tests/cypress/cypress.json --config baseUrl=http://0.0.0.0:${PORT:-8002}/"
   },
   "dependencies": {
-    "@canonical/cookie-policy": "^3.6.3",
+    "@canonical/cookie-policy": "^3.6.4",
     "@canonical/global-nav": "3.6.4",
     "@canonical/latest-news": "1.5.0",
     "@testing-library/cypress": "9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,10 +316,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@^3.6.3":
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.6.3.tgz#b242dd3cd838564be16e20c6bfadb92f6058950d"
-  integrity sha512-an3od9wrtESgbexSu4Cc81vyHExZaeDeDJWd0+g2SANSAt3OFMt+gsT2c78rGep9J7+a1qhuvQRC43koSVWACQ==
+"@canonical/cookie-policy@^3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.6.4.tgz#895c3770f621b73d88b0d5843c43a32d99e4a462"
+  integrity sha512-kfwamTpAaBhtH5TzlMb8wE814a8lIbONUuSYnS7VPiHDfcdmw4NoBPNpldmNY1j3CAT5vMKOx5kulRTWpEXpag==
 
 "@canonical/global-nav@3.6.4":
   version "3.6.4"


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Delete cookies so you get the cookie policy pop up
- Accept nothing and check that in cookies there exists `_cookies_accepted=essential`
- Repeat with only accept 'performance', only accepting 'functional' and finally 'all'

## Issue / Card

Fixes # [WD-13370](https://warthogs.atlassian.net/browse/WD-13370)
## Screenshots

[if relevant, include a screenshot]


[WD-13370]: https://warthogs.atlassian.net/browse/WD-13370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ