### PR TITLE
Implement GA tracking for the meganav

### DIFF
--- a/static/js/navigation/ga-tracking.js
+++ b/static/js/navigation/ga-tracking.js
@@ -1,0 +1,52 @@
+export default function initGATracking() {
+  addGANavEvents("#products-nav", "canonical.com-nav-products");
+  addGANavEvents("#solutions-nav", "canonical.com-nav-solutions");
+  addGANavEvents("#partners-nav", "canonical.com-nav-partners");
+  addGANavEvents("#careers-nav", "canonical.com-nav-careers");
+  addGANavEvents("#company-nav", "canonical.com-nav-careers");
+
+  function addGANavEvents(target, category) {
+    var t = document.querySelector(target);
+    if (t) {
+      t.querySelectorAll("a").forEach(function (a) {
+        a.addEventListener("click", function () {
+          dataLayer.push({
+            event: "GAEvent",
+            eventCategory: category,
+            eventAction: `from:${origin} to:${a.href}`,
+            eventLabel: a.text,
+            eventValue: undefined,
+          });
+        });
+      });
+    }
+  }
+
+  addGAContentEvents("#main-content");
+
+  function addGAContentEvents(target) {
+    var t = document.querySelector(target);
+    if (t) {
+      t.querySelectorAll("a").forEach(function (a) {
+        if (a.className.includes("p-button--positive")) {
+          var category = "canonical.com-content-cta-0";
+        } else if (a.className.includes("p-button")) {
+          var category = "canonical.com-content-cta-1";
+        } else {
+          var category = "canonical.com-content-link";
+        }
+        if (!a.href.startsWith("#")) {
+          a.addEventListener("click", function () {
+            dataLayer.push({
+              event: "GAEvent",
+              eventCategory: category,
+              eventAction: `from:${origin} to:${a.href}`,
+              eventLabel: a.text,
+              eventValue: undefined,
+            });
+          });
+        }
+      });
+    }
+  }
+}

--- a/static/js/navigation/main.js
+++ b/static/js/navigation/main.js
@@ -13,6 +13,7 @@ import {
 } from "./keyboard-navigation";
 import { toggleMenu, closeMenu, goBackOneLevel } from "./mobile";
 import populateCareersRoles from "./careers/populate-careers-roles";
+import initGATracking from "./ga-tracking";
 
 const ANIMATION_SNAP_DURATION = 100;
 
@@ -223,8 +224,6 @@ function closeAllNavigationItems({ exception } = {}) {
  * @param {Function} fn
  * @param {Int} delay
  */
-
-//
 var throttle = function (fn, delay) {
   var timer = null;
   return function () {
@@ -237,10 +236,13 @@ var throttle = function (fn, delay) {
   };
 };
 
-// hide side navigation drawer when screen is resized
+// hide navigation when screen is resized
 window.addEventListener("resize", throttle(closeAllNavigationItems, 10));
 
 // Update careers dropdown with latest avaiable roles
 populateCareersRoles();
+
+// Init GA tracking
+initGATracking();
 
 export default closeAllNavigationItems;

--- a/templates/navigation/navigation.html
+++ b/templates/navigation/navigation.html
@@ -29,8 +29,8 @@
       <ul class="p-navigation__items js-dropdown-list">
         <li class="p-navigation__item--dropdown-toggle"
             role="menuitem"
-            id="products">
-          <a class="p-navigation__link js-dropdown-button js-focus-target"
+            id="products-nav">
+          <a class="p-navigation__link js-dropdown-button"
              href="#"
              aria-controls="products-content"
              tabindex="0"
@@ -39,8 +39,8 @@
         </li>
         <li class="p-navigation__item--dropdown-toggle"
             role="menuitem"
-            id="solutions">
-          <a class="p-navigation__link js-dropdown-button js-focus-target"
+            id="solutions-nav">
+          <a class="p-navigation__link js-dropdown-button"
              href="#"
              aria-controls="solutions-content"
              tabindex="0"
@@ -49,8 +49,8 @@
         </li>
         <li class="p-navigation__item--dropdown-toggle"
             role="menuitem"
-            id="partner">
-          <a class="p-navigation__link js-dropdown-button js-focus-target"
+            id="partners-nav">
+          <a class="p-navigation__link js-dropdown-button"
              href="#"
              aria-controls="partners-content"
              tabindex="0"
@@ -59,8 +59,8 @@
         </li>
         <li class="p-navigation__item--dropdown-toggle"
             role="menuitem"
-            id="careers">
-          <a class="p-navigation__link js-dropdown-button js-focus-target"
+            id="careers-nav">
+          <a class="p-navigation__link js-dropdown-button"
              href="#"
              aria-controls="careers-content"
              tabindex="0"
@@ -69,8 +69,8 @@
         </li>
         <li class="p-navigation__item--dropdown-toggle"
             role="menuitem"
-            id="company">
-          <a class="p-navigation__link js-dropdown-button js-focus-target"
+            id="company-nav">
+          <a class="p-navigation__link js-dropdown-button"
              href="#"
              aria-controls="company-content"
              tabindex="0"


### PR DESCRIPTION
## Done

- Implement GA tracking for the meganav. This means copying what exists already on c.com, [see here](https://github.com/canonical/canonical.com/blob/main/static/js/navigation.js#L96)

## QA

- Open [the demo](https://canonical-com-1342.demos.haus/)
- Check that the GA event are being attached to the appropriate dropdowns, you can inspect this in the network tab and logging in the JS.
- If you want to you can install  Chrome extension 'Google Tag Assistant' and actually look at the tags being fired. But given this is an exact copy of what we currently have, isn't necessary. 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12082