### PR TITLE
feat: Only close the navigation when resizing horizontally

### DIFF
--- a/static/js/navigation/main.js
+++ b/static/js/navigation/main.js
@@ -1,3 +1,5 @@
+import throttle from "../utils/throttle";
+
 import {
   navigation,
   secondaryNavigation,
@@ -218,23 +220,6 @@ function closeAllNavigationItems({ exception } = {}) {
     }
   }
 }
-
-/**
- * Throttle util (for window resize event)
- * @param {Function} fn
- * @param {Int} delay
- */
-var throttle = function (fn, delay) {
-  var timer = null;
-  return function () {
-    var context = this,
-      args = arguments;
-    clearTimeout(timer);
-    timer = setTimeout(function () {
-      fn.apply(context, args);
-    }, delay);
-  };
-};
 
 // Hide navigation when screen is horizontally resized
 let previousWidth = window.innerWidth;

--- a/static/js/navigation/main.js
+++ b/static/js/navigation/main.js
@@ -236,8 +236,18 @@ var throttle = function (fn, delay) {
   };
 };
 
-// hide navigation when screen is resized
-window.addEventListener("resize", throttle(closeAllNavigationItems, 10));
+// Hide navigation when screen is horizontally resized
+let previousWidth = window.innerWidth;
+window.addEventListener(
+  "resize",
+  throttle(function () {
+    const currentWidth = window.innerWidth;
+    if (currentWidth !== previousWidth) {
+      closeAllNavigationItems();
+      previousWidth = currentWidth;
+    }
+  }, 10)
+);
 
 // Update careers dropdown with latest avaiable roles
 populateCareersRoles();

--- a/static/js/utils/throttle.js
+++ b/static/js/utils/throttle.js
@@ -1,0 +1,18 @@
+/**
+ * Throttle util (for window resize event)
+ * @param {Function} fn
+ * @param {Int} delay
+ */
+var throttle = function (fn, delay) {
+  var timer = null;
+  return function () {
+    var context = this,
+      args = arguments;
+    clearTimeout(timer);
+    timer = setTimeout(function () {
+      fn.apply(context, args);
+    }, delay);
+  };
+};
+
+export default throttle;


### PR DESCRIPTION
## Done

- Adds logic to only close the navigation when resizing horizontally. For context: Vanilla added this the feature to close when resizing as there was still some issue going fluidly from mobile to desktop. This was causing a bug on mobile when you scrolled down and the search hid itself.

## QA

- Open [the demo](https://canonical-com-1344.demos.haus/) on a mobile device with chrome
- Open then navigation and going to a section which is scroll-able (Products > Private cloud, for ex.)
- Start to scroll down to reveal the rest of the navigation and causing the search bar to hide itself.
- See that the navigation stays open.
- Check that the navigation closes on horizontal resize on desktop.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14167
