### PR TITLE
bug: Replace homepage suru that was incompatible with firefox

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -53,7 +53,7 @@ meta_copydoc %}
         </div>
       </div>
       <div class="u-fixed-width u-no-padding u-hide--medium u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/41749314-bottom_suru_DARK.png"
+        <img src="https://assets.ubuntu.com/v1/41749314-test_suru_1.png"
              alt=""
              style="aspect-ratio: 2580/501;
                     width: 100%" />

--- a/templates/index.html
+++ b/templates/index.html
@@ -53,7 +53,7 @@ meta_copydoc %}
         </div>
       </div>
       <div class="u-fixed-width u-no-padding u-hide--medium u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/9469ef82-1_website_suru_DARK_25%20(1)122.jpg"
+        <img src="https://assets.ubuntu.com/v1/41749314-bottom_suru_DARK.png"
              alt=""
              style="aspect-ratio: 2580/501;
                     width: 100%" />

--- a/templates/index.html
+++ b/templates/index.html
@@ -53,7 +53,7 @@ meta_copydoc %}
         </div>
       </div>
       <div class="u-fixed-width u-no-padding u-hide--medium u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/41749314-test_suru_1.png"
+        <img src="https://assets.ubuntu.com/v1/9469ef82-suru_dark.jpg"
              alt=""
              style="aspect-ratio: 2580/501;
                     width: 100%" />


### PR DESCRIPTION
## Done

- Update dates the suru on the home page to fix a issue where the colours did not match

## QA

- Check out [the demo](https://canonical-com-1347.demos.haus/) on firefox
- see that the suru background matches the page background

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9552?focusedCommentId=554655
https://github.com/canonical/canonical.com/issues/1201
