### PR TITLE
Update copy on careers FAQ page

### DIFF
--- a/templates/careers/application/faq.html
+++ b/templates/careers/application/faq.html
@@ -31,7 +31,7 @@
                 <button type="button" class="p-accordion__tab" id="employment-tab2" aria-controls="employment-tab2-section" aria-expanded="false"><span class="u-default-max-width">How will I be employed?</span></button>
               </div>
               <section class="p-accordion__panel" id="employment-tab2-section" aria-hidden="true" aria-labelledby="employment-tab2">
-                <p>This will depend on your location and the role. This will be discussed with you during your Talent interview where our Talent Partners will confirm how we will engage with you during your employment.</p>
+                <p>This will depend on your location and the role. This will be discussed with you during your Talent interview where we will confirm how we will engage with you.</p>
               </section>
             </li>
             <li class="p-accordion__group">
@@ -55,7 +55,7 @@
                 <button type="button" class="p-accordion__tab" id="employment-tab5" aria-controls="employment-tab5-section" aria-expanded="false"><span class="u-default-max-width">Can you tell me the salary for this role?</span></button>
               </div>
               <section class="p-accordion__panel" id="employment-tab5-section" aria-hidden="true" aria-labelledby="employment-tab5">
-                <p>If you would like to send the Hiring Lead your requirements on salary to check these are suitable first, then please make contact with them by email. We will have this discussion with you during the Talent Interview. Ultimately, it will be the Hiring Lead who will decide if they can match your expectations.</p>
+                <p>The discussion on compensation will happen during the Talent Interview stage. Ultimately, it will be the Hiring Lead who will decide if they can match your expectations.</p>
               </section>
             </li>
             <li class="p-accordion__group">
@@ -118,7 +118,7 @@
                 <button type="button" class="p-accordion__tab" id="written-interview-tab4" aria-controls="written-interview-tab4-section" aria-expanded="false"><span class="u-default-max-width">Can we jump on a quick call instead of the written interview?</span></button>
               </div>
               <section class="p-accordion__panel" id="written-interview-tab4-section" aria-hidden="true" aria-labelledby="written-interview-tab4">
-                <p>Unfortunately we are not able to arrange calls with all of our candidates mainly due to time zones and our Global reach. We also want to make sure that we give everyone a fair chance to demonstrate their skills and experience. Our written interview was designed to provide this, especially given we see such a range in length and detail on CVs from around the world. It also allows us to make unbiased decisions on who to progress with as this is reviewed anonymously by our teams. If you have received a request to complete this then it's great news! Your CV has been received and we are really keen to learn more about your skills and experiences. We look forward to receiving your submission.</p>
+                <p>Unfortunately we are not able to arrange calls with all of our candidates mainly due to time zones and our Global reach. We also want to make sure that we give everyone a fair chance to demonstrate their skills and experience. Our written interview was designed to provide this, especially given we see such a range in length and detail on each resume. It also allows us to make unbiased decisions on who to progress with as this is reviewed anonymously by our teams. If you have received a request to complete this then it's great news! Your resume has been received and we are really keen to learn more about your skills and experiences. We look forward to receiving your submission.</p>
               </section>
             </li>
             <li class="p-accordion__group">
@@ -183,7 +183,7 @@
                 <button type="button" class="p-accordion__tab" id="psychometric-assessments-tab2" aria-controls="psychometric-assessments-tab2-section" aria-expanded="false"><span class="u-default-max-width">Is the psychometric assessment an IQ test?</span></button>
               </div>
               <section class="p-accordion__panel" id="psychometric-assessments-tab2-section" aria-hidden="true" aria-labelledby="psychometric-assessments-tab2">
-                <p>The GIA assessment rates a candidate's overall train-ability and speed of adaptation in dynamic environments. It is an 'Aptitude' assessment that assesses speed of trainability, mental processing speed, concentration, response to training and a prediction of potential to grasp a new role. The overall percentile is a weighted combination of Perceptual Speed, Number Speed & Accuracy, Reasoning, Word Meaning and Spatial Visualisation. The overall percentile is an estimate of the candidate's general intelligence, reflecting both fluid and crystallised intelligence, against a norm group. The norm group is refreshed every 5 years and is made up of circa 16,000 people in the age group 18-73. Its accent is on response to training, mental processing speed, concentration and potential.</p>
+                <p>No it is not. The GIA assessment rates a candidate's overall trainability and speed of adaptation in dynamic environments. It is an 'Aptitude' assessment that assesses speed of trainability, mental processing speed, concentration, response to training and a prediction of potential to grasp a new role. The overall percentile is a weighted combination of Perceptual Speed, Number Speed & Accuracy, Reasoning, Word Meaning and Spatial Visualisation. The overall percentile is an estimate of the candidate's general intelligence, reflecting both fluid and crystallised intelligence, against a norm group. The norm group is refreshed every 5 years and is made up of circa 16,000 people in the age group 18-73. Its accent is on response to training, mental processing speed, concentration and potential.</p>
               </section>
             </li>
             <li class="p-accordion__group">
@@ -191,7 +191,7 @@
                 <button type="button" class="p-accordion__tab" id="psychometric-assessments-tab3" aria-controls="psychometric-assessments-tab3-section" aria-expanded="false"><span class="u-default-max-width">I completed my GIA/PPA just now, what's the next step?</span></button>
               </div>
               <section class="p-accordion__panel" id="psychometric-assessments-tab3-section" aria-hidden="true" aria-labelledby="psychometric-assessments-tab3">
-                <p>Once you have completed your Thomas International assessments our Hiring Lead will get an automatic alert that you have finished your assessment. Please bear with us whilst we review. At this point we will take a look at your whole application again (CV, Written Interview and Psychometric results etc). You will shortly receive confirmation of our decision and if you are moving to the next stage of the process.</p>
+                <p>Once you have completed your Thomas International assessments our Hiring Lead will get an automatic alert that you have finished your assessment. Please bear with us whilst we review. At this point we will take a look at your whole application again (Resume, Written Interview and Psychometric results etc). You will shortly receive confirmation of our decision and if you are moving to the next stage of the process.</p>
               </section>
             </li>
             <li class="p-accordion__group">
@@ -199,7 +199,7 @@
                 <button type="button" class="p-accordion__tab" id="psychometric-assessments-tab4" aria-controls="psychometric-assessments-tab4-section" aria-expanded="false"><span class="u-default-max-width">Can I get the results of my psychometric assessments?</span></button>
               </div>
               <section class="p-accordion__panel" id="psychometric-assessments-tab4-section" aria-hidden="true" aria-labelledby="psychometric-assessments-tab4">
-                <p>Yes you can! Once you have completed the assessment you can request to download this directly from your candidate page. Both the GIA and PPA reports are available via the button under the Assessment stage: Request assessment report. If you reach the Talent Interview stage, then just navigate back to this button and request your report again to receive your second document.</p>
+                <p>Yes you can! Once you have completed the assessment you can request to download this directly from your candidate dashboard. Both the GIA and PPA reports are available via the button under the Assessment stage: Request assessment report. If you reach the Talent Interview stage, then just navigate back to this button and request your report again to receive your second document.</p>
               </section>
             </li>
           </ul>
@@ -222,7 +222,7 @@
                 <button type="button" class="p-accordion__tab" id="application-management-tab2" aria-controls="application-management-tab2-section" aria-expanded="false"><span class="u-default-max-width">I need to reschedule my interview. How do I do this?</span></button>
               </div>
               <section class="p-accordion__panel" id="application-management-tab2-section" aria-hidden="true" aria-labelledby="application-management-tab2">
-                <p>If your interview is booked via Calendly, please click on the 'Reschedule' link on the email invite.</p>
+                <p class="u-no-margin--bottom">If your interview is booked via Calendly, please click on the 'Reschedule' link on the email invite.</p>
                 <p>If your interview is scheduled by the Hiring Team (you've received an interview confirmation from the team), please contact your Hiring Lead.</p>
               </section>
             </li>
@@ -231,7 +231,7 @@
                 <button type="button" class="p-accordion__tab" id="application-management-tab3" aria-controls="application-management-tab3-section" aria-expanded="false"><span class="u-default-max-width">How can I get some more specific feedback as to why I was rejected?</span></button>
               </div>
               <section class="p-accordion__panel" id="application-management-tab3-section" aria-hidden="true" aria-labelledby="application-management-tab3">
-                <p>We try our hardest to give some useful feedback to our candidates, especially if you have entered the interview stage. However it is not always possible for us to provide individual feedback for candidates at the earlier assessment stages of our process. We hope you understand that we receive a lot of applications so it is hard to deliver individual feedback.</p>
+                <p>It is not always possible for us to provide individual feedback for candidates due to the number of applications we receive and the fact that we prioritise getting you in front of the business team as opposed to a screening process run by HR. We hope you understand this impacts our ability to handle specific feedback requests.</p>
               </section>
             </li>
             <li class="p-accordion__group">
@@ -239,7 +239,7 @@
                 <button type="button" class="p-accordion__tab" id="application-management-tab4" aria-controls="application-management-tab4-section" aria-expanded="false"><span class="u-default-max-width">When can I apply again?</span></button>
               </div>
               <section class="p-accordion__panel" id="application-management-tab4-section" aria-hidden="true" aria-labelledby="application-management-tab4">
-                <p>We try to hire with potential in mind and divert you to other roles that we feel might be a better fit for you. If you have been rejected for a role you may not quite have the right skills required at that point in time. There is no limit on when you can apply again, but it probably means that you may need to gain some more experience before applying to the same role again.</p>
+                <p>We try to hire with potential in mind and divert you to other roles that we feel might be a better fit for you during your process. If you have been rejected for a role you may not quite have the right skills required at that point in time. You can apply to a specific role once in a 180 day period or for up to four different roles at Canonical in a 180 day period.</p>
               </section>
             </li>
             <li class="p-accordion__group">
@@ -255,7 +255,7 @@
                 <button type="button" class="p-accordion__tab" id="application-management-tab6" aria-controls="application-management-tab6-section" aria-expanded="false"><span class="u-default-max-width">Can I apply to multiple roles at the same time?</span></button>
               </div>
               <section class="p-accordion__panel" id="application-management-tab6-section" aria-hidden="true" aria-labelledby="application-management-tab6">
-                <p>Yes you can. If you see more than one role we are happy to receive your application again. Try to take a look at the job description and requirements and apply to the ones you specifically feel most suitable for. Our Hiring Leads work to find you the best fit role here too but it is always good to understand where your main interests lie.</p>
+                <p>Yes you can apply for up to four roles in a 180 day period. Try to take a look at the job description and requirements and apply to the ones you specifically feel most suitable for. Our Hiring Leads work to find you the best fit role here too but it is always good to understand where your main interests lie.</p>
               </section>
             </li>
             <li class="p-accordion__group">
@@ -263,7 +263,7 @@
                 <button type="button" class="p-accordion__tab" id="application-management-tab7" aria-controls="application-management-tab7-section" aria-expanded="false"><span class="u-default-max-width">How do I withdraw my application?</span></button>
               </div>
               <section class="p-accordion__panel" id="application-management-tab7-section" aria-hidden="true" aria-labelledby="application-management-tab7">
-                <p>If you would like to withdraw your application for a role please locate the button on your candidate page to confirm you would like us to process your request.</p>
+                <p>If you would like to withdraw your application for a role please locate the button on your candidate dashboard to confirm you would like us to process your request.</p>
               </section>
             </li>
           </ul>


### PR DESCRIPTION
## Done

- Updated copy on the careers FAQ page (`/careers/application/faq`) according to the [updated copy doc](https://docs.google.com/document/d/12_O_QtPqfv9p7kaDFdiP8Xq-kY5xa1XB-C-CRbXjDew/edit)

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Navigate to FAQ page `http://localhost:8002/careers/application/faq`
- Ensure that copy matches that of the updated copy doc

## Issue / Card

[WD-14594](https://warthogs.atlassian.net/browse/WD-14594)


[WD-14594]: https://warthogs.atlassian.net/browse/WD-14594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ