### PR TITLE
update "four" to "4" in faq copy

### DIFF
--- a/templates/careers/application/faq.html
+++ b/templates/careers/application/faq.html
@@ -239,7 +239,7 @@
                 <button type="button" class="p-accordion__tab" id="application-management-tab4" aria-controls="application-management-tab4-section" aria-expanded="false"><span class="u-default-max-width">When can I apply again?</span></button>
               </div>
               <section class="p-accordion__panel" id="application-management-tab4-section" aria-hidden="true" aria-labelledby="application-management-tab4">
-                <p>We try to hire with potential in mind and divert you to other roles that we feel might be a better fit for you during your process. If you have been rejected for a role you may not quite have the right skills required at that point in time. You can apply to a specific role once in a 180 day period or for up to four different roles at Canonical in a 180 day period.</p>
+                <p>We try to hire with potential in mind and divert you to other roles that we feel might be a better fit for you during your process. If you have been rejected for a role you may not quite have the right skills required at that point in time. You can apply to a specific role once in a 180 day period or for up to 4 different roles at Canonical in a 180 day period.</p>
               </section>
             </li>
             <li class="p-accordion__group">


### PR DESCRIPTION
## Done

- As per TS request, updated the number "four" to be a digit instead.

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Navigate to FAQ page http://localhost:8002/careers/application/faq
- Ensure that four is displayed as a digit for the "When can I apply again?" question.
