### PR TITLE
Add is-required label to required fields

### DIFF
--- a/templates/data/_form-data-kafka.html
+++ b/templates/data/_form-data-kafka.html
@@ -30,11 +30,11 @@
                   </li>
                   <li class="p-list__item">
                     <label class="is-required" for="company">Company name:</label>
-                    <input required id="company" name="company" maxlength="255" type="text">
+                    <input required id="company" name="company" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
                     <label class="is-required" for="title">Job title:</label>
-                    <input required id="title" name="title" maxlength="255" type="text">
+                    <input required id="title" name="title" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
                     <label class="is-required" for="email">Work email:</label>
@@ -46,7 +46,7 @@
                   </li>
                   <li class="p-list__item">
                     <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+                      <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                       <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                     </label>
                   </li>

--- a/templates/data/_form-data-kafka.html
+++ b/templates/data/_form-data-kafka.html
@@ -21,27 +21,27 @@
                 <h3 class="p-heading--5">How should we get in touch?</h3>
                 <ul class="p-list">
                   <li class="p-list__item">
-                    <label for="firstName">First name:</label>
+                    <label class="is-required" for="firstName">First name:</label>
                     <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
                   </li>
                   <li class="p-list__item">
-                    <label for="lastName">Last name:</label>
+                    <label class="is-required" for="lastName">Last name:</label>
                     <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
                   </li>
                   <li class="p-list__item">
-                    <label for="company">Company name:</label>
+                    <label class="is-required" for="company">Company name:</label>
                     <input required id="company" name="company" maxlength="255" type="text">
                   </li>
                   <li class="p-list__item">
-                    <label for="title">Job title:</label>
+                    <label class="is-required" for="title">Job title:</label>
                     <input required id="title" name="title" maxlength="255" type="text">
                   </li>
                   <li class="p-list__item">
-                    <label for="email">Work email:</label>
+                    <label class="is-required" for="email">Work email:</label>
                     <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
                   </li>
                   <li class="p-list__item">
-                    <label for="phone">Mobile/cell phone number:</label>
+                    <label class="is-required" for="phone">Mobile/cell phone number:</label>
                     <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
                   </li>
                   <li class="p-list__item">

--- a/templates/data/_form-data-mongodb.html
+++ b/templates/data/_form-data-mongodb.html
@@ -16,17 +16,17 @@
               <hr>
               <h3 class="p-heading--5">How should we get in touch?</h3>
               <div class="p-section--shallow">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
-                <label for="company">Company name:</label>
+                <label class="is-required" for="company">Company name:</label>
                 <input required id="company" name="company" maxlength="255" type="text">
-                <label for="title">Job title:</label>
+                <label class="is-required" for="title">Job title:</label>
                 <input data-testid="form-jobTitle" required id="title" name="title" maxlength="255" type="text">
-                <label for="email">Work email:</label>
+                <label class="is-required" for="email">Work email:</label>
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
-                <label for="phone">Phone number:</label>
+                <label class="is-required" for="phone">Phone number:</label>
                 <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </div>
               <div class="p-section--shallow">

--- a/templates/data/_form-data-mongodb.html
+++ b/templates/data/_form-data-mongodb.html
@@ -10,10 +10,10 @@
           <div class="row">
             <div class="col-6">
               <div class="p-section--shallow">
-                <label for="Comments_from_lead__c">Tell us more about your MongoDB use case</h2>
+                <label for="Comments_from_lead__c">Tell us more about your MongoDB use case</label>
                 <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" aria-label="Anything you'd like to communicate about your needs or interests?" rows="3" placeholder="Anything you'd like to communicate about your needs or interests?"></textarea>
               </div>
-              <hr>
+              <hr />
               <h3 class="p-heading--5">How should we get in touch?</h3>
               <div class="p-section--shallow">
                 <label class="is-required" for="firstName">First name:</label>
@@ -21,9 +21,9 @@
                 <label class="is-required" for="lastName">Last name:</label>
                 <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
                 <label class="is-required" for="company">Company name:</label>
-                <input required id="company" name="company" maxlength="255" type="text">
+                <input required id="company" name="company" maxlength="255" type="text" />
                 <label class="is-required" for="title">Job title:</label>
-                <input data-testid="form-jobTitle" required id="title" name="title" maxlength="255" type="text">
+                <input data-testid="form-jobTitle" required id="title" name="title" maxlength="255" type="text" />
                 <label class="is-required" for="email">Work email:</label>
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
                 <label class="is-required" for="phone">Phone number:</label>
@@ -31,7 +31,7 @@
               </div>
               <div class="p-section--shallow">
                 <label class="p-checkbox">
-                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
                 <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
@@ -61,7 +61,7 @@
                 <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               </div>
               
-              <hr class="is-fixed-width">
+              <hr class="is-fixed-width" />
               <div class="pagination">
                 <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
               </div>


### PR DESCRIPTION
## Done

- Add "is-required" class to required fields for /data/mongodb#get-in-touch and /data/kafka#get-in-touch contact forms
- The Jira issue reports a "Not Provided" payload for the required fields, this could not be replicated locally so this PR should explicitly tell users to fill up the forms with the required labels

## QA

- Go to /data/mongodb#get-in-touch and /data/kafka#get-in-touch
- See that the contact fields have required `*` on the labels

## Issue / Card

Fixes [WD-14682](https://warthogs.atlassian.net/browse/WD-14682)

## Screenshots

[if relevant, include a screenshot]


[WD-14682]: https://warthogs.atlassian.net/browse/WD-14682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ