### PR TITLE
Fix application question field

### DIFF
--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -6,10 +6,10 @@
 
 {% block meta_keywords %}{{ job.skills | join(', ') }}{% endblock %}
 
-{% block canonical_url %}{{request.host_url}}careers/{{job.id}}{% endblock %}
+{% block canonical_url %}{{ request.host_url }}careers/{{ job.id }}{% endblock %}
 
 {% block extra_metatags %}
-<link rel="alternate" type="application/rss+xml"  href="/careers/feed" title="All job roles | Canonical Careers">
+<link rel="alternate" type="application/rss+xml"  href="/careers/feed" title="All job roles | Canonical Careers"/>
 
 <script type="application/ld+json">
   {
@@ -52,9 +52,9 @@
 {% if message %}
 <div class="row">
   <div class="col-8">
-    <div class="p-notification--{{message.type}}">
+    <div class="p-notification--{{ message.type }}">
       <p class="p-notification__content">
-        <span class="p-notification__title">{{message.title}}:&nbsp;</span>{{message.text}}
+        <span class="p-notification__title">{{ message.title }}:&nbsp;</span>{{ message.text }}
       </p>
     </div>
   </div>
@@ -77,7 +77,7 @@
 {% block application_content %}
 <div class="row">
   <div class="col-6">
-    <hr class="u-no-margin--bottom">
+    <hr class="u-no-margin--bottom"/>
     <h3 class="p-heading--5">Apply for this role</h3>
     <form action="{{ request.path }}" method="POST" enctype="multipart/form-data" class="js-roles-list--form" onsubmit="dataLayer.push({
           'event': 'GAEvent',
@@ -92,10 +92,10 @@
           {% for question in job.questions %}
           <label for="{{ question.name }}" class="{% if question.required %}is-required{% endif %}">{{ question.label }}</label>
             {% if question.type == "short_text" %}
-            <input id="{{ question.name }}" name="{{ question.name }}" {% if question.description %}aria-describedby="{{ question.name }}_help"{% endif %} type="text" {% if question.required %}required{% endif %} maxlength="255">
+            <input id="{{ question.name }}" name="{{ question.name }}" {% if question.description %}aria-describedby="{{ question.name }}_help"{% endif %} type="text" {% if question.required %}required{% endif %} maxlength="255"/>
             {% if question.description %}<p class="p-form-help-text" id="{{ question.name }}_help">{{ question.description | striptags }}</p>{% endif %}
             {% elif question.type == "attachment" %}
-            <input id="{{ question.name }}" name="{{ question.name }}" {% if question.description %}aria-describedby="{{ question.name }}_help"{% endif %} type="file" {% if question.required %}required{% endif %} accept=".pdf, .doc, .docx, .txt, .rtf">
+            <input id="{{ question.name }}" name="{{ question.name }}" {% if question.description %}aria-describedby="{{ question.name }}_help"{% endif %} type="file" {% if question.required %}required{% endif %} accept=".pdf, .doc, .docx, .txt, .rtf"/>
             {% if question.description %}<p class="p-form-help-text" id="{{ question.name }}_help">{{ question.description | striptags }}</p>{% endif %}
             {% elif question.type == "long_text" %}
             <textarea id="{{ question.name }}" name="{{ question.name }}" {% if question.description %}aria-describedby="{{ question.name }}_help"{% endif %} type="textarea" {% if question.required %}required{% endif %}></textarea>
@@ -120,7 +120,7 @@
           {% endfor %}
         {% endif %}
         <hr style="margin: 1rem 0;" />
-        <input type="submit" class="p-button--positive u-no-margin--bottom" name="submit" value="Submit application">
+        <input type="submit" class="p-button--positive u-no-margin--bottom" name="submit" value="Submit application"/>
       </fieldset>
     </form>
   </div>

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -108,7 +108,7 @@
               {% endfor %}
             </select>
             {% if question.description %}<p class="p-form-help-text" id="{{ question.name }}_help">{% if 'a href' in question.description %}{{ question.description | safe }}{% else %}{{ question.description | striptags }}{% endif %}</p>{% endif %}
-            {% elif question.type == "multi_value_multi_select" %}
+            {% elif question.type == "multi_value_multi_select" or question.type == "multi_select" %}
             <select name="{{ question.name }}" id="{{ question.name }}" {% if question.description %}aria-describedby="{{ question.name }}_help"{% endif %} multiple="" {% if question.required %}required{% endif %}>
               <option value="" disabled="disabled">Select...</option>
               {% for answer_option in question.get("values",[]) %}


### PR DESCRIPTION
## Rationale
An issue came through the TS ticketing system and was passed to us, where this application has an input field missing for the Ceph question.

Turned out that this Ceph question has a question type of `multi_select`, while on the frontend for canonical.com we only check for the multi select type of `multi_value_multi_select`, hence the problem.

## Done

- Add check for `multi_select` question type

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Navigate to http://localhost:8002/careers/1861978/application and ensure that the field shows up correctly for the "Describe your experience with Ceph" question.

## Issue / Card

[WD-14817](https://warthogs.atlassian.net/browse/WD-14817)

## Screenshots

Before fix:
![image](https://github.com/user-attachments/assets/62078e39-9c33-481e-9b3d-b57e183ce8ae)

After fix:
![Screenshot 2024-09-11 193359](https://github.com/user-attachments/assets/7ed5dfe0-436f-419d-8ba6-b513a002c8b5)


[WD-14817]: https://warthogs.atlassian.net/browse/WD-14817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ