### PR TITLE
WD-15180 Added secondary navigation for /data/* pages

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -55,3 +55,42 @@ lxd:
       path: https://documentation.ubuntu.com/lxd/en/latest/?_ga=2.91941594.1329653141.1700868845-1063360542.1700868845
     - title: Forum
       path: https://discourse.ubuntu.com/c/lxd/126?_ga=2.69179345.1978494405.1700868870-354120313.1700868870
+
+mongodb:
+  title: MongoDB
+  path: /data/mongodb
+
+  children:
+    - title: Overview
+      path: /data/mongodb
+    - title: Managed
+      path: /data/mongodb/managed
+    - title: Support
+      path: /data/mongodb/support
+    - title: What is MongoDB
+      path: /data/mongodb/what-is-mongodb
+
+opensearch:
+  title: OpenSearch
+  path: /data/opensearch
+
+  children:
+    - title: Overview
+      path: /data/opensearch
+    - title: Managed
+      path: /data/opensearch/managed
+    - title: Support
+      path: /data/opensearch/support
+    - title: What is OpenSearch
+      path: /data/opensearch/what-is-opensearch
+
+postgresql:
+  title: PostgreSQL
+  path: /data/postgresql
+
+  children:
+    - title: Overview
+      path: /data/postgresql
+    - title: What is PostgreSQL
+      path: /data/postgresql/what-is-postgresql
+


### PR DESCRIPTION
## Done

- Secondary navigation for pages inside 
   - /data/opensearch 
   - /data/postgresql
   - /data/opensearch
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [Design](https://www.figma.com/design/p0y7lHJ7edLIeSXM1qbpRZ/23.10-C.com-%26-U.com---Navigation?node-id=201-1141&node-type=canvas&t=wtOPAA7pKwQPInkA-0)
- [Copydoc](https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit#heading=h.wgubbpfalsgo)
- [Demo](https://canonical-com-1378.demos.haus/data/)
## Issue / Card

Fixes # [WD-15180](https://warthogs.atlassian.net/browse/WD-15180)

## Screenshots

[if relevant, include a screenshot]


[WD-15180]: https://warthogs.atlassian.net/browse/WD-15180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ