### PR TITLE
fix: incorrect usage of p-rule on secure open source page

### DIFF
--- a/templates/solutions/secure-open-source/index.html
+++ b/templates/solutions/secure-open-source/index.html
@@ -123,7 +123,7 @@
         <div class="col-3 col-start-large-4 col-medium-2">
           <h5>Data centres</h5>
         </div>
-        <div class="p-section--shallow col-6 col-start-large-7 col-medium-4 p-rule--muted">
+        <div class="p-section--shallow col-6 col-start-large-7 col-medium-4">
           <p>
             Secure your enterprise data centre and all its open source components, from the OS to private cloud platforms like OpenStack and orchestration tools like Kubernetes. Perform hardening and auditing at scale, even in air-gapped environments.
           </p>


### PR DESCRIPTION
## Done

Removes incorrect usage of `p-rule--muted` on the secure open source page. Looks like an `is-muted` (that was doing nothing without `p-rule`) was [changed to a p-rule--muted](https://github.com/canonical/canonical.com/commit/bc874d6a1d66d1d50d2fe48730ec83890aa8f52a#diff-a7ad1fda3162b6860337dc853c6f5d422ca84ebbaab360bb4a25b7dcf070ce8e), which caused a section to behave like a rule and threw off spacing.

## QA

- Navigate to [secure open source page](https://canonical-com-1387.demos.haus/solutions/secure-open-source)
- See "data centres" list item and confirm it has no spacing issues, like it does on [production currently](https://canonical.com/solutions/secure-open-source)

## Issue / Card

Fixes [MM message](https://chat.canonical.com/canonical/pl/85ph1dz6zfdciquqm4idssy7rc)

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/dfba6621-b225-41e2-88cb-2f6bec517f77)
After:
![image](https://github.com/user-attachments/assets/b867c7a1-8ba5-42ec-96ff-fa03c5b0cdc4)

