### PR TITLE
Add parent path to secondary navigation

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -84,6 +84,10 @@ opensearch:
   title: OpenSearch
   path: /data/opensearch
 
+  parent:
+    - title: All data solutions
+    - path: /data
+
   children:
     - title: Overview
       path: /data/opensearch
@@ -97,6 +101,10 @@ opensearch:
 postgresql:
   title: PostgreSQL
   path: /data/postgresql
+
+  parent:
+    - title: All data solutions
+    - path: /data
 
   children:
     - title: Overview

--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -4,6 +4,10 @@
 #   title: Page title
 #   path: /page-url
 #
+#   parent: (optional)
+#     - title: Parent navigation title
+#     - path: /parent-page-url
+#
 #   children:
 #     - title: Overview
 #       path: /page-url (note this is the same as the page's url)
@@ -61,6 +65,10 @@ lxd:
 mongodb:
   title: MongoDB
   path: /data/mongodb
+
+  parent:
+    - title: All data solutions
+    - path: /data
 
   children:
     - title: Overview

--- a/templates/navigation/secondary-navigation.html
+++ b/templates/navigation/secondary-navigation.html
@@ -35,8 +35,16 @@
               </li>
             {% endif %}
           {% endfor %}
+        </ul>
+        {% if page_bubble.parent_title and page_bubble.parent_path %}
+          <ul class="p-navigation__items">
+            <li class="p-navigation__item"></li>
+              <li class="p-navigation__item">
+                <a class="p-navigation__link" href={{ page_bubble.parent_path }}>{{ page_bubble.parent_title }}</a>
+              </li>
+          </ul>
         {% endif %}
-      </ul>
+      {% endif %}
     </nav>
   </div>
 </div>

--- a/webapp/navigation.py
+++ b/webapp/navigation.py
@@ -26,12 +26,10 @@ def get_current_page_bubble(path):
 
     page_bubbles = copy.deepcopy(secondary_navigation_data)
 
-    parent = None
     for page_bubble_name, page_bubble in page_bubbles.items():
         if path.startswith(page_bubble["path"]):
             current_page_bubble = page_bubble
-            if parent is None:
-                parent = page_bubble.get("parent", None)
+            parent = page_bubble.get("parent", None)
 
             if parent:
                 current_page_bubble["parent_title"] = parent[0]["title"]

--- a/webapp/navigation.py
+++ b/webapp/navigation.py
@@ -26,9 +26,17 @@ def get_current_page_bubble(path):
 
     page_bubbles = copy.deepcopy(secondary_navigation_data)
 
+    parent = None
     for page_bubble_name, page_bubble in page_bubbles.items():
         if path.startswith(page_bubble["path"]):
             current_page_bubble = page_bubble
+            if parent is None:
+                parent = page_bubble.get("parent", None)
+
+            if parent:
+                current_page_bubble["parent_title"] = parent[0]["title"]
+                current_page_bubble["parent_path"] = parent[1]["path"]
+
             for page in page_bubble["children"]:
                 if page["path"] == path:
                     page["active"] = True


### PR DESCRIPTION
## Done
- Add `parent` attribute to secondary navigation
- Includes parent link and title
- Shows the parent title & link on secondary navigation 
- Add parent navigation path to data bubbles (/data/mongodb, /data/postgresql, /data/opensearch)



## QA

- Go to https://canonical-com-1390.demos.haus/data/mongodb, https://canonical-com-1390.demos.haus/data/postgresql, https://canonical-com-1390.demos.haus/data/opensearch
- [Figma](https://www.figma.com/design/p0y7lHJ7edLIeSXM1qbpRZ/23.10-C.com-%26-U.com---Navigation?node-id=751-3021&node-type=canvas&t=1QDhRKdqjli5aiQn-0)
- Check on small screens

## Issue / Card

Fixes [WD-15568](https://warthogs.atlassian.net/browse/WD-15568)

## Screenshots

[if relevant, include a screenshot]


[WD-15568]: https://warthogs.atlassian.net/browse/WD-15568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ