### PR TITLE
Update form id for telco-5g and quote macro

### DIFF
--- a/templates/macros/quote_wrapper.jinja
+++ b/templates/macros/quote_wrapper.jinja
@@ -21,7 +21,7 @@
   citation_source_title_text="",
   citation_source_organisation_text="",
   is_shallow=False
-  ) -%}
+) -%}
   {% set heading_link_content = caller('heading_link') %}
   {% set has_heading_link = heading_link_content|trim|length > 0 %}
   {% set has_title = title_text|length > 0 %}
@@ -48,7 +48,8 @@
   {% endif %}
 
   {%- macro _quote_body() -%}
-    <div class="p-section--shallow">
+    {#- Only use shallow section spacing if a another block follows -#}
+    <div {% if has_cta or has_image %} class="p-section--shallow"{% endif %}>
       <p class="p-heading--{{ quote_heading_level }}">
         <i>
           &#8220;{{ quote_text }}&#8221;
@@ -92,7 +93,7 @@
 
   {%- macro _heading_block() %}
     {% if has_heading_row -%}
-      {#- Optional heading  -#}
+      {#- Optional heading -#}
       <div class="p-section--shallow">
         <hr class="p-rule--highlight is-fixed-width" />
         <div class="row">
@@ -106,7 +107,9 @@
           {%- if has_heading_link %}
             {#- Optional heading link  -#}
             <div class="col-3 col-medium-4 col-start-large-10 col-start-medium-3">
-              <p class="p-text--default">{{ heading_link_content }}</p>
+              <p class="p-text--default">
+                {{ heading_link_content }}
+              </p>
             </div>
           {% endif -%}
         </div>
@@ -120,7 +123,9 @@
       {% if has_signpost_image -%}
         {#- Optional signpost image -#}
         <div class="col-3 col-medium-2">
-          <div class="p-section--shallow">{{ signpost_image_content }}</div>
+          <div class="p-section--shallow">
+            {{ signpost_image_content }}
+          </div>
         </div>
       {% endif -%}
       {#- Skip to fourth column if the signpost_image (which takes up first three columns) is missing -#}
@@ -129,7 +134,9 @@
         {% if has_citation -%}
           {#-  When a citation is present, wrap the quote and citation in a nested grid to space them properly  -#}
           <div class="row">
-            <div class="col-6">{{ _quote_body() }}</div>
+            <div class="col-6">
+              {{ _quote_body() }}
+            </div>
             <div class="col-3">
               <hr class="p-rule--muted u-hide--large" />
               {{ _citation_block() }}
@@ -142,19 +149,17 @@
 
         {%- if has_cta or has_image -%}
           {#-  Optional CTA and/or image block  -#}
-          <div class="p-section--shallow">
-            <div class="row">
-              {%- if has_cta %}
-                {#-  Optional CTA block -#}
-                <div class="p-cta-block">{{ cta_content }}</div>
-              {% endif -%}
-
-              {% if has_image -%}
-                {#-  Optional image block  -#}
-                {{ image_content }}
-              {% endif -%}
+          {%- if has_cta %}
+            {#-  Optional CTA block -#}
+            <div class="p-cta-block">
+              {{ cta_content }}
             </div>
-          </div>
+          {% endif -%}
+
+          {% if has_image -%}
+            {#-  Optional image block  -#}
+            {{ image_content }}
+          {% endif -%}
         {% endif -%}
       </div>
     </div>

--- a/templates/solutions/telco/_form-telco-5g.html
+++ b/templates/solutions/telco/_form-telco-5g.html
@@ -129,7 +129,7 @@
                          aria-hidden="true"
                          aria-label="hidden field"
                          name="formid"
-                         value="5522" />
+                         value="5716" />
                   <input type="hidden"
                          aria-hidden="true"
                          aria-label="hidden field"


### PR DESCRIPTION
## Done

- Update form ID for dynamic telco 5g forms
- Copy over updated quote macros from Vanilla to fix extra bottom padding issue

## QA

- Go to https://canonical-com-1391.demos.haus/solutions/telco/5g-core#get-in-touch and https://canonical-com-1391.demos.haus/solutions/telco/5g-edge#get-in-touch
- Click on Contact Us CTA and check that form ID is 5716, matching the [copy doc](https://docs.google.com/document/d/1mi6NOW_GiCMZ1O4xRCxS2RPhZMjEaOdipD5LFnCvMz4/edit) for forms
- Go to https://canonical-com-1391.demos.haus/solutions/telco/5g-edge
- Scroll down to the quote section, see that there is only one bottom padding for the quote section
![Uploading Screenshot 2024-10-09 at 1.53.22 PM.png…]()


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
