### PR TITLE
Feature openstack

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -82,7 +82,7 @@ products:
             url: https://snapcraft.io/
           - title: OpenStack
             description: Private cloud provisioning
-            url: https://ubuntu.com/openstack
+            url: /openstack
           - title: MicroCloud
             description: Lightweight, automated clouds
             url: /microcloud

--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -195,3 +195,13 @@ microstack:
       path: https://bugs.launchpad.net/snap-openstack/+filebug
     - title: Get commercial support
       path: https://ubuntu.com/pro
+
+openstack:
+  title: OpenStack
+  path: /openstack
+
+  children:
+    - title: Overview
+      path: /openstack
+    - title: Architecture
+      path: /openstack/architecture 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -206,6 +206,15 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   }
 }
 
+.p-stepped-list--detailed {
+  .p-stepped-list__title {
+    &::before {
+      text-align: left;
+    }
+    padding-left: 2rem;
+  }
+}
+
 .p-card--pillar {
   background: url("https://assets.ubuntu.com/v1/8131976a-sustainability-suru.png");
   background-position: -45px 45px;

--- a/templates/openstack/_form-openstack.html
+++ b/templates/openstack/_form-openstack.html
@@ -1,0 +1,165 @@
+<div class="p-modal" style="display: none;" id="openstack-modal">
+  <div class="p-modal__dialog is-paper" role="dialog">
+    <div class="js-pagination js-pagination--1">
+      <div class="js-formfield">
+        <div class="row--50-50 p-strip is-shallow">
+          <div class="col">
+            <h2 class="p-heading--1">Tell us about your OpenStack needs</h2>
+          </div>
+          <div class="col">
+            <button class="p-modal__close p-modal-close-button "
+                    aria-controls="openstack-modal"
+                    aria-label="Close active modal"
+                    style="margin-top: 0">Close</button>
+            <form action="https://ubuntu.com/marketo/submit"
+                  method="post"
+                  class="modal-form">
+              <div class="p-section--shallow">
+                <label for="Comments_from_lead__c">What advice are you looking for?</label>
+                <textarea required
+                          id="Comments_from_lead__c"
+                          name="Comments_from_lead__c"
+                          rows="4"
+                          maxlength="2000"></textarea>
+              </div>
+              <h3 class="p-heading--5">How should we get in touch</h3>
+              <div class="p-section--shallow">
+                <label for="firstName" class="is-required">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
+              </div>
+              <div class="p-section--shallow">
+                <label for="lastName" class="is-required">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
+              </div>
+              <div class="p-section--shallow">
+                <label for="email" class="is-required">Email:</label>
+                <input required
+                       id="email"
+                       name="email"
+                       maxlength="255"
+                       type="email"
+                       pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+              </div>
+              <div class="p-section--shallow">
+                <label for="phone">Phone number:</label>
+                <input id="phone" name="phone" maxlength="255" type="tel" pattern="[0-9\s]+" />
+                <p class="p-form-help-text" id="exampleHelpTextMessage">Format: only numbers</p>
+              </div>
+              <div class="p-section--shallow">
+                <label for="company">Company:</label>
+                <input id="company" name="company" maxlength="255" type="text" />
+              </div>
+              <div class="p-section--shallow">
+                <label for="title">Job title:</label>
+                <input id="title" name="title" maxlength="255" type="text" />
+              </div>
+              <div class="p-section--shallow">
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input"
+                         value="yes"
+                         aria-labelledby="canonicalUpdatesOptIn"
+                         name="canonicalUpdatesOptIn"
+                         type="checkbox" />
+                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+                </label>
+              </div>
+              <div class="p-section--shallow">
+                By submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact" target="_blank">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a>.
+              </div>
+              {# These are honey pot fields to catch bots #}
+              <div class="u-off-screen">
+                <label class="website" for="website">Website:</label>
+                <input name="website"
+                       type="text"
+                       class="website"
+                       autocomplete="off"
+                       value=""
+                       id="website"
+                       tabindex="-1" />
+              </div>
+              <div class="u-off-screen">
+                <label class="name" for="name">Name:</label>
+                <input name="name"
+                       type="text"
+                       class="name"
+                       autocomplete="off"
+                       value=""
+                       id="name"
+                       tabindex="-1" />
+              </div>
+              {# End of honey pots #}
+
+              <div class="u-hide">
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="returnURL"
+                       value="{{ returnURL }}" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="formid"
+                       value="6024" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="Consent_to_Processing__c"
+                       value="yes" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="acquisition_url"
+                       id="acquisition_url"
+                       value="{{ request.url }}" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="utm_campaign"
+                       id="utm_campaign"
+                       value="" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="utm_medium"
+                       id="utm_medium"
+                       value="" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="utm_source"
+                       id="utm_source"
+                       value="" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="utm_content"
+                       id="utm_content"
+                       value="" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="utm_term"
+                       id="utm_term"
+                       value="" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       id="preferredLanguage"
+                       name="preferredLanguage"
+                       maxlength="255"
+                       value="" />
+              </div>
+
+              <div class="pagination">
+                <hr class="p-rule--muted" />
+                <button type="submit"
+                        class="pagination__link--next p-button--positive"
+                        aria-label="Submit">Submit</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/openstack/_form-openstack.html
+++ b/templates/openstack/_form-openstack.html
@@ -4,7 +4,8 @@
       <div class="js-formfield">
         <div class="row--50-50 p-strip is-shallow">
           <div class="col">
-            <h2 class="p-heading--1">Tell us about your OpenStack needs</h2>
+            <h2 class="p-heading--1">Get in touch with the OpenStack team</h2>
+            <p>Fill in this form and a member of our team will be in touch shortly.</p>
           </div>
           <div class="col">
             <button class="p-modal__close p-modal-close-button "
@@ -15,7 +16,7 @@
                   method="post"
                   class="modal-form">
               <div class="p-section--shallow">
-                <label for="Comments_from_lead__c">What advice are you looking for?</label>
+                <label for="Comments_from_lead__c" class="is-required">What advice are you looking for?</label>
                 <textarea required
                           id="Comments_from_lead__c"
                           name="Comments_from_lead__c"
@@ -153,7 +154,7 @@
               <div class="pagination">
                 <hr class="p-rule--muted" />
                 <button type="submit"
-                        class="pagination__link--next p-button--positive"
+                        class="pagination__link--next p-button--positive js-submit-button"
                         aria-label="Submit">Submit</button>
               </div>
             </form>

--- a/templates/openstack/architecture.html
+++ b/templates/openstack/architecture.html
@@ -171,7 +171,7 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <hr class="p-rule--muted u-hide--small" />
+        <hr class="p-rule--muted u-hide--small u-hide--medium" />
         <div class="p-image-container u-hide--medium u-hide--small">
           {{ image(url="https://assets.ubuntu.com/v1/aa31dc00-1.2.2.png",
                     alt="",

--- a/templates/openstack/architecture.html
+++ b/templates/openstack/architecture.html
@@ -1,0 +1,284 @@
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1i8rjvhw3N2gDA5NXuKEPcftXY95zePjsURmQu4dSgGo
+{% endblock meta_copydoc %}
+
+{% block title %}OpenStack architecture{% endblock %}
+
+{% block meta_description %}
+  OpenStack under the hood: explore OpenStack architecture and understand how it works.
+{% endblock %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block content %}
+  <section class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col">
+        <h1>OpenStack architecture</h1>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <p>
+            The best recipe for a successful cloud deployment is to follow a proven design guide from an experienced and trusted advisor. Canonical's reference architecture for OpenStack has been successfully deployed across hundreds of customers and thousands of sites.
+          </p>
+        </div>
+        <hr class="is-muted" />
+        <a class="p-button--positive"
+           href="https://ubuntu.com/engage/dell-openstack-reference-architecture">Check the reference architecture</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="is-muted" />
+      <div class="col">
+        <h2>Is OpenStack complex?</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <p>
+            Everyone who has any experience with OpenStack knows this feeling very well. You want to try it. You're committed to learning it. You even start exploring its documentation. But then, almost immediately, <a href="https://docs.openstack.org/install-guide/_images/openstack-arch-kilo-logical-v1.png">you are exposed to its complex architecture</a>.
+          </p>
+          <p>
+            Tens of services, hundreds of processes, thousands of different configuration options: all of that to meet the needs of the most demanding industries, end users and their use cases. But do you really need all this overhead? What if all you need is your own general-purpose cloud?
+          </p>
+          <p>Keep reading to learn how Canonical OpenStack helps you bypass all this complexity.</p>
+        </div>
+      </div>
+      <div class="p-image-container is-highlighted u-hide--small">
+
+        {{ image(url="https://assets.ubuntu.com/v1/4cb083ab-openstack-arch-kilo-logical-v1.png",
+                alt="",
+                width="2102",
+                height="1003",
+                hi_def=True,
+                attrs={"class": "p-image-container__image"},
+                loading="lazy") | safe
+        }}
+      </div>
+    </div>
+
+  </section>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="is-muted" />
+      <div class="col">
+        <h2>Why Canonical OpenStack?</h2>
+      </div>
+      <div class="col p-section">
+        <div>
+          <p>
+            If you want to use OpenStack, but don't necessarily want to deal with its internals, you're in the right place. Canonical effectively tames the complexity of the upstream OpenStack project and delivers its distilled excellence in the form of a human-friendly product &mdash; Canonical OpenStack.
+          </p>
+        </div>
+        <hr class="is-muted" />
+        <a href="https://canonical.com/openstack">Explore Canonical OpenStack&nbsp;&rsaquo;</a>
+      </div>
+      <hr class="is-muted u-hide--medium u-hide--small" />
+      <div class="p-equal-height-row">
+        <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__item">
+            <h5 class="p-heading--5">Opinionated design</h5>
+          </div>
+          <p class="p-equal-height-row__item">
+            Canonical OpenStack includes active and stable services only, together with the major compute, network and storage options. This eliminates friction, ensures an enterprise-grade stability and provides an “on rails” user experience.
+          </p>
+        </div>
+        <div class="p-equal-height-row__col">
+
+          <div class="p-equal-height-row__item">
+            <h5 class="p-heading--5">Cloud-native architecture</h5>
+          </div>
+          <p class="p-equal-height-row__item">
+            Canonical OpenStack comes with a fully cloud-native architecture based on <a href="https://ubuntu.com/kubernetes">Kubernetes</a>, <a href="https://ubuntu.com/security/docker-images">OCI images</a> and <a href="https://snapcraft.io/">snaps</a>. This decouples OpenStack from the underlying Ubuntu OS and makes its updates and upgrades simple, straightforward and user-friendly.
+          </p>
+        </div>
+        <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__item">
+            <h5 class="p-heading--5">Full bottom-up automation</h5>
+          </div>
+          <p class="p-equal-height-row__item">
+            Canonical OpenStack uses full bottom-up automation based on <a href="https://maas.io/">MAAS</a> and <a href="https://juju.is/">Juju</a> across all the layers of the stack. This covers the initial provisioning of physical machines, cloud bootstrap processes as well as its post-deployment operations.
+          </p>
+        </div>
+        <div class="p-equal-height-row__col">
+
+          <div class="p-equal-height-row__item">
+            <h5 class="p-heading--5">High-level abstraction</h5>
+          </div>
+          <p class="p-equal-height-row__item">
+
+            Canonical OpenStack exposes a high-level interface for bootstrapping and operating the cloud. This effectively abstracts the complexity of the upstream project and enables users to spin up a cloud in just a few simple steps.
+
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr />
+      <div class="col">
+        <h2>OpenStack under the hood</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <div class="p-image-container is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/144affdb-Canonical OpenStack architecture diagram final@2x.png",
+                        alt="",
+                        width="1954",
+                        height="720",
+                        hi_def=True,
+                        attrs={"class": "p-image-container__image"},
+                        loading="lazy") | safe
+            }}
+          </div>
+        </div>
+        <div class="p-section--shallow">
+          <p>
+            OpenStack uses a modular architecture with every service responsible for an individual cloud feature. This includes identity management, an image catalogue as well as all the compute, network and storage functions that are typically required to provision and decommission virtual machines.
+          </p>
+          <p>
+            The services are further broken down into processes based on a microservices architecture. Each process implements an atomic cloud function, such as handling user requests, proxying database queries or invoking various types of backend technologies used by OpenStack underneath.
+          </p>
+          <p>
+            In order to minimise its footprint, Canonical OpenStack ships with only the key features enabled by default. Additional features, such as CaaS or a Load Balancer can be enabled post-deployment with a single terminal command.
+          </p>
+        </div>
+        <hr class="is-muted" />
+        <a class="p-button--positive"
+           href="https://canonical.com/openstack/docs">Access supported features</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr />
+      <div class="col">
+        <div class="p-section--shallow">
+          <h2>OpenStack components</h2>
+        </div>
+      </div>
+      <div class="col">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">Services expose APIs and handle user requests</li>
+          <li class="p-list__item is-ticked">Processes create a service and implement atomic cloud functions</li>
+          <li class="p-list__item is-ticked">Dashboard provides a web-based user interface to services</li>
+          <li class="p-list__item is-ticked">Client provides a command-line user interface to services</li>
+          <li class="p-list__item is-ticked">Databases store various types of records created by services</li>
+          <li class="p-list__item is-ticked">Queues facilitate communication between processes within a service</li>
+        </ul>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <hr class="is-muted u-hide--small" />
+        <div class="p-image-container is-highlighted u-hide--small">
+          {{ image(url="https://assets.ubuntu.com/v1/aa31dc00-1.2.2.png",
+                    alt="",
+                    width="1846",
+                    height="1053",
+                    hi_def=True,
+                    attrs={"class": "p-image-container__image"},
+                    loading="lazy") | safe
+          }}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr />
+      <div class="col">
+        <h2>How does it work?</h2>
+      </div>
+      <div class="col">
+        <p>
+          In principle, OpenStack resembles the behaviour of leading public clouds. Users can provision resources from their own pool through a self-service portal. All requests are handled by OpenStack itself in a fully automated way. Don't believe it?
+        </p>
+        <hr class="is-muted" />
+        <p>
+          <a href="https://ubuntu.com/engage/openstack-introduction">Read the whitepaper: “An introduction to OpenStack”
+          &nbsp;&rsquo;</a>
+        </p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-start-large-4 col-9 col-medium-6">
+        <hr class="is-muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">1. The user requests resources</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              OpenStack enables on-demand resource provisioning. This means that users can request them at any time through the client, dashboard or APIs. No admin intervention is required. No ticket is needed to process users' requests. Provisioning happens behind the scenes. OpenStack takes care of everything.
+            </p>
+          </div>
+        </div>
+        <hr class="is-muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">2. OpenStack handles the request</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Depending on the type of a request, one or another service gets involved in its processing. Each service manages its own domain and provides all necessary functions to handle the given task. This includes user authentication, authorization, resource scheduling, metrics collection, etc.
+            </p>
+          </div>
+        </div>
+        <hr class="is-muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">3. OpenStack provisions resources</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              In order to provision the actual resource (a VM, a block storage volume, a snapshot or an external IP address), OpenStack relies on other technologies. This includes the <a href="https://ubuntu.com/server/docs/virtualisation-with-qemu">KVM</a> hypervisor, <a href="https://ubuntu.com/blog/data-centre-networking-what-is-ovn">OVN</a> for networking, <a href="https://ubuntu.com/ceph">Ceph</a> for storage and many, many more.
+            </p>
+          </div>
+        </div>
+        <hr class="is-muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">Payments</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              MongoDB can handle high-volume transactional data efficiently, making it suitable for banking operations that require quick and reliable transaction processing.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr />
+      <div class="col">
+        <h2>Get started with Canonical OpenStack</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <p>Are you ready for the next step? Get your own OpenStack instance up and running in just a few minutes.</p>
+          <p>
+            With Canonical OpenStack you can get started on your journey on a single physical machine. Simply try it out and continue learning through some practical exercises.
+          </p>
+        </div>
+        <hr class="is-muted" />
+        <a class="p-button--positive"
+           href="https://canonical.com/openstack/docs/single-node">Start today</a>
+      </div>
+    </div>
+  </section>
+
+{% endblock %}

--- a/templates/openstack/architecture.html
+++ b/templates/openstack/architecture.html
@@ -206,48 +206,50 @@
         </p>
       </div>
     </div>
-    <div class="col-start-large-4 col-9 col-medium-6">
-      <ol class="p-stepped-list--detailed">
-        <li class="p-stepped-list__item">
-          <div class="row">
-            <hr class="p-rule--muted u-hide--large" />
-            <div class="col-3 col-medium-3">
-              <h3 class="p-heading--5 p-stepped-list__title">The user requests resources</h3>
+    <div class="row">
+      <div class="col-start-large-4 col-9 col-medium-6">
+        <ol class="p-stepped-list--detailed">
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <hr class="p-rule--muted u-hide--large" />
+              <div class="col-3 col-medium-3">
+                <h3 class="p-heading--5 p-stepped-list__title">The user requests resources</h3>
+              </div>
+              <div class="col-6 col-medium-3">
+                <p class="p-stepped-list__content">
+                  OpenStack enables on-demand resource provisioning. This means that users can request them at any time through the client, dashboard or APIs. No admin intervention is required. No ticket is needed to process users' requests. Provisioning happens behind the scenes. OpenStack takes care of everything.
+                </p>
+              </div>
             </div>
-            <div class="col-6 col-medium-3">
-              <p class="p-stepped-list__content">
-                OpenStack enables on-demand resource provisioning. This means that users can request them at any time through the client, dashboard or APIs. No admin intervention is required. No ticket is needed to process users' requests. Provisioning happens behind the scenes. OpenStack takes care of everything.
-              </p>
+          </li>
+          <hr class="p-rule--muted u-hide--large" />
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-3">
+                <h3 class="p-heading--5 p-stepped-list__title">OpenStack handles the request</h3>
+              </div>
+              <div class="col-6 col-medium-3">
+                <p class="p-stepped-list__content">
+                  Depending on the type of a request, one or another service gets involved in its processing. Each service manages its own domain and provides all necessary functions to handle the given task. This includes user authentication, authorization, resource scheduling, metrics collection, etc.
+                </p>
+              </div>
             </div>
-          </div>
-        </li>
-        <hr class="p-rule--muted u-hide--large" />
-        <li class="p-stepped-list__item">
-          <div class="row">
-            <div class="col-3 col-medium-3">
-              <h3 class="p-heading--5 p-stepped-list__title">OpenStack handles the request</h3>
+          </li>
+          <hr class="p-rule--muted u-hide--large" />
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-3">
+                <h3 class="p-heading--5 p-stepped-list__title">OpenStack provisions resources</h3>
+              </div>
+              <div class="col-6 col-medium-3">
+                <p class="p-stepped-list__content">
+                  In order to provision the actual resource (a VM, a block storage volume, a snapshot or an external IP address), OpenStack relies on other technologies. This includes the <a href="https://ubuntu.com/server/docs/virtualisation-with-qemu">KVM</a> hypervisor, <a href="https://ubuntu.com/blog/data-centre-networking-what-is-ovn">OVN</a> for networking, <a href="https://ubuntu.com/ceph">Ceph</a> for storage and many, many more.
+                </p>
+              </div>
             </div>
-            <div class="col-6 col-medium-3">
-              <p class="p-stepped-list__content">
-                Depending on the type of a request, one or another service gets involved in its processing. Each service manages its own domain and provides all necessary functions to handle the given task. This includes user authentication, authorization, resource scheduling, metrics collection, etc.
-              </p>
-            </div>
-          </div>
-        </li>
-        <hr class="p-rule--muted u-hide--large" />
-        <li class="p-stepped-list__item">
-          <div class="row">
-            <div class="col-3 col-medium-3">
-              <h3 class="p-heading--5 p-stepped-list__title">OpenStack provisions resources</h3>
-            </div>
-            <div class="col-6 col-medium-3">
-              <p class="p-stepped-list__content">
-                In order to provision the actual resource (a VM, a block storage volume, a snapshot or an external IP address), OpenStack relies on other technologies. This includes the <a href="https://ubuntu.com/server/docs/virtualisation-with-qemu">KVM</a> hypervisor, <a href="https://ubuntu.com/blog/data-centre-networking-what-is-ovn">OVN</a> for networking, <a href="https://ubuntu.com/ceph">Ceph</a> for storage and many, many more.
-              </p>
-            </div>
-          </div>
-        </li>
-      </ol>
+          </li>
+        </ol>
+      </div>
     </div>
   </section>
 

--- a/templates/openstack/architecture.html
+++ b/templates/openstack/architecture.html
@@ -35,7 +35,7 @@
 
   <section class="p-section">
     <div class="row--50-50">
-      <hr class="is-muted" />
+      <hr />
       <div class="col">
         <h2>Is OpenStack complex?</h2>
       </div>
@@ -50,8 +50,7 @@
           <p>Keep reading to learn how Canonical OpenStack helps you bypass all this complexity.</p>
         </div>
       </div>
-      <div class="p-image-container is-highlighted u-hide--small">
-
+      <div class="p-image-container u-hide--small">
         {{ image(url="https://assets.ubuntu.com/v1/4cb083ab-openstack-arch-kilo-logical-v1.png",
                 alt="",
                 width="2102",
@@ -62,22 +61,20 @@
         }}
       </div>
     </div>
-
   </section>
+
   <section class="p-section">
     <div class="row--50-50">
-      <hr class="is-muted" />
+      <hr />
       <div class="col">
         <h2>Why Canonical OpenStack?</h2>
       </div>
       <div class="col p-section">
-        <div>
-          <p>
-            If you want to use OpenStack, but don't necessarily want to deal with its internals, you're in the right place. Canonical effectively tames the complexity of the upstream OpenStack project and delivers its distilled excellence in the form of a human-friendly product &mdash; Canonical OpenStack.
-          </p>
-        </div>
+        <p>
+          If you want to use OpenStack, but don't necessarily want to deal with its internals, you're in the right place. Canonical effectively tames the complexity of the upstream OpenStack project and delivers its distilled excellence in the form of a human-friendly product &mdash; Canonical OpenStack.
+        </p>
         <hr class="is-muted" />
-        <a href="https://canonical.com/openstack">Explore Canonical OpenStack&nbsp;&rsaquo;</a>
+        <a href="/openstack">Explore Canonical OpenStack&nbsp;&rsaquo;</a>
       </div>
       <hr class="is-muted u-hide--medium u-hide--small" />
       <div class="p-equal-height-row">
@@ -90,7 +87,6 @@
           </p>
         </div>
         <div class="p-equal-height-row__col">
-
           <div class="p-equal-height-row__item">
             <h5 class="p-heading--5">Cloud-native architecture</h5>
           </div>
@@ -107,14 +103,11 @@
           </p>
         </div>
         <div class="p-equal-height-row__col">
-
           <div class="p-equal-height-row__item">
             <h5 class="p-heading--5">High-level abstraction</h5>
           </div>
           <p class="p-equal-height-row__item">
-
             Canonical OpenStack exposes a high-level interface for bootstrapping and operating the cloud. This effectively abstracts the complexity of the upstream project and enables users to spin up a cloud in just a few simple steps.
-
           </p>
         </div>
       </div>
@@ -152,8 +145,7 @@
           </p>
         </div>
         <hr class="is-muted" />
-        <a class="p-button--positive"
-           href="https://canonical.com/openstack/docs">Access supported features</a>
+        <a class="p-button--positive" href="/openstack/docs">Access supported features</a>
       </div>
     </div>
   </section>
@@ -180,7 +172,7 @@
     <div class="row">
       <div class="col-9 col-start-large-4">
         <hr class="is-muted u-hide--small" />
-        <div class="p-image-container is-highlighted u-hide--small">
+        <div class="p-image-container u-hide--small">
           {{ image(url="https://assets.ubuntu.com/v1/aa31dc00-1.2.2.png",
                     alt="",
                     width="1846",
@@ -206,12 +198,11 @@
         </p>
         <hr class="is-muted" />
         <p>
-          <a href="https://ubuntu.com/engage/openstack-introduction">Read the whitepaper: “An introduction to OpenStack”
-          &nbsp;&rsquo;</a>
+          <a href="https://ubuntu.com/engage/openstack-introduction">Read the whitepaper: “An introduction to OpenStack”&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
-    <div class="row">
+    <div class="row p-section--shallow">
       <div class="col-start-large-4 col-9 col-medium-6">
         <hr class="is-muted" />
         <div class="row">
@@ -246,22 +237,11 @@
             </p>
           </div>
         </div>
-        <hr class="is-muted" />
-        <div class="row">
-          <div class="col-3 col-medium-3">
-            <h3 class="p-heading--5">Payments</h3>
-          </div>
-          <div class="col-6 col-medium-3">
-            <p>
-              MongoDB can handle high-volume transactional data efficiently, making it suitable for banking operations that require quick and reliable transaction processing.
-            </p>
-          </div>
-        </div>
       </div>
     </div>
   </section>
 
-  <section class="p-section">
+  <section class="p-section--deep">
     <div class="row--50-50">
       <hr />
       <div class="col">
@@ -275,8 +255,7 @@
           </p>
         </div>
         <hr class="is-muted" />
-        <a class="p-button--positive"
-           href="https://canonical.com/openstack/docs/single-node">Start today</a>
+        <a class="p-button--positive" href="/openstack/docs/single-node">Start today</a>
       </div>
     </div>
   </section>

--- a/templates/openstack/architecture.html
+++ b/templates/openstack/architecture.html
@@ -149,7 +149,7 @@
           </p>
         </div>
         <hr class="p-rule--muted" />
-        <a class="p-button--positive" href="/openstack/docs">Access supported features</a>
+        <a class="p-button--positive" href="https://microstack.run/docs">Access supported features</a>
       </div>
     </div>
   </section>
@@ -272,7 +272,7 @@
           </p>
         </div>
         <hr class="p-rule--muted" />
-        <a class="p-button--positive" href="/openstack/docs/single-node">Start today</a>
+        <a class="p-button--positive" href="https://microstack.run/docs/single-node">Start today</a>
       </div>
     </div>
   </section>

--- a/templates/openstack/architecture.html
+++ b/templates/openstack/architecture.html
@@ -26,7 +26,7 @@
             The best recipe for a successful cloud deployment is to follow a proven design guide from an experienced and trusted advisor. Canonical's reference architecture for OpenStack has been successfully deployed across hundreds of customers and thousands of sites.
           </p>
         </div>
-        <hr class="is-muted" />
+        <hr class="p-rule--muted" />
         <a class="p-button--positive"
            href="https://ubuntu.com/engage/dell-openstack-reference-architecture">Check the reference architecture</a>
       </div>
@@ -50,11 +50,13 @@
           <p>Keep reading to learn how Canonical OpenStack helps you bypass all this complexity.</p>
         </div>
       </div>
+    </div>
+    <div class="u-fixed-width">
       <div class="p-image-container u-hide--small u-hide--medium">
         {{ image(url="https://assets.ubuntu.com/v1/943a8b94-is-openstack-complex-img.png",
                 alt="",
-                width="1280",
-                height="534",
+                width="2464",
+                height="1027",
                 hi_def=True,
                 attrs={"class": "p-image-container__image"},
                 loading="lazy") | safe
@@ -74,7 +76,9 @@
           If you want to use OpenStack, but don't necessarily want to deal with its internals, you're in the right place. Canonical effectively tames the complexity of the upstream OpenStack project and delivers its distilled excellence in the form of a human-friendly product &mdash; Canonical OpenStack.
         </p>
         <hr class="p-rule--muted" />
-        <a href="/openstack">Explore Canonical OpenStack&nbsp;&rsaquo;</a>
+        <p>
+          <a href="/openstack">Explore Canonical OpenStack&nbsp;&rsaquo;</a>
+        </p>
       </div>
       <hr class="p-rule--muted u-hide--medium u-hide--small" />
       <div class="p-equal-height-row">
@@ -125,8 +129,8 @@
           <div class="p-image-container--cinematic is-highlighted u-hide--medium u-hide--small">
             {{ image(url="https://assets.ubuntu.com/v1/ccb38017-openstack-under-the-hood.png",
                         alt="",
-                        width="640",
-                        height="268",
+                        width="1200",
+                        height="501",
                         hi_def=True,
                         attrs={"class": "p-image-container__image"},
                         loading="lazy") | safe
@@ -144,7 +148,7 @@
             In order to minimise its footprint, Canonical OpenStack ships with only the key features enabled by default. Additional features, such as CaaS or a Load Balancer can be enabled post-deployment with a single terminal command.
           </p>
         </div>
-        <hr class="is-muted" />
+        <hr class="p-rule--muted" />
         <a class="p-button--positive" href="/openstack/docs">Access supported features</a>
       </div>
     </div>
@@ -175,8 +179,8 @@
         <div class="p-image-container u-hide--medium u-hide--small">
           {{ image(url="https://assets.ubuntu.com/v1/aa31dc00-1.2.2.png",
                     alt="",
-                    width="960",
-                    height="545",
+                    width="1349",
+                    height="769",
                     hi_def=True,
                     attrs={"class": "p-image-container__image"},
                     loading="lazy") | safe
@@ -202,44 +206,48 @@
         </p>
       </div>
     </div>
-    <div class="row p-section--shallow">
-      <div class="col-start-large-4 col-9 col-medium-6">
-        <ol class="p-stepped-list--detailed">
-          <li class="p-stepped-list__item">
-            <div class="row">
-              <hr class="p-rule--muted u-hide--large" />
-              <div class="col-3 col-medium-3">
-                <h3 class="p-heading--5 p-stepped-list__title">The user requests resources</h3>
-              </div>
-              <div class="col-6 col-medium-3">
-                <p class="p-stepped-list__content">OpenStack enables on-demand resource provisioning. This means that users can request them at any time through the client, dashboard or APIs. No admin intervention is required. No ticket is needed to process users' requests. Provisioning happens behind the scenes. OpenStack takes care of everything.</p>
-              </div>
+    <div class="col-start-large-4 col-9 col-medium-6">
+      <ol class="p-stepped-list--detailed">
+        <li class="p-stepped-list__item">
+          <div class="row">
+            <hr class="p-rule--muted u-hide--large" />
+            <div class="col-3 col-medium-3">
+              <h3 class="p-heading--5 p-stepped-list__title">The user requests resources</h3>
             </div>
-          </li>
-          <hr class="p-rule--muted u-hide--large" />
-          <li class="p-stepped-list__item">
-            <div class="row">
-              <div class="col-3 col-medium-3">
-                <h3 class="p-heading--5 p-stepped-list__title">OpenStack handles the request</h3>
-              </div>
-              <div class="col-6 col-medium-3">
-                <p class="p-stepped-list__content">Depending on the type of a request, one or another service gets involved in its processing. Each service manages its own domain and provides all necessary functions to handle the given task. This includes user authentication, authorization, resource scheduling, metrics collection, etc.</p>
-              </div>
+            <div class="col-6 col-medium-3">
+              <p class="p-stepped-list__content">
+                OpenStack enables on-demand resource provisioning. This means that users can request them at any time through the client, dashboard or APIs. No admin intervention is required. No ticket is needed to process users' requests. Provisioning happens behind the scenes. OpenStack takes care of everything.
+              </p>
             </div>
-          </li>
-          <hr class="p-rule--muted u-hide--large" />
-          <li class="p-stepped-list__item">
-            <div class="row">
-              <div class="col-3 col-medium-3">
-                <h3 class="p-heading--5 p-stepped-list__title">OpenStack provisions resources</h3>
-              </div>
-              <div class="col-6 col-medium-3">
-                <p class="p-stepped-list__content">In order to provision the actual resource (a VM, a block storage volume, a snapshot or an external IP address), OpenStack relies on other technologies. This includes the <a href="https://ubuntu.com/server/docs/virtualisation-with-qemu">KVM</a> hypervisor, <a href="https://ubuntu.com/blog/data-centre-networking-what-is-ovn">OVN</a> for networking, <a href="https://ubuntu.com/ceph">Ceph</a> for storage and many, many more.</p>
-              </div>
+          </div>
+        </li>
+        <hr class="p-rule--muted u-hide--large" />
+        <li class="p-stepped-list__item">
+          <div class="row">
+            <div class="col-3 col-medium-3">
+              <h3 class="p-heading--5 p-stepped-list__title">OpenStack handles the request</h3>
             </div>
-          </li>
-        </ol>
-      </div>
+            <div class="col-6 col-medium-3">
+              <p class="p-stepped-list__content">
+                Depending on the type of a request, one or another service gets involved in its processing. Each service manages its own domain and provides all necessary functions to handle the given task. This includes user authentication, authorization, resource scheduling, metrics collection, etc.
+              </p>
+            </div>
+          </div>
+        </li>
+        <hr class="p-rule--muted u-hide--large" />
+        <li class="p-stepped-list__item">
+          <div class="row">
+            <div class="col-3 col-medium-3">
+              <h3 class="p-heading--5 p-stepped-list__title">OpenStack provisions resources</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p class="p-stepped-list__content">
+                In order to provision the actual resource (a VM, a block storage volume, a snapshot or an external IP address), OpenStack relies on other technologies. This includes the <a href="https://ubuntu.com/server/docs/virtualisation-with-qemu">KVM</a> hypervisor, <a href="https://ubuntu.com/blog/data-centre-networking-what-is-ovn">OVN</a> for networking, <a href="https://ubuntu.com/ceph">Ceph</a> for storage and many, many more.
+              </p>
+            </div>
+          </div>
+        </li>
+      </ol>
     </div>
   </section>
 
@@ -247,7 +255,11 @@
     <div class="row--50-50">
       <hr />
       <div class="col">
-        <h2>Get started<br /> with Canonical OpenStack</h2>
+        <h2>
+          Get started
+          <br />
+          with Canonical OpenStack
+        </h2>
       </div>
       <div class="col">
         <div class="p-section--shallow">
@@ -256,7 +268,7 @@
             With Canonical OpenStack you can get started on your journey on a single physical machine. Simply try it out and continue learning through some practical exercises.
           </p>
         </div>
-        <hr class="is-muted" />
+        <hr class="p-rule--muted" />
         <a class="p-button--positive" href="/openstack/docs/single-node">Start today</a>
       </div>
     </div>

--- a/templates/openstack/architecture.html
+++ b/templates/openstack/architecture.html
@@ -186,6 +186,7 @@
                     loading="lazy") | safe
           }}
         </div>
+        <p class="u-text--muted u-hide--medium u-hide--small">Example of the OpenStack dashboard.</p>
       </div>
     </div>
   </section>

--- a/templates/openstack/architecture.html
+++ b/templates/openstack/architecture.html
@@ -50,11 +50,11 @@
           <p>Keep reading to learn how Canonical OpenStack helps you bypass all this complexity.</p>
         </div>
       </div>
-      <div class="p-image-container u-hide--small">
-        {{ image(url="https://assets.ubuntu.com/v1/4cb083ab-openstack-arch-kilo-logical-v1.png",
+      <div class="p-image-container u-hide--small u-hide--medium">
+        {{ image(url="https://assets.ubuntu.com/v1/943a8b94-is-openstack-complex-img.png",
                 alt="",
-                width="2102",
-                height="1003",
+                width="1280",
+                height="534",
                 hi_def=True,
                 attrs={"class": "p-image-container__image"},
                 loading="lazy") | safe
@@ -73,14 +73,14 @@
         <p>
           If you want to use OpenStack, but don't necessarily want to deal with its internals, you're in the right place. Canonical effectively tames the complexity of the upstream OpenStack project and delivers its distilled excellence in the form of a human-friendly product &mdash; Canonical OpenStack.
         </p>
-        <hr class="is-muted" />
+        <hr class="p-rule--muted" />
         <a href="/openstack">Explore Canonical OpenStack&nbsp;&rsaquo;</a>
       </div>
-      <hr class="is-muted u-hide--medium u-hide--small" />
+      <hr class="p-rule--muted u-hide--medium u-hide--small" />
       <div class="p-equal-height-row">
         <div class="p-equal-height-row__col">
           <div class="p-equal-height-row__item">
-            <h5 class="p-heading--5">Opinionated design</h5>
+            <h3 class="p-heading--5">Opinionated design</h3>
           </div>
           <p class="p-equal-height-row__item">
             Canonical OpenStack includes active and stable services only, together with the major compute, network and storage options. This eliminates friction, ensures an enterprise-grade stability and provides an “on rails” user experience.
@@ -88,7 +88,7 @@
         </div>
         <div class="p-equal-height-row__col">
           <div class="p-equal-height-row__item">
-            <h5 class="p-heading--5">Cloud-native architecture</h5>
+            <h3 class="p-heading--5">Cloud-native architecture</h3>
           </div>
           <p class="p-equal-height-row__item">
             Canonical OpenStack comes with a fully cloud-native architecture based on <a href="https://ubuntu.com/kubernetes">Kubernetes</a>, <a href="https://ubuntu.com/security/docker-images">OCI images</a> and <a href="https://snapcraft.io/">snaps</a>. This decouples OpenStack from the underlying Ubuntu OS and makes its updates and upgrades simple, straightforward and user-friendly.
@@ -96,7 +96,7 @@
         </div>
         <div class="p-equal-height-row__col">
           <div class="p-equal-height-row__item">
-            <h5 class="p-heading--5">Full bottom-up automation</h5>
+            <h3 class="p-heading--5">Full bottom-up automation</h3>
           </div>
           <p class="p-equal-height-row__item">
             Canonical OpenStack uses full bottom-up automation based on <a href="https://maas.io/">MAAS</a> and <a href="https://juju.is/">Juju</a> across all the layers of the stack. This covers the initial provisioning of physical machines, cloud bootstrap processes as well as its post-deployment operations.
@@ -104,7 +104,7 @@
         </div>
         <div class="p-equal-height-row__col">
           <div class="p-equal-height-row__item">
-            <h5 class="p-heading--5">High-level abstraction</h5>
+            <h3 class="p-heading--5">High-level abstraction</h3>
           </div>
           <p class="p-equal-height-row__item">
             Canonical OpenStack exposes a high-level interface for bootstrapping and operating the cloud. This effectively abstracts the complexity of the upstream project and enables users to spin up a cloud in just a few simple steps.
@@ -122,11 +122,11 @@
       </div>
       <div class="col">
         <div class="p-section--shallow">
-          <div class="p-image-container is-highlighted">
-            {{ image(url="https://assets.ubuntu.com/v1/144affdb-Canonical OpenStack architecture diagram final@2x.png",
+          <div class="p-image-container--cinematic is-highlighted u-hide--medium u-hide--small">
+            {{ image(url="https://assets.ubuntu.com/v1/ccb38017-openstack-under-the-hood.png",
                         alt="",
-                        width="1954",
-                        height="720",
+                        width="640",
+                        height="268",
                         hi_def=True,
                         attrs={"class": "p-image-container__image"},
                         loading="lazy") | safe
@@ -171,12 +171,12 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <hr class="is-muted u-hide--small" />
-        <div class="p-image-container u-hide--small">
+        <hr class="p-rule--muted u-hide--small" />
+        <div class="p-image-container u-hide--medium u-hide--small">
           {{ image(url="https://assets.ubuntu.com/v1/aa31dc00-1.2.2.png",
                     alt="",
-                    width="1846",
-                    height="1053",
+                    width="960",
+                    height="545",
                     hi_def=True,
                     attrs={"class": "p-image-container__image"},
                     loading="lazy") | safe
@@ -196,7 +196,7 @@
         <p>
           In principle, OpenStack resembles the behaviour of leading public clouds. Users can provision resources from their own pool through a self-service portal. All requests are handled by OpenStack itself in a fully automated way. Don't believe it?
         </p>
-        <hr class="is-muted" />
+        <hr class="p-rule--muted" />
         <p>
           <a href="https://ubuntu.com/engage/openstack-introduction">Read the whitepaper: “An introduction to OpenStack”&nbsp;&rsaquo;</a>
         </p>
@@ -204,39 +204,41 @@
     </div>
     <div class="row p-section--shallow">
       <div class="col-start-large-4 col-9 col-medium-6">
-        <hr class="is-muted" />
-        <div class="row">
-          <div class="col-3 col-medium-3">
-            <h3 class="p-heading--5">1. The user requests resources</h3>
-          </div>
-          <div class="col-6 col-medium-3">
-            <p>
-              OpenStack enables on-demand resource provisioning. This means that users can request them at any time through the client, dashboard or APIs. No admin intervention is required. No ticket is needed to process users' requests. Provisioning happens behind the scenes. OpenStack takes care of everything.
-            </p>
-          </div>
-        </div>
-        <hr class="is-muted" />
-        <div class="row">
-          <div class="col-3 col-medium-3">
-            <h3 class="p-heading--5">2. OpenStack handles the request</h3>
-          </div>
-          <div class="col-6 col-medium-3">
-            <p>
-              Depending on the type of a request, one or another service gets involved in its processing. Each service manages its own domain and provides all necessary functions to handle the given task. This includes user authentication, authorization, resource scheduling, metrics collection, etc.
-            </p>
-          </div>
-        </div>
-        <hr class="is-muted" />
-        <div class="row">
-          <div class="col-3 col-medium-3">
-            <h3 class="p-heading--5">3. OpenStack provisions resources</h3>
-          </div>
-          <div class="col-6 col-medium-3">
-            <p>
-              In order to provision the actual resource (a VM, a block storage volume, a snapshot or an external IP address), OpenStack relies on other technologies. This includes the <a href="https://ubuntu.com/server/docs/virtualisation-with-qemu">KVM</a> hypervisor, <a href="https://ubuntu.com/blog/data-centre-networking-what-is-ovn">OVN</a> for networking, <a href="https://ubuntu.com/ceph">Ceph</a> for storage and many, many more.
-            </p>
-          </div>
-        </div>
+        <ol class="p-stepped-list--detailed">
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <hr class="p-rule--muted u-hide--large" />
+              <div class="col-3 col-medium-3">
+                <h3 class="p-heading--5 p-stepped-list__title">The user requests resources</h3>
+              </div>
+              <div class="col-6 col-medium-3">
+                <p class="p-stepped-list__content">OpenStack enables on-demand resource provisioning. This means that users can request them at any time through the client, dashboard or APIs. No admin intervention is required. No ticket is needed to process users' requests. Provisioning happens behind the scenes. OpenStack takes care of everything.</p>
+              </div>
+            </div>
+          </li>
+          <hr class="p-rule--muted u-hide--large" />
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-3">
+                <h3 class="p-heading--5 p-stepped-list__title">OpenStack handles the request</h3>
+              </div>
+              <div class="col-6 col-medium-3">
+                <p class="p-stepped-list__content">Depending on the type of a request, one or another service gets involved in its processing. Each service manages its own domain and provides all necessary functions to handle the given task. This includes user authentication, authorization, resource scheduling, metrics collection, etc.</p>
+              </div>
+            </div>
+          </li>
+          <hr class="p-rule--muted u-hide--large" />
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-3">
+                <h3 class="p-heading--5 p-stepped-list__title">OpenStack provisions resources</h3>
+              </div>
+              <div class="col-6 col-medium-3">
+                <p class="p-stepped-list__content">In order to provision the actual resource (a VM, a block storage volume, a snapshot or an external IP address), OpenStack relies on other technologies. This includes the <a href="https://ubuntu.com/server/docs/virtualisation-with-qemu">KVM</a> hypervisor, <a href="https://ubuntu.com/blog/data-centre-networking-what-is-ovn">OVN</a> for networking, <a href="https://ubuntu.com/ceph">Ceph</a> for storage and many, many more.</p>
+              </div>
+            </div>
+          </li>
+        </ol>
       </div>
     </div>
   </section>
@@ -245,7 +247,7 @@
     <div class="row--50-50">
       <hr />
       <div class="col">
-        <h2>Get started with Canonical OpenStack</h2>
+        <h2>Get started<br /> with Canonical OpenStack</h2>
       </div>
       <div class="col">
         <div class="p-section--shallow">

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -24,9 +24,11 @@
         </div>
       </div>
       <div class="col">
-        <p>
-          Get a public cloud-like experience while hosting your applications in your own data centre. Strengthen your business with a flexible infrastructure that meets the highest industry standards.
-        </p>
+        <div class="p-section--shallow">
+          <p>
+            Get a public cloud-like experience while hosting your applications in your own data centre. Strengthen your business with a flexible infrastructure that meets the highest industry standards.
+          </p>
+        </div>
         <div class="p-cta-block">
           <a href="https://microstack.run/docs/single-node"
              class="p-button--positive">Try Canonical OepnStack</a>
@@ -346,10 +348,10 @@
         <a href="https://ubuntu.com/engage/sicredi-openstack-case-study"
            aria-label="Read the Sicredi case study">
           <div class="p-image-container--16-9 is-highlighted">
-            {{ image(url="https://assets.ubuntu.com/v1/59a71df3-Rectangle%206.png",
+            {{ image(url="https://assets.ubuntu.com/v1/9a219e83-sicredi-logo-new.png",
                         alt="Sicredi",
-                        width="207",
-                        height="45",
+                        width="104",
+                        height="104",
                         hi_def=True,
                         loading="lazy",
                         attrs={"class": "p-image-container__image"}) | safe
@@ -360,7 +362,7 @@
       </div>
     </div>
     <div class="u-fixed-width p-section--shallow">
-      <hr class="p-rule" />
+      <hr class="p-rule--muted" />
       <div class="p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
@@ -404,9 +406,9 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/5b45c88e-gendarmerie-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/b831f28b-pthl-logo.png",
                         alt="Gendarmerie",
-                        width="190",
+                        width="328",
                         height="312",
                         hi_def=True,
                         loading="lazy",

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -1,0 +1,408 @@
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1bfo97XdFdKlzrMcMoRxiTdzt_bPVndx6j55IPsapuAE/edit
+{% endblock meta_copydoc %}
+
+{% block title %}Canonical OpenStack{% endblock %}
+
+{% block meta_description %}
+Canonical OpenStack - your own professional cloud for sophisticated workloads, including AI/ML, and full control over your sensitive data
+{% endblock %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block content %}
+
+<section class="p-section--hero">
+  <div class="row--50-50">
+    <div class="col">
+      <div class="p-section--shallow">
+        <h1>Canonical OpenStack</h1>
+      </div>
+    </div>
+    <div class="col">
+      <p>Get a public cloud-like experience while hosting your applications in your own data centre. Strengthen your business with a flexible infrastructure that meets the highest industry standards.</p>
+      <div class="p-cta-block">
+        <a href="https://microstack.run/docs/single-node" class="p-button--positive">Try Canonical OepnStack</a>
+        <a href="https://ubuntu.com/engage/openstack-ebook-beginners" class="p-button">Download OpenStack e-book</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="row">
+    <hr class="u-no-margin--bottom"/>
+    <div class="col-3 p-section--shallow">
+      <h2 class="p-text--small-caps">Canonical OpenStack in numbers</h2>
+    </div>
+    <div class="col-9">
+      <div class="row">
+        <div class="col-3 col-medium-2">
+          <hr class="p-rule--highlight">
+          <p class="p-heading--2"><strong>100&plus;</strong></p>
+          <p class="p-heading--4 u-no-padding--top">Happy customers</p>
+        </div>
+        <div class="col-3 col-medium-2">
+          <hr class="p-rule--highlight">
+          <p class="p-heading--2"><strong>500&plus;</strong></p>
+          <p class="p-heading--4 u-no-padding--top">Clouds in production</p>
+        </div>
+        <div class="col-3 col-medium-2">
+          <hr class="p-rule--highlight">
+          <p class="p-heading--2"><strong><span aria-label="about">~</span>30 minutes</strong></p>
+          <p class="p-heading--4 u-no-padding--top">To spin it up in your lab</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>Keep your future in your hands with your own professional cloud</h2>
+    </div>
+    <div class="col">
+      <p>Transform your data centre into a fully functional and professional cloud environment. Take advantage of cloud-based operations, while retaining all the benefits of owning your computing infrastructure.</p>
+      <div class="p-cta-block">
+        <a class="p-button--positive">Get in touch</a>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-start-large-4 col-9">
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3 col-medium-3">
+          <h3 class="p-heading--5">Improve your business' efficiency</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Equip your teams with a self-service IT infrastructure. Canonical OpenStack delivers a cloud-like experience and on-demand resources to serve your business' computing needs.</p>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3 col-medium-3">
+          <h3 class="p-heading--5">You reduce and Optimise your infrastructure costs</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Deploy it in your existing multi-cloud ecosystem and benefit from a long-term TCO reduction. With Canonical OpenStack there is no hidden licence or subscription cost.</p>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3 col-medium-3">
+          <h3 class="p-heading--5">Re-gain control over your data</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Keep your sensitive data on your premises where you have full control over the underlying infrastructure. Canonical OpenStack helps you build sovereign clouds and adhere to local policies and regulations.</p>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3 col-medium-3">
+          <h3 class="p-heading--5">Avoid lock-in and costly surprises</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Bet on a product that uses stable, mature and distilled upstream open source code underneath. Benefit from years of community collaboration, while relying on us for security updates and support with guaranteed SLAs.</p>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3 col-medium-3">
+          <h3 class="p-heading--5">Accelerate your digital transformation</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Plug in your GPUs and get an extendable Kubernetes layer running on top of Canonical OpenStack in minutes. Use with confidence for your sophisticated AI/ML and other cloud-native workloads.</p>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3 col-medium-3">
+          <h3 class="p-heading--5">Build with ease and operate at scale</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Launch your own instance of Canonical OpenStack in your lab in a few simple steps. Scale out with ease and benefit from full bottom-up automation for daily operations.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<section class="p-section">
+  <div class="u-fixed-width p-section--shallow">
+    <hr class="p-rule--highlight" />
+    <h2 class="p-text--small-caps">Endorsed by executives, globally</h2>
+  </div>
+  <div class="row p-section--shallow">
+    <hr class="p-rule--muted" />
+    <div class="col-3 p-section--shallow">
+      {{ image(
+        url="https://assets.ubuntu.com/v1/1db9d47a-Rectangle%204.png",
+        alt="Pacific Textiles Holding Limited",
+        width="257",
+        height="45",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6 col-medium-4">
+      <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
+        <p>
+          <i>Canonical is miles ahead of other providers where every server is manually configured.</i>
+          <span class="u-off-screen">Hubert Tsang, CIO, Pacific textiles</span>
+        </p>
+      </blockquote>
+    </div>
+    <div class="col-3 col-medium-2">
+      <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Hubert Tsang</p>
+      <p class="u-text--muted" aria-hidden="true">CIO, Pacific Textiles</p>
+    </div>
+  </div>
+  <div class="row p-section--shallow">
+    <hr class="p-rule--muted" />
+    <div class="col-3 p-section--shallow">
+      {{ image(
+        url="https://assets.ubuntu.com/v1/59a71df3-Rectangle%206.png",
+        alt="Sicredi",
+        width="207",
+        height="45",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6 col-medium-4">
+      <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
+        <p>
+          <i>We recently reassessed our cloud strategy, and one of the parameters was cost-efficiency. We observed that Canonical OpenStack is helping us to achieve two-to-three times more cost-efficiency than using public clouds.</i>
+          <span class="u-off-screen">Cléber Alexandre Agazzi, Head of Infrastructure & IT Operations, Sicredi</span>
+        </p>
+      </blockquote>
+    </div>
+    <div class="col-3 col-medium-2">
+      <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Cléber Alexandre Agazzi</p>
+      <p class="u-text--muted" aria-hidden="true">Head of Infrastructure & IT Operations, Sicredi</p>
+    </div>
+  </div>
+  <div class="row p-section--shallow">
+    <hr class="p-rule--muted" />
+    <div class="col-3 p-section--shallow">
+      {{ image(
+        url="https://assets.ubuntu.com/v1/4108a96c-Rectangle%207.png",
+        alt="Telefonica",
+        width="189",
+        height="50",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6 col-medium-4">
+      <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
+        <p>
+          <i>Migrating our OCS application to the cloud will give us the base and agility we need in order to consistently offer best-in-class solutions for our customers. This selection [Canonical OpenStack] was an obvious choice to enable us to scale our charging capabilities to a future-proofed private cloud platform.</i>
+          <span class="u-off-screen">Flavio Matiello, Head of PrePaid Platforms & OCS, Telefonica Brazil</span>
+        </p>
+      </blockquote>
+    </div>
+    <div class="col-3 col-medium-2">
+      <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Flavio Matiello</p>
+      <p class="u-text--muted" aria-hidden="true">Head of PrePaid Platforms & OCS, Telefonica Brazil</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>Where does<br />Canonical OpenStack fit?</h2>
+    </div>
+    <div class="col">
+      <ul class="p-list--divided">
+        <li class="p-list__item is-ticked">General-purpose cloud computing on your premises</li>
+        <li class="p-list__item is-ticked">An alternative to proprietary virtualisation solutions</li>
+        <li class="p-list__item is-ticked">Implementing a sovereign cloud for digital sovereignty</li>
+        <li class="p-list__item is-ticked">Building a local/regional public cloud for your customers</li>
+        <li class="p-list__item is-ticked">Performance-intensive workloads such as HPC and AI/ML</li>
+        <li class="p-list__item is-ticked">Telco network function virtualisation infrastructure (NFVI)</li>
+        <li class="p-list__item is-ticked">Edge infrastructure distributed across thousands of sides</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="u-fixed-width p-section--shallow">
+    <hr class="p-rule" />
+    <h2>Proven record of success</h2>
+  </div>
+  <div class="row p-section--shallow">
+    <div class="col-3 col-medium-3">
+      <a href="https://www.youtube.com/watch?v=0oFnOHJrRQs" aria-label="Watch how BT Group improves fan experience with 5G">
+        <div class="p-image-container--16-9 is-highlighted">
+          {{ image(
+            url="https://assets.ubuntu.com/v1/1b743a00-BT%20Service%20Cloud.png",
+            alt="BT",
+            width="111",
+            height="111",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+        <p>
+          Watch the video&nbsp;&rsaquo;
+        </p>
+      </a>
+    </div>
+    <div class="col-3 col-medium-3">
+      <a href="https://www.unicc.org/news/2023/10/19/unicc-partners-with-canonical-to-build-unicc-cloud/" aria-label="Read the UNICC announcement">
+        <div class="p-image-container--16-9 is-highlighted">
+          {{ image(
+            url="https://assets.ubuntu.com/v1/d82024b3-United%20Nations%20International%20Computing%20Centre%20(UNICC).png",
+            alt="",
+            width="370",
+            height="136",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+        <p>
+          Read the announcement&nbsp;&rsaquo;
+        </p>
+      </a>
+    </div>
+    <div class="col-3 col-medium-3">
+      <a href="https://ubuntu.com/engage/kubernetes-openstack-case-study-firmus" aria-label="Read the Firmus case study">
+        <div class="p-image-container--16-9 is-highlighted">
+          {{ image(
+            url="https://assets.ubuntu.com/v1/818f7f12-Firmusgrid%20Supercloud%20Pty%20Ltd.png",
+            alt="",
+            width="200",
+            height="45",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+        <p>
+          Read the case study&nbsp;&rsaquo;
+        </p>
+      </a>
+    </div>
+    <div class="col-3 col-medium-3">
+      <a href="/blog/telefonica-brazil-selects-charmed-openstack" aria-label="Read the Telefonica annoucement">
+        <div class="p-image-container--16-9 is-highlighted">
+          {{ image(
+            url="https://assets.ubuntu.com/v1/4108a96c-Rectangle%207.png",
+            alt="Telefonica",
+            width="189",
+            height="50",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+        <p>
+          Read the announcement&nbsp;&rsaquo;
+        </p>
+      </a>
+    </div>
+    <div class="col-3 col-medium-3">
+      <a href="https://www.youtube.com/watch?v=0oFnOHJrRQs" aria-label="Read the Sicredi case study">
+        <div class="p-image-container--16-9 is-highlighted">
+          {{ image(
+            url="https://assets.ubuntu.com/v1/59a71df3-Rectangle%206.png",
+            alt="Sicredi",
+            width="207",
+            height="45",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+        <p>
+          Read the case study&nbsp;&rsaquo;
+        </p>
+      </a>
+    </div>
+  </div>
+  <div class="u-fixed-width p-section--shallow">
+    <hr class="p-rule" />
+    <div class="p-logo-section">
+      <div class="p-logo-section__items">
+        <div class="p-logo-section__item">
+          {{ image(
+            url="https://assets.ubuntu.com/v1/2311ff1f-Bloomberg-Logo .png",
+            alt="",
+            width="314",
+            height="312",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image(
+            url="https://assets.ubuntu.com/v1/80b0c768-bnp-paribas-logo .png",
+            alt="",
+            width="486",
+            height="312",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}) | safe
+          }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-section--deep">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>Get Canonical OpenStack</h2>
+    </div>
+    <div class="col">
+      <div class="p-section--shallow">
+        <p>Self-deployed or Canonical-deployed? This is the only dilemma you have to deal with when getting started with Canonical OpenStack. Choose the option that suits you best and start your adventure with your own professional cloud today.</p>
+      </div>
+    </div>
+  </div>
+  <div class="row--50-50">
+    <div class="col">
+      <hr class="p-rule--highlight u-no-margin--bottom" />
+      <div class="p-card--overlay u-no-padding--top u-no-padding--bottom" style="padding: 1.5rem;">
+        <h3>Self-deployed</h3>
+        <p>You deploy Canonical OpenStack yourself by relying on public-facing materials, such as <a href="https://microstack.run/docs">product documentation</a> and <a href="/openstack/tutorials">turotials</a>. Once deployed according to Canonical's best practices, your cloud qualifies for various levels of <a href="">commercial services</a>.</p>
+        <div class="p-cta-block">
+          <a href="https://microstack.run/docs/single-node" class="p-button--positive">Start on your own</a>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <hr class="p-rule--highlight u-no-margin--bottom" />
+      <div class="p-card--overlay u-no-padding--top u-no-padding--bottom" style="padding: 1.5rem;">
+        <h3>Canonical-deployed</h3>
+        <div class="p-section--shallow">
+          <p>We deploy Canonical OpenStack for you. Together, we find the design that suits your use case and requirements best. We will share our best practices and hand over the cloud to you once it's built, tested and validated by us.</p>
+        </div>
+        <div class="p-cta-block">
+          <a href="" class="p-button--positive">Start with Canonical</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -31,7 +31,7 @@
         </div>
         <div class="p-cta-block">
           <a href="https://microstack.run/docs/single-node"
-             class="p-button--positive">Try Canonical OepnStack</a>
+             class="p-button--positive">Try Canonical OpenStack</a>
           <a href="https://ubuntu.com/engage/openstack-ebook-beginners"
              class="p-button">Download the OpenStack e-book</a>
         </div>
@@ -84,7 +84,9 @@
           Transform your data centre into a fully functional and professional cloud environment. Take advantage of cloud-based operations, while retaining all the benefits of owning your computing infrastructure.
         </p>
         <div class="p-cta-block">
-          <a class="p-button--positive">Get in touch</a>
+          <a class="p-button--positive"
+             href="/contact-us"
+             aria-controls="openstack-modal">Get in touch</a>
         </div>
       </div>
     </div>
@@ -466,5 +468,12 @@
       </div>
     </div>
   </section>
+
+  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+
+  {% with %}
+    {% set returnURL = "https://canonical.com/openstack#success" %}
+    {% include "openstack/_form-openstack.html" %}
+  {% endwith %}
 
 {% endblock content %}

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -7,7 +7,7 @@
 {% block title %}Canonical OpenStack{% endblock %}
 
 {% block meta_description %}
-Canonical OpenStack - your own professional cloud for sophisticated workloads, including AI/ML, and full control over your sensitive data
+  Canonical OpenStack - your own professional cloud for sophisticated workloads, including AI/ML, and full control over your sensitive data
 {% endblock %}
 
 {% block body_class %}
@@ -16,393 +16,442 @@ Canonical OpenStack - your own professional cloud for sophisticated workloads, i
 
 {% block content %}
 
-<section class="p-section--hero">
-  <div class="row--50-50">
-    <div class="col">
-      <div class="p-section--shallow">
-        <h1>Canonical OpenStack</h1>
-      </div>
-    </div>
-    <div class="col">
-      <p>Get a public cloud-like experience while hosting your applications in your own data centre. Strengthen your business with a flexible infrastructure that meets the highest industry standards.</p>
-      <div class="p-cta-block">
-        <a href="https://microstack.run/docs/single-node" class="p-button--positive">Try Canonical OepnStack</a>
-        <a href="https://ubuntu.com/engage/openstack-ebook-beginners" class="p-button">Download OpenStack e-book</a>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <div class="row">
-    <hr class="u-no-margin--bottom"/>
-    <div class="col-3 p-section--shallow">
-      <h2 class="p-text--small-caps">Canonical OpenStack in numbers</h2>
-    </div>
-    <div class="col-9">
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <hr class="p-rule--highlight">
-          <p class="p-heading--2"><strong>100&plus;</strong></p>
-          <p class="p-heading--4 u-no-padding--top">Happy customers</p>
-        </div>
-        <div class="col-3 col-medium-2">
-          <hr class="p-rule--highlight">
-          <p class="p-heading--2"><strong>500&plus;</strong></p>
-          <p class="p-heading--4 u-no-padding--top">Clouds in production</p>
-        </div>
-        <div class="col-3 col-medium-2">
-          <hr class="p-rule--highlight">
-          <p class="p-heading--2"><strong><span aria-label="about">~</span>30 minutes</strong></p>
-          <p class="p-heading--4 u-no-padding--top">To spin it up in your lab</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2>Keep your future in your hands with your own professional cloud</h2>
-    </div>
-    <div class="col">
-      <p>Transform your data centre into a fully functional and professional cloud environment. Take advantage of cloud-based operations, while retaining all the benefits of owning your computing infrastructure.</p>
-      <div class="p-cta-block">
-        <a class="p-button--positive">Get in touch</a>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9">
-      <hr class="p-rule--muted" />
-      <div class="row">
-        <div class="col-3 col-medium-3">
-          <h3 class="p-heading--5">Improve your business' efficiency</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Equip your teams with a self-service IT infrastructure. Canonical OpenStack delivers a cloud-like experience and on-demand resources to serve your business' computing needs.</p>
-        </div>
-      </div>
-      <hr class="p-rule--muted" />
-      <div class="row">
-        <div class="col-3 col-medium-3">
-          <h3 class="p-heading--5">You reduce and Optimise your infrastructure costs</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Deploy it in your existing multi-cloud ecosystem and benefit from a long-term TCO reduction. With Canonical OpenStack there is no hidden licence or subscription cost.</p>
-        </div>
-      </div>
-      <hr class="p-rule--muted" />
-      <div class="row">
-        <div class="col-3 col-medium-3">
-          <h3 class="p-heading--5">Re-gain control over your data</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Keep your sensitive data on your premises where you have full control over the underlying infrastructure. Canonical OpenStack helps you build sovereign clouds and adhere to local policies and regulations.</p>
-        </div>
-      </div>
-      <hr class="p-rule--muted" />
-      <div class="row">
-        <div class="col-3 col-medium-3">
-          <h3 class="p-heading--5">Avoid lock-in and costly surprises</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Bet on a product that uses stable, mature and distilled upstream open source code underneath. Benefit from years of community collaboration, while relying on us for security updates and support with guaranteed SLAs.</p>
-        </div>
-      </div>
-      <hr class="p-rule--muted" />
-      <div class="row">
-        <div class="col-3 col-medium-3">
-          <h3 class="p-heading--5">Accelerate your digital transformation</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Plug in your GPUs and get an extendable Kubernetes layer running on top of Canonical OpenStack in minutes. Use with confidence for your sophisticated AI/ML and other cloud-native workloads.</p>
-        </div>
-      </div>
-      <hr class="p-rule--muted" />
-      <div class="row">
-        <div class="col-3 col-medium-3">
-          <h3 class="p-heading--5">Build with ease and operate at scale</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Launch your own instance of Canonical OpenStack in your lab in a few simple steps. Scale out with ease and benefit from full bottom-up automation for daily operations.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-<section class="p-section">
-  <div class="u-fixed-width p-section--shallow">
-    <hr class="p-rule--highlight" />
-    <h2 class="p-text--small-caps">Endorsed by executives, globally</h2>
-  </div>
-  <div class="row p-section--shallow">
-    <hr class="p-rule--muted" />
-    <div class="col-3 p-section--shallow">
-      {{ image(
-        url="https://assets.ubuntu.com/v1/1db9d47a-Rectangle%204.png",
-        alt="Pacific Textiles Holding Limited",
-        width="257",
-        height="45",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-    <div class="col-6 col-medium-4">
-      <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
-        <p>
-          <i>Canonical is miles ahead of other providers where every server is manually configured.</i>
-          <span class="u-off-screen">Hubert Tsang, CIO, Pacific textiles</span>
-        </p>
-      </blockquote>
-    </div>
-    <div class="col-3 col-medium-2">
-      <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Hubert Tsang</p>
-      <p class="u-text--muted" aria-hidden="true">CIO, Pacific Textiles</p>
-    </div>
-  </div>
-  <div class="row p-section--shallow">
-    <hr class="p-rule--muted" />
-    <div class="col-3 p-section--shallow">
-      {{ image(
-        url="https://assets.ubuntu.com/v1/59a71df3-Rectangle%206.png",
-        alt="Sicredi",
-        width="207",
-        height="45",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-    <div class="col-6 col-medium-4">
-      <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
-        <p>
-          <i>We recently reassessed our cloud strategy, and one of the parameters was cost-efficiency. We observed that Canonical OpenStack is helping us to achieve two-to-three times more cost-efficiency than using public clouds.</i>
-          <span class="u-off-screen">Cléber Alexandre Agazzi, Head of Infrastructure & IT Operations, Sicredi</span>
-        </p>
-      </blockquote>
-    </div>
-    <div class="col-3 col-medium-2">
-      <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Cléber Alexandre Agazzi</p>
-      <p class="u-text--muted" aria-hidden="true">Head of Infrastructure & IT Operations, Sicredi</p>
-    </div>
-  </div>
-  <div class="row p-section--shallow">
-    <hr class="p-rule--muted" />
-    <div class="col-3 p-section--shallow">
-      {{ image(
-        url="https://assets.ubuntu.com/v1/4108a96c-Rectangle%207.png",
-        alt="Telefonica",
-        width="189",
-        height="50",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-    <div class="col-6 col-medium-4">
-      <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
-        <p>
-          <i>Migrating our OCS application to the cloud will give us the base and agility we need in order to consistently offer best-in-class solutions for our customers. This selection [Canonical OpenStack] was an obvious choice to enable us to scale our charging capabilities to a future-proofed private cloud platform.</i>
-          <span class="u-off-screen">Flavio Matiello, Head of PrePaid Platforms & OCS, Telefonica Brazil</span>
-        </p>
-      </blockquote>
-    </div>
-    <div class="col-3 col-medium-2">
-      <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Flavio Matiello</p>
-      <p class="u-text--muted" aria-hidden="true">Head of PrePaid Platforms & OCS, Telefonica Brazil</p>
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2>Where does<br />Canonical OpenStack fit?</h2>
-    </div>
-    <div class="col">
-      <ul class="p-list--divided">
-        <li class="p-list__item is-ticked">General-purpose cloud computing on your premises</li>
-        <li class="p-list__item is-ticked">An alternative to proprietary virtualisation solutions</li>
-        <li class="p-list__item is-ticked">Implementing a sovereign cloud for digital sovereignty</li>
-        <li class="p-list__item is-ticked">Building a local/regional public cloud for your customers</li>
-        <li class="p-list__item is-ticked">Performance-intensive workloads such as HPC and AI/ML</li>
-        <li class="p-list__item is-ticked">Telco network function virtualisation infrastructure (NFVI)</li>
-        <li class="p-list__item is-ticked">Edge infrastructure distributed across thousands of sides</li>
-      </ul>
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <div class="u-fixed-width p-section--shallow">
-    <hr class="p-rule" />
-    <h2>Proven record of success</h2>
-  </div>
-  <div class="row p-section--shallow">
-    <div class="col-3 col-medium-3">
-      <a href="https://www.youtube.com/watch?v=0oFnOHJrRQs" aria-label="Watch how BT Group improves fan experience with 5G">
-        <div class="p-image-container--16-9 is-highlighted">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/1b743a00-BT%20Service%20Cloud.png",
-            alt="BT",
-            width="111",
-            height="111",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-image-container__image"}) | safe
-          }}
-        </div>
-        <p>
-          Watch the video&nbsp;&rsaquo;
-        </p>
-      </a>
-    </div>
-    <div class="col-3 col-medium-3">
-      <a href="https://www.unicc.org/news/2023/10/19/unicc-partners-with-canonical-to-build-unicc-cloud/" aria-label="Read the UNICC announcement">
-        <div class="p-image-container--16-9 is-highlighted">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/d82024b3-United%20Nations%20International%20Computing%20Centre%20(UNICC).png",
-            alt="",
-            width="370",
-            height="136",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-image-container__image"}) | safe
-          }}
-        </div>
-        <p>
-          Read the announcement&nbsp;&rsaquo;
-        </p>
-      </a>
-    </div>
-    <div class="col-3 col-medium-3">
-      <a href="https://ubuntu.com/engage/kubernetes-openstack-case-study-firmus" aria-label="Read the Firmus case study">
-        <div class="p-image-container--16-9 is-highlighted">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/818f7f12-Firmusgrid%20Supercloud%20Pty%20Ltd.png",
-            alt="",
-            width="200",
-            height="45",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-image-container__image"}) | safe
-          }}
-        </div>
-        <p>
-          Read the case study&nbsp;&rsaquo;
-        </p>
-      </a>
-    </div>
-    <div class="col-3 col-medium-3">
-      <a href="/blog/telefonica-brazil-selects-charmed-openstack" aria-label="Read the Telefonica annoucement">
-        <div class="p-image-container--16-9 is-highlighted">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/4108a96c-Rectangle%207.png",
-            alt="Telefonica",
-            width="189",
-            height="50",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-image-container__image"}) | safe
-          }}
-        </div>
-        <p>
-          Read the announcement&nbsp;&rsaquo;
-        </p>
-      </a>
-    </div>
-    <div class="col-3 col-medium-3">
-      <a href="https://www.youtube.com/watch?v=0oFnOHJrRQs" aria-label="Read the Sicredi case study">
-        <div class="p-image-container--16-9 is-highlighted">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/59a71df3-Rectangle%206.png",
-            alt="Sicredi",
-            width="207",
-            height="45",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-image-container__image"}) | safe
-          }}
-        </div>
-        <p>
-          Read the case study&nbsp;&rsaquo;
-        </p>
-      </a>
-    </div>
-  </div>
-  <div class="u-fixed-width p-section--shallow">
-    <hr class="p-rule" />
-    <div class="p-logo-section">
-      <div class="p-logo-section__items">
-        <div class="p-logo-section__item">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/2311ff1f-Bloomberg-Logo .png",
-            alt="",
-            width="314",
-            height="312",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/80b0c768-bnp-paribas-logo .png",
-            alt="",
-            width="486",
-            height="312",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}) | safe
-          }}
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-section--deep">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2>Get Canonical OpenStack</h2>
-    </div>
-    <div class="col">
-      <div class="p-section--shallow">
-        <p>Self-deployed or Canonical-deployed? This is the only dilemma you have to deal with when getting started with Canonical OpenStack. Choose the option that suits you best and start your adventure with your own professional cloud today.</p>
-      </div>
-    </div>
-  </div>
-  <div class="row--50-50">
-    <div class="col">
-      <hr class="p-rule--highlight u-no-margin--bottom" />
-      <div class="p-card--overlay u-no-padding--top u-no-padding--bottom" style="padding: 1.5rem;">
-        <h3>Self-deployed</h3>
-        <p>You deploy Canonical OpenStack yourself by relying on public-facing materials, such as <a href="https://microstack.run/docs">product documentation</a> and <a href="/openstack/tutorials">turotials</a>. Once deployed according to Canonical's best practices, your cloud qualifies for various levels of <a href="">commercial services</a>.</p>
-        <div class="p-cta-block">
-          <a href="https://microstack.run/docs/single-node" class="p-button--positive">Start on your own</a>
-        </div>
-      </div>
-    </div>
-    <div class="col">
-      <hr class="p-rule--highlight u-no-margin--bottom" />
-      <div class="p-card--overlay u-no-padding--top u-no-padding--bottom" style="padding: 1.5rem;">
-        <h3>Canonical-deployed</h3>
+  <section class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col">
         <div class="p-section--shallow">
-          <p>We deploy Canonical OpenStack for you. Together, we find the design that suits your use case and requirements best. We will share our best practices and hand over the cloud to you once it's built, tested and validated by us.</p>
+          <h1>Canonical OpenStack</h1>
         </div>
+      </div>
+      <div class="col">
+        <p>
+          Get a public cloud-like experience while hosting your applications in your own data centre. Strengthen your business with a flexible infrastructure that meets the highest industry standards.
+        </p>
         <div class="p-cta-block">
-          <a href="" class="p-button--positive">Start with Canonical</a>
+          <a href="https://microstack.run/docs/single-node"
+             class="p-button--positive">Try Canonical OepnStack</a>
+          <a href="https://ubuntu.com/engage/openstack-ebook-beginners"
+             class="p-button">Download OpenStack e-book</a>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
+
+  <section class="p-section">
+    <div class="row">
+      <hr class="u-no-margin--bottom" />
+      <div class="col-3 p-section--shallow">
+        <h2 class="p-text--small-caps">Canonical OpenStack in numbers</h2>
+      </div>
+      <div class="col-9">
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <hr class="p-rule--highlight" />
+            <p class="p-heading--2">
+              <strong>100&plus;</strong>
+            </p>
+            <p class="p-heading--4 u-no-padding--top">Happy customers</p>
+          </div>
+          <div class="col-3 col-medium-2">
+            <hr class="p-rule--highlight" />
+            <p class="p-heading--2">
+              <strong>500&plus;</strong>
+            </p>
+            <p class="p-heading--4 u-no-padding--top">Clouds in production</p>
+          </div>
+          <div class="col-3 col-medium-2">
+            <hr class="p-rule--highlight" />
+            <p class="p-heading--2">
+              <strong><span aria-label="about">~</span>30 minutes</strong>
+            </p>
+            <p class="p-heading--4 u-no-padding--top">To spin it up in your lab</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Keep your future in your hands with your own professional cloud</h2>
+      </div>
+      <div class="col">
+        <p>
+          Transform your data centre into a fully functional and professional cloud environment. Take advantage of cloud-based operations, while retaining all the benefits of owning your computing infrastructure.
+        </p>
+        <div class="p-cta-block">
+          <a class="p-button--positive">Get in touch</a>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">Improve your business' efficiency</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Equip your teams with a self-service IT infrastructure. Canonical OpenStack delivers a cloud-like experience and on-demand resources to serve your business' computing needs.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">You reduce and Optimise your infrastructure costs</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Deploy it in your existing multi-cloud ecosystem and benefit from a long-term TCO reduction. With Canonical OpenStack there is no hidden licence or subscription cost.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">Re-gain control over your data</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Keep your sensitive data on your premises where you have full control over the underlying infrastructure. Canonical OpenStack helps you build sovereign clouds and adhere to local policies and regulations.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">Avoid lock-in and costly surprises</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Bet on a product that uses stable, mature and distilled upstream open source code underneath. Benefit from years of community collaboration, while relying on us for security updates and support with guaranteed SLAs.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">Accelerate your digital transformation</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Plug in your GPUs and get an extendable Kubernetes layer running on top of Canonical OpenStack in minutes. Use with confidence for your sophisticated AI/ML and other cloud-native workloads.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">Build with ease and operate at scale</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Launch your own instance of Canonical OpenStack in your lab in a few simple steps. Scale out with ease and benefit from full bottom-up automation for daily operations.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width p-section--shallow">
+      <hr class="p-rule--highlight" />
+      <h2 class="p-text--small-caps">Endorsed by executives, globally</h2>
+    </div>
+    <div class="row p-section--shallow">
+      <hr class="p-rule--muted" />
+      <div class="col-3 p-section--shallow">
+        {{ image(url="https://assets.ubuntu.com/v1/1db9d47a-Rectangle%204.png",
+                alt="Pacific Textiles Holding Limited",
+                width="257",
+                height="45",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
+      <div class="col-6 col-medium-4">
+        <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
+          <p>
+            <i>Canonical is miles ahead of other providers where every server is manually configured.</i>
+            <span class="u-off-screen">Hubert Tsang, CIO, Pacific textiles</span>
+          </p>
+        </blockquote>
+      </div>
+      <div class="col-3 col-medium-2">
+        <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Hubert Tsang</p>
+        <p class="u-text--muted" aria-hidden="true">CIO, Pacific Textiles</p>
+      </div>
+    </div>
+    <div class="row p-section--shallow">
+      <hr class="p-rule--muted" />
+      <div class="col-3 p-section--shallow">
+        {{ image(url="https://assets.ubuntu.com/v1/59a71df3-Rectangle%206.png",
+                alt="Sicredi",
+                width="207",
+                height="45",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
+      <div class="col-6 col-medium-4">
+        <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
+          <p>
+            <i>We recently reassessed our cloud strategy, and one of the parameters was cost-efficiency. We observed that Canonical OpenStack is helping us to achieve two-to-three times more cost-efficiency than using public clouds.</i>
+            <span class="u-off-screen">Cléber Alexandre Agazzi, Head of Infrastructure & IT Operations, Sicredi</span>
+          </p>
+        </blockquote>
+      </div>
+      <div class="col-3 col-medium-2">
+        <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Cléber Alexandre Agazzi</p>
+        <p class="u-text--muted" aria-hidden="true">Head of Infrastructure & IT Operations, Sicredi</p>
+      </div>
+    </div>
+    <div class="row p-section--shallow">
+      <hr class="p-rule--muted" />
+      <div class="col-3 p-section--shallow">
+        {{ image(url="https://assets.ubuntu.com/v1/4108a96c-Rectangle%207.png",
+                alt="Telefonica",
+                width="189",
+                height="50",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
+      <div class="col-6 col-medium-4">
+        <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
+          <p>
+            <i>Migrating our OCS application to the cloud will give us the base and agility we need in order to consistently offer best-in-class solutions for our customers. This selection [Canonical OpenStack] was an obvious choice to enable us to scale our charging capabilities to a future-proofed private cloud platform.</i>
+            <span class="u-off-screen">Flavio Matiello, Head of PrePaid Platforms & OCS, Telefonica Brazil</span>
+          </p>
+        </blockquote>
+      </div>
+      <div class="col-3 col-medium-2">
+        <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Flavio Matiello</p>
+        <p class="u-text--muted" aria-hidden="true">Head of PrePaid Platforms & OCS, Telefonica Brazil</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>
+          Where does
+          <br />
+          Canonical OpenStack fit?
+        </h2>
+      </div>
+      <div class="col">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">General-purpose cloud computing on your premises</li>
+          <li class="p-list__item is-ticked">An alternative to proprietary virtualisation solutions</li>
+          <li class="p-list__item is-ticked">Implementing a sovereign cloud for digital sovereignty</li>
+          <li class="p-list__item is-ticked">Building a local/regional public cloud for your customers</li>
+          <li class="p-list__item is-ticked">Performance-intensive workloads such as HPC and AI/ML</li>
+          <li class="p-list__item is-ticked">Telco network function virtualisation infrastructure (NFVI)</li>
+          <li class="p-list__item is-ticked">Edge infrastructure distributed across thousands of sides</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width p-section--shallow">
+      <hr class="p-rule" />
+      <h2>Proven record of success</h2>
+    </div>
+    <div class="row p-section--shallow">
+      <div class="col-3 col-medium-3">
+        <a href="https://www.youtube.com/watch?v=0oFnOHJrRQs"
+           aria-label="Watch how BT Group improves fan experience with 5G">
+          <div class="p-image-container--16-9 is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/1b743a00-BT%20Service%20Cloud.png",
+                        alt="BT",
+                        width="111",
+                        height="111",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-image-container__image"}) | safe
+            }}
+          </div>
+          <p>Watch the video&nbsp;&rsaquo;</p>
+        </a>
+      </div>
+      <div class="col-3 col-medium-3">
+        <a href="https://www.unicc.org/news/2023/10/19/unicc-partners-with-canonical-to-build-unicc-cloud/"
+           aria-label="Read the UNICC announcement">
+          <div class="p-image-container--16-9 is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/e49d170a-unicc-logo.png",
+                        alt="UNICC",
+                        width="160",
+                        height="161",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-image-container__image"}) | safe
+            }}
+          </div>
+          <p>Read the announcement&nbsp;&rsaquo;</p>
+        </a>
+      </div>
+      <div class="col-3 col-medium-3">
+        <a href="https://ubuntu.com/engage/kubernetes-openstack-case-study-firmus"
+           aria-label="Read the Firmus case study">
+          <div class="p-image-container--16-9 is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/818f7f12-Firmusgrid%20Supercloud%20Pty%20Ltd.png",
+                        alt="Firmus",
+                        width="200",
+                        height="45",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-image-container__image"}) | safe
+            }}
+          </div>
+          <p>Read the case study&nbsp;&rsaquo;</p>
+        </a>
+      </div>
+      <div class="col-3 col-medium-3">
+        <a href="/blog/telefonica-brazil-selects-charmed-openstack"
+           aria-label="Read the Telefonica annoucement">
+          <div class="p-image-container--16-9 is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/4108a96c-Rectangle%207.png",
+                        alt="Telefonica",
+                        width="189",
+                        height="50",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-image-container__image"}) | safe
+            }}
+          </div>
+          <p>Read the announcement&nbsp;&rsaquo;</p>
+        </a>
+      </div>
+      <div class="col-3 col-medium-3">
+        <a href="/engage/sicredi-openstack-case-study"
+           aria-label="Read the Sicredi case study">
+          <div class="p-image-container--16-9 is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/59a71df3-Rectangle%206.png",
+                        alt="Sicredi",
+                        width="207",
+                        height="45",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-image-container__image"}) | safe
+            }}
+          </div>
+          <p>Read the case study&nbsp;&rsaquo;</p>
+        </a>
+      </div>
+    </div>
+    <div class="u-fixed-width p-section--shallow">
+      <hr class="p-rule" />
+      <div class="p-logo-section">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/44ee0936-mercedes-logo.png",
+                        alt="Mercedes Benz",
+                        width="604",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/2311ff1f-Bloomberg-Logo%20.png",
+                        alt="Bloomberg",
+                        width="314",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/80b0c768-bnp-paribas-logo%20.png",
+                        alt="BNP Paribas",
+                        width="486",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/ae9b96b6-kings-college-london-logo.png",
+                        alt="Kings College London",
+                        width="196",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/5b45c88e-gendarmerie-logo.png",
+                        alt="Gendarmerie",
+                        width="190",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Get Canonical OpenStack</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <p>
+            Self-deployed or Canonical-deployed? This is the only dilemma you have to deal with when getting started with Canonical OpenStack. Choose the option that suits you best and start your adventure with your own professional cloud today.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="row--50-50">
+      <div class="col">
+        <hr class="p-rule--highlight u-no-margin--bottom" />
+        <div class="p-card--overlay u-no-padding--top u-no-padding--bottom"
+             style="padding: 1.5rem">
+          <h3>Self-deployed</h3>
+          <p>
+            You deploy Canonical OpenStack yourself by relying on public-facing materials, such as <a href="https://microstack.run/docs">product documentation</a> and <a href="/openstack/tutorials">turotials</a>. Once deployed according to Canonical's best practices, your cloud qualifies for various levels of <a href="">commercial services</a>.
+          </p>
+          <div class="p-cta-block">
+            <a href="https://microstack.run/docs/single-node"
+               class="p-button--positive">Start on your own</a>
+          </div>
+        </div>
+      </div>
+      <div class="col">
+        <hr class="p-rule--highlight u-no-margin--bottom" />
+        <div class="p-card--overlay u-no-padding--top u-no-padding--bottom"
+             style="padding: 1.5rem">
+          <h3>Canonical-deployed</h3>
+          <div class="p-section--shallow">
+            <p>
+              We deploy Canonical OpenStack for you. Together, we find the design that suits your use case and requirements best. We will share our best practices and hand over the cloud to you once it's built, tested and validated by us.
+            </p>
+          </div>
+          <div class="p-cta-block">
+            <a href="" class="p-button--positive">Start with Canonical</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
 {% endblock content %}

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -31,7 +31,7 @@
           <a href="https://microstack.run/docs/single-node"
              class="p-button--positive">Try Canonical OepnStack</a>
           <a href="https://ubuntu.com/engage/openstack-ebook-beginners"
-             class="p-button">Download OpenStack e-book</a>
+             class="p-button">Download the OpenStack e-book</a>
         </div>
       </div>
     </div>
@@ -102,7 +102,7 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-3 col-medium-3">
-            <h3 class="p-heading--5">You reduce and Optimise your infrastructure costs</h3>
+            <h3 class="p-heading--5">You reduce and optimise your infrastructure costs</h3>
           </div>
           <div class="col-6 col-medium-3">
             <p>
@@ -332,7 +332,7 @@
         </a>
       </div>
       <div class="col-3 col-medium-3">
-        <a href="/engage/sicredi-openstack-case-study"
+        <a href="https://ubuntu.com/engage/sicredi-openstack-case-study"
            aria-label="Read the Sicredi case study">
           <div class="p-image-container--16-9 is-highlighted">
             {{ image(url="https://assets.ubuntu.com/v1/59a71df3-Rectangle%206.png",
@@ -428,7 +428,7 @@
              style="padding: 1.5rem">
           <h3>Self-deployed</h3>
           <p>
-            You deploy Canonical OpenStack yourself by relying on public-facing materials, such as <a href="https://microstack.run/docs">product documentation</a> and <a href="/openstack/tutorials">turotials</a>. Once deployed according to Canonical's best practices, your cloud qualifies for various levels of <a href="">commercial services</a>.
+            You deploy Canonical OpenStack yourself by relying on public-facing materials, such as <a href="https://microstack.run/docs">product documentation</a> and <a href="/openstack/tutorials">tutorials</a>. Once deployed according to Canonical's best practices, your cloud qualifies for various levels of <a href="">commercial services</a>.
           </p>
           <div class="p-cta-block">
             <a href="https://microstack.run/docs/single-node"

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -47,24 +47,24 @@
         <div class="row">
           <div class="col-3 col-medium-2">
             <hr class="p-rule--highlight" />
-            <p class="p-heading--2">
+            <p class="p-heading--2 u-sv-1">
               <strong>100&plus;</strong>
             </p>
-            <p class="p-heading--4 u-no-padding--top">Happy customers</p>
+            <p class="u-no-padding--top">Happy customers</p>
           </div>
           <div class="col-3 col-medium-2">
             <hr class="p-rule--highlight" />
-            <p class="p-heading--2">
+            <p class="p-heading--2 u-sv-1">
               <strong>500&plus;</strong>
             </p>
-            <p class="p-heading--4 u-no-padding--top">Clouds in production</p>
+            <p class="u-no-padding--top">Clouds in production</p>
           </div>
           <div class="col-3 col-medium-2">
             <hr class="p-rule--highlight" />
-            <p class="p-heading--2">
+            <p class="p-heading--2 u-sv-1">
               <strong><span aria-label="about">~</span>30 minutes</strong>
             </p>
-            <p class="p-heading--4 u-no-padding--top">To spin it up in your lab</p>
+            <p class="u-no-padding--top">To spin it up in your lab</p>
           </div>
         </div>
       </div>
@@ -164,75 +164,87 @@
       <h2 class="p-text--small-caps">Endorsed by executives, globally</h2>
     </div>
     <div class="row p-section--shallow">
-      <hr class="p-rule--muted" />
-      <div class="col-3 p-section--shallow">
+      <div class="col-3 p-section--shallow" style="margin-top: 1rem;">
         {{ image(url="https://assets.ubuntu.com/v1/1db9d47a-Rectangle%204.png",
                 alt="Pacific Textiles Holding Limited",
-                width="257",
-                height="45",
+                width="188",
+                height="33",
                 hi_def=True,
                 loading="lazy") | safe
         }}
       </div>
-      <div class="col-6 col-medium-4">
-        <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
-          <p>
-            <i>Canonical is miles ahead of other providers where every server is manually configured.</i>
-            <span class="u-off-screen">Hubert Tsang, CIO, Pacific textiles</span>
-          </p>
-        </blockquote>
-      </div>
-      <div class="col-3 col-medium-2">
-        <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Hubert Tsang</p>
-        <p class="u-text--muted" aria-hidden="true">CIO, Pacific Textiles</p>
+      <div class="col-9">
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-6 col-medium-4">
+            <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
+              <p>
+                <i>Canonical is miles ahead of other providers where every server is manually configured.</i>
+                <span class="u-off-screen">Hubert Tsang, CIO, Pacific textiles</span>
+              </p>
+            </blockquote>
+          </div>
+          <div class="col-3 col-medium-2">
+            <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Hubert Tsang</p>
+            <p class="u-text--muted" aria-hidden="true">CIO, Pacific Textiles</p>
+          </div>
+        </div>
       </div>
     </div>
     <div class="row p-section--shallow">
-      <hr class="p-rule--muted" />
-      <div class="col-3 p-section--shallow">
+      <div class="col-3 p-section--shallow" style="margin-top: 1rem;">
         {{ image(url="https://assets.ubuntu.com/v1/59a71df3-Rectangle%206.png",
                 alt="Sicredi",
-                width="207",
-                height="45",
+                width="124",
+                height="30",
                 hi_def=True,
                 loading="lazy") | safe
         }}
       </div>
-      <div class="col-6 col-medium-4">
-        <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
-          <p>
-            <i>We recently reassessed our cloud strategy, and one of the parameters was cost-efficiency. We observed that Canonical OpenStack is helping us to achieve two-to-three times more cost-efficiency than using public clouds.</i>
-            <span class="u-off-screen">Cléber Alexandre Agazzi, Head of Infrastructure & IT Operations, Sicredi</span>
-          </p>
-        </blockquote>
-      </div>
-      <div class="col-3 col-medium-2">
-        <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Cléber Alexandre Agazzi</p>
-        <p class="u-text--muted" aria-hidden="true">Head of Infrastructure & IT Operations, Sicredi</p>
+      <div class="col-9">
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-6 col-medium-4">
+            <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
+              <p>
+                <i>We recently reassessed our cloud strategy, and one of the parameters was cost-efficiency. We observed that Canonical OpenStack is helping us to achieve two-to-three times more cost-efficiency than using public clouds.</i>
+                <span class="u-off-screen">Cléber Alexandre Agazzi, Head of Infrastructure & IT Operations, Sicredi</span>
+              </p>
+            </blockquote>
+          </div>
+          <div class="col-3 col-medium-2">
+            <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Cléber Alexandre Agazzi</p>
+            <p class="u-text--muted" aria-hidden="true">Head of Infrastructure & IT Operations, Sicredi</p>
+          </div>
+        </div>
       </div>
     </div>
     <div class="row p-section--shallow">
-      <hr class="p-rule--muted" />
-      <div class="col-3 p-section--shallow">
+      <div class="col-3 p-section--shallow" style="margin-top: 1rem;">
         {{ image(url="https://assets.ubuntu.com/v1/4108a96c-Rectangle%207.png",
                 alt="Telefonica",
-                width="189",
-                height="50",
+                width="123",
+                height="33",
                 hi_def=True,
                 loading="lazy") | safe
         }}
       </div>
-      <div class="col-6 col-medium-4">
-        <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
-          <p>
-            <i>Migrating our OCS application to the cloud will give us the base and agility we need in order to consistently offer best-in-class solutions for our customers. This selection [Canonical OpenStack] was an obvious choice to enable us to scale our charging capabilities to a future-proofed private cloud platform.</i>
-            <span class="u-off-screen">Flavio Matiello, Head of PrePaid Platforms & OCS, Telefonica Brazil</span>
-          </p>
-        </blockquote>
-      </div>
-      <div class="col-3 col-medium-2">
-        <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Flavio Matiello</p>
-        <p class="u-text--muted" aria-hidden="true">Head of PrePaid Platforms & OCS, Telefonica Brazil</p>
+      <div class="col-9">
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-6 col-medium-4">
+            <blockquote class="u-no-margin--bottom u-no-padding" style="border: none;">
+              <p>
+                <i>Migrating our OCS application to the cloud will give us the base and agility we need in order to consistently offer best-in-class solutions for our customers. This selection [Canonical OpenStack] was an obvious choice to enable us to scale our charging capabilities to a future-proofed private cloud platform.</i>
+                <span class="u-off-screen">Flavio Matiello, Head of PrePaid Platforms & OCS, Telefonica Brazil</span>
+              </p>
+            </blockquote>
+          </div>
+          <div class="col-3 col-medium-2">
+            <p class="p-heading--5 u-no-margin--bottom" aria-hidden="true">Flavio Matiello</p>
+            <p class="u-text--muted" aria-hidden="true">Head of PrePaid Platforms & OCS, Telefonica Brazil</p>
+          </div>
+        </div>
       </div>
     </div>
   </section>
@@ -267,30 +279,29 @@
       <h2>Proven record of success</h2>
     </div>
     <div class="row p-section--shallow">
-      <div class="col-3 col-medium-3">
+      <div class="col-3 col-medium-3 col-small-2">
         <a href="https://www.youtube.com/watch?v=0oFnOHJrRQs"
            aria-label="Watch how BT Group improves fan experience with 5G">
           <div class="p-image-container--16-9 is-highlighted">
-            {{ image(url="https://assets.ubuntu.com/v1/1b743a00-BT%20Service%20Cloud.png",
+            {{ image(url="https://assets.ubuntu.com/v1/89e42e5e-bt-logo%20.png",
                         alt="BT",
-                        width="111",
-                        height="111",
+                        width="45",
+                        height="104",
                         hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-image-container__image"}) | safe
+                        loading="lazy") | safe
             }}
           </div>
           <p>Watch the video&nbsp;&rsaquo;</p>
         </a>
       </div>
-      <div class="col-3 col-medium-3">
+      <div class="col-3 col-medium-3 col-small-2">
         <a href="https://www.unicc.org/news/2023/10/19/unicc-partners-with-canonical-to-build-unicc-cloud/"
            aria-label="Read the UNICC announcement">
           <div class="p-image-container--16-9 is-highlighted">
             {{ image(url="https://assets.ubuntu.com/v1/e49d170a-unicc-logo.png",
                         alt="UNICC",
-                        width="160",
-                        height="161",
+                        width="104",
+                        height="104",
                         hi_def=True,
                         loading="lazy",
                         attrs={"class": "p-image-container__image"}) | safe
@@ -299,14 +310,14 @@
           <p>Read the announcement&nbsp;&rsaquo;</p>
         </a>
       </div>
-      <div class="col-3 col-medium-3">
+      <div class="col-3 col-medium-3 col-small-2">
         <a href="https://ubuntu.com/engage/kubernetes-openstack-case-study-firmus"
            aria-label="Read the Firmus case study">
           <div class="p-image-container--16-9 is-highlighted">
-            {{ image(url="https://assets.ubuntu.com/v1/818f7f12-Firmusgrid%20Supercloud%20Pty%20Ltd.png",
-                        alt="Firmus",
-                        width="200",
-                        height="45",
+            {{ image(url="https://assets.ubuntu.com/v1/052c9997-firmus-logo.png",
+                        alt="",
+                        width="91",
+                        height="104",
                         hi_def=True,
                         loading="lazy",
                         attrs={"class": "p-image-container__image"}) | safe
@@ -315,14 +326,14 @@
           <p>Read the case study&nbsp;&rsaquo;</p>
         </a>
       </div>
-      <div class="col-3 col-medium-3">
+      <div class="col-3 col-medium-3 col-small-2">
         <a href="/blog/telefonica-brazil-selects-charmed-openstack"
            aria-label="Read the Telefonica annoucement">
           <div class="p-image-container--16-9 is-highlighted">
-            {{ image(url="https://assets.ubuntu.com/v1/4108a96c-Rectangle%207.png",
-                        alt="Telefonica",
-                        width="189",
-                        height="50",
+            {{ image(url="https://assets.ubuntu.com/v1/e91919f4-telefonica-logo%20.png",
+                        alt="",
+                        width="132",
+                        height="104",
                         hi_def=True,
                         loading="lazy",
                         attrs={"class": "p-image-container__image"}) | safe
@@ -331,7 +342,7 @@
           <p>Read the announcement&nbsp;&rsaquo;</p>
         </a>
       </div>
-      <div class="col-3 col-medium-3">
+      <div class="col-3 col-medium-3 col-small-2">
         <a href="https://ubuntu.com/engage/sicredi-openstack-case-study"
            aria-label="Read the Sicredi case study">
           <div class="p-image-container--16-9 is-highlighted">


### PR DESCRIPTION
## Done

- New pages:
  - https://canonical-com-1393.demos.haus/openstack
  - https://canonical-com-1393.demos.haus/openstack/architecture
- Meganav in Products -> OpenStack now takes user to the new /openstack page
- There is now a sub-navigation for the new OpenStack bubble that consists of a link to the new /openstack/architecture page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
