### PR TITLE
feat: added security headers

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -23,6 +23,7 @@ from slugify import slugify
 
 # Local
 from webapp.application import application
+from webapp.handlers import init_handlers
 from webapp.greenhouse import Greenhouse, Harvest
 from webapp.partners import Partners
 from webapp.static_data import homepage_featured_products
@@ -49,6 +50,8 @@ app = FlaskBase(
     template_404="404.html",
     template_500="500.html",
 )
+
+init_handlers(app)
 
 charmhub_discourse_api = DiscourseAPI(
     base_url="https://discourse.charmhub.io/",

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -1,4 +1,3 @@
-
 CSP = {
     "default-src": ["'self'"],
     "img-src": [
@@ -99,4 +98,3 @@ def init_handlers(app):
         response.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
         response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
         return response
-

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -56,9 +56,6 @@ CSP = {
         "'self'",
         "'unsafe-inline'",
     ],
-    "media-src": [
-        "'self'",
-    ],
 }
 
 

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -1,0 +1,102 @@
+
+CSP = {
+    "default-src": ["'self'"],
+    "img-src": [
+        "data: blob:",
+        # This is needed to allow images from
+        # https://www.google.*/ads/ga-audiences to load.
+        "*",
+    ],
+    "script-src-elem": [
+        "'self'",
+        "assets.ubuntu.com",
+        "www.google-analytics.com",
+        "www.googletagmanager.com",
+        "script.crazyegg.com",
+        "connect.facebook.net",
+        "w.usabilla.com",
+        "munchkin.marketo.net",
+        "www.googleadservices.com",
+        "js.zi-scripts.com",
+        "*.g.doubleclick.net",
+        "*.googlesyndication.com",
+        # This is necessary for Google Tag Manager to function properly.
+        "'unsafe-inline'",
+    ],
+    "font-src": [
+        "'self'",
+        "assets.ubuntu.com",
+    ],
+    "script-src": [
+        "'self'",
+        "blob:",
+        "'unsafe-eval'",
+        "'unsafe-hashes'",
+        "'unsafe-inline'",
+    ],
+    "connect-src": [
+        "'self'",
+        "*.googlesyndication.com",
+        "www.google.com",
+        "analytics.google.com",
+        "www.googletagmanager.com",
+        "*.crazyegg.com",
+        "*.g.doubleclick.net",
+        "js.zi-scripts.com",
+        "*.mktoresp.com",
+        "*.google-analytics.com",
+    ],
+    "frame-src": [
+        "'self'",
+        "*.doubleclick.net",
+        "www.youtube.com/",
+        "asciinema.org",
+        "player.vimeo.com",
+    ],
+    "style-src": [
+        "'self'",
+        "'unsafe-inline'",
+    ],
+    "media-src": [
+        "'self'",
+    ],
+}
+
+
+def init_handlers(app):
+    @app.after_request
+    def add_headers(response):
+        """
+        Generic rules for headers to add to all requests
+        - Content-Security-Policy: Restrict resources (e.g., JavaScript, CSS,
+        Images) and URLs
+        - Referrer-Policy: Limit referrer data for security while preserving
+        full referrer for same-origin requests
+        - Cross-Origin-Embedder-Policy: allows embedding cross-origin
+        resources
+        - Cross-Origin-Opener-Policy: enable the page to open pop-ups while
+        maintaining same-origin policy
+        - Cross-Origin-Resource-Policy: allowing cross-origin requests to
+        access the resource
+        - X-Permitted-Cross-Domain-Policies: disallows cross-domain access to
+        resources.
+        """
+
+        def get_csp_as_str(csp={}):
+            csp_str = ""
+            for key, values in csp.items():
+                csp_value = " ".join(values)
+                csp_str += f"{key} {csp_value}; "
+            return csp_str.strip()
+
+        response.headers["Content-Security-Policy"] = get_csp_as_str(CSP)
+
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Cross-Origin-Embedder-Policy"] = "unsafe-none"
+        response.headers["Cross-Origin-Opener-Policy"] = (
+            "same-origin-allow-popups"
+        )
+        response.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
+        response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
+        return response
+


### PR DESCRIPTION
## Done

Added security headers.

- Content-Security-Policy: Restrict resources (e.g., JavaScript, CSS, Images) and URLs
- Referrer-Policy: Limit referrer data for security while preserving full referrer for same-origin requests
- Cross-Origin-Embedder-Policy: allows embedding cross-origin resources
- Cross-Origin-Opener-Policy: enable the page to open pop-ups while maintaining same-origin policy
- Cross-Origin-Resource-Policy: allowing cross-origin requests to access the resource
- X-Permitted-Cross-Domain-Policies: disallows cross-domain access to resources

Read more from [here](https://docs.google.com/document/d/15ajij_jStQ4oUTEo7pT4TgaW5zRH4SOMaW9TDyy0dGE).

## QA

- Open : https://canonical-com-1396.demos.haus/
- Verify no security header error is shown in the console.
- Verify all the images, videos, iframes and other resources are shown correctly
- Verify there is no behavior change (such as a link doesnt open)
- Open [header analyzer](https://dri.es/headers?url=https%3A%2F%2Fcanonical-com-1396.demos.haus%2F)
- Verify Referrer-Policy, Cross-Origin-Embedder-Policy, Cross-Origin-Opener-Policy, Cross-Origin-Resource-Policy and X-Permitted-Cross-Domain-Policies headers arent missing

## Issue / Card

Fixes [#14453](https://warthogs.atlassian.net/browse/WD-14453), [#14454](https://warthogs.atlassian.net/browse/WD-14454), [#14455](https://warthogs.atlassian.net/browse/WD-14455),  [#14456](https://warthogs.atlassian.net/browse/WD-14456), [#14457](https://warthogs.atlassian.net/browse/WD-14457), [#14458](https://warthogs.atlassian.net/browse/WD-14458)
