### PR TITLE
Update data bubble navigation

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -73,12 +73,12 @@ mongodb:
   children:
     - title: Overview
       path: /data/mongodb
+    - title: What is MongoDB
+      path: /data/mongodb/what-is-mongodb
     - title: Managed
       path: /data/mongodb/managed
     - title: Support
       path: /data/mongodb/support
-    - title: What is MongoDB
-      path: /data/mongodb/what-is-mongodb
 
 opensearch:
   title: OpenSearch
@@ -91,12 +91,12 @@ opensearch:
   children:
     - title: Overview
       path: /data/opensearch
+    - title: What is OpenSearch
+      path: /data/opensearch/what-is-opensearch
     - title: Managed
       path: /data/opensearch/managed
     - title: Support
       path: /data/opensearch/support
-    - title: What is OpenSearch
-      path: /data/opensearch/what-is-opensearch
 
 postgresql:
   title: PostgreSQL

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1207,4 +1207,7 @@ def set_form_rules():
             app.add_url_rule(path, view_func=render_form(form), endpoint=path)
 
 
-set_form_rules()
+# this causes secondary navigation to dissapear
+# on /data/opensearch and /data/postresql
+# see: https://github.com/canonical/canonical.com/issues/1399
+# set_form_rules()


### PR DESCRIPTION
## Done

Updated secondary navigation of MongoDB and OpenSearch in data bubble.

Copy doc: https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?tab=t.0#heading=h.ib9c04garte2

Drive-by: some recent form updates started to cause secondary nav to dissapear on several pages. This was commented out here as a drive-by and reported separately in https://github.com/canonical/canonical.com/issues/1399

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Go to MongoDB page: https://canonical-com-1398.demos.haus/data/mongodb
  - make sure secondary navigation items are in order requested by the [copy doc](https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?tab=t.0#heading=h.ib9c04garte2)
- Go to OpenSearch page: https://canonical-com-1398.demos.haus/data/opensearch
  - make sure secondary navigation items are in order requested by the [copy doc](https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?tab=t.0#heading=h.ib9c04garte2)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-15791

## Screenshots

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/8fbc93a5-6822-46df-9054-d2d3ccee3b35">
