### PR TITLE
Update data/postgresql/support title

### DIFF
--- a/templates/data/postgresql/support.html
+++ b/templates/data/postgresql/support.html
@@ -4,7 +4,7 @@
 https://docs.google.com/document/d/1scPktUiI2XRVoYcR4L6qUZ91iZ0upZA-FaqyJN7uMJg/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Get comprehensive support for PostgreSQL, the world's most acclaimed open source database management system.{% endblock %}
+{% block title %}Get support for PostgreSQL, the world's most acclaimed DBMS.{% endblock %}
 
 {% block meta_description %}
 Get support for PostgreSQL from Canonical, the experts in open-source. We provide ticket, phone or screen sharing support 24/7 for up to ten years per release track.


### PR DESCRIPTION
## Done

Updates title of `data/postgresql/support` page per [copy doc update](https://docs.google.com/document/d/1scPktUiI2XRVoYcR4L6qUZ91iZ0upZA-FaqyJN7uMJg/edit?disco=AAABT_iI3g4)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Go to [PostgreSQL support page](https://canonical-com-1412.demos.haus/data/postgresql/support). Verify the page title has been updated to match the copy doc.

## Issue / Card

Fixes [copy doc update](https://docs.google.com/document/d/1scPktUiI2XRVoYcR4L6qUZ91iZ0upZA-FaqyJN7uMJg/edit?disco=AAABT_iI3g4)
