### PR TITLE
bug: Fix seperators and remove stale custom styles

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -235,10 +235,6 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   }
 }
 
-.u-data-border--top {
-  border-top: 3px solid $color-dark;
-}
-
 .u-image-margin--top {
   margin-bottom: -0.5rem;
   margin-top: 0.5rem;

--- a/templates/careers/_base-department.html
+++ b/templates/careers/_base-department.html
@@ -136,11 +136,11 @@
     <div class="row">
       <div class="col-6 col-medium-3">
         <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Blogs</h2>
-        <h5 class="p-heading--2">
+        <h3 class="p-heading--2">
           Find out more about
           <br class="u-hide--small" />
           {{ heading_topic }}
-        </h5>
+        </h3>
       </div>
       <div id="latest-articles"
            class="col-6 col-medium-3"
@@ -154,9 +154,7 @@
       <article class="u-extra-space">
         <div class="blog-p-card__content">
           <hr class="p-rule" />
-          <h5 class="p-rule">
-            <a class="article-link article-title" href=""></a>
-          </h5>
+            <a class="article-link article-title p-heading--5" href=""></a>
           <p class="article-excerpt"></p>
         </div>
       </article>

--- a/templates/careers/company-culture/index.html
+++ b/templates/careers/company-culture/index.html
@@ -26,31 +26,34 @@
 
   <div class="p-strip u-no-padding--top">
     <div class="u-fixed-width">
-      <hr class="p-rule u-hide--medium u-hide--small" />
+      <hr class="p-rule u-hide--medium u-hide--small u-no-margin--bottom" />
     </div>
     <div class="row">
       <div class="col-medium-3 col-3">
         <h3 class="p-muted-heading">We're Canonical</h3>
       </div>
       <div class="col-medium-6 col-9">
-        <hr class="p-rule u-hide--large u-hide--small" />
+        <hr class="p-rule u-hide--large u-hide--small u-no-margin--bottom" />
         <div class="row">
           <div class="col-medium-2 col-3">
-            <h4 class="p-heading--2 u-data-border--top">
+            <hr class="p-rule--highlight" />
+            <h4 class="p-heading--2">
               <strong>1,000+</strong>
               <br />
               People
             </h4>
           </div>
           <div class="col-medium-2 col-3">
-            <h4 class="p-heading--2 u-data-border--top">
+            <hr class="p-rule--highlight" />
+            <h4 class="p-heading--2">
               <strong>70&plus;</strong>
               <br />
               Countries
             </h4>
           </div>
           <div class="col-medium-2 col-3">
-            <h4 class="p-heading--2 u-data-border--top">
+            <hr class="p-rule--highlight" />
+            <h4 class="p-heading--2">
               <strong>75&plus;</strong>
               <br />
               Nationalities


### PR DESCRIPTION
## Done

- Fixed gap between highlighted and base separators  
- Fixed blog section separators for department pages

## QA

- View the site locally in your web browser at: https://canonical-com-1413.demos.haus/careers/company-culture
- See that there is no gap between separators in the "We're hiring" section
- View the site locally in your web browser at: https://canonical-com-1413.demos.haus/careers/engineering (or any department page)
- Scroll down to the blog section and see that the separators have been fixed 

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/1397, https://warthogs.atlassian.net/browse/WD-15954

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/a1990022-26c7-4171-a94f-12642ee37a5d)
![image](https://github.com/user-attachments/assets/e1e53152-96bb-44b8-bfc8-0160ffb4c537)

After:
![image](https://github.com/user-attachments/assets/0aabe4a9-1b9c-476a-82a7-ed5ab1110d07)
![image](https://github.com/user-attachments/assets/ab35144b-901d-41d7-8926-e1ccca43d83d)



