### PR TITLE
Fix link font weight

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -78,13 +78,7 @@ $navigation-heading-color: #fff9;
 }
 
 @mixin canonical-p-navigation-dropdown-content {
-  .p-navigation__content-panel--full-width {
-    a {
-      display: block;
-      font-weight: 400;
-      white-space: normal;
-      text-decoration: none;
-    }
+  .p-navigation__content-panel--full-width { 
 
     .p-navigation__dropdown-item small,
     .p-navigation__dropdown-item small:visited {
@@ -97,6 +91,7 @@ $navigation-heading-color: #fff9;
       a {
         &:hover {
           text-decoration: underline;
+          text-decoration-thickness: from-font;
         }
       }
     }


### PR DESCRIPTION
## Done

- Fix nav link using paragraph font weight 

## QA

- View the site locally in your web browser at: http://0.0.0.0:8002/
- Click on the careers nav and see that the "Roles by department" matches h2 styles
- See that this is the case for the rest of the dropdowns as well  

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/1353