### PR TITLE
specify timeouts on all http requests

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -678,7 +678,8 @@ class BlogSitemapIndex(BlogView):
     def dispatch_request(self):
         with get_requests_session() as session:
             response = session.get(
-                "https://admin.insights.ubuntu.com/sitemap_index.xml"
+                "https://admin.insights.ubuntu.com/sitemap_index.xml",
+                timeout=15,
             )
 
             xml = response.text.replace(
@@ -696,7 +697,8 @@ class BlogSitemapPage(BlogView):
     def dispatch_request(self, slug):
         with get_requests_session() as session:
             response = session.get(
-                f"https://admin.insights.ubuntu.com/{slug}.xml"
+                f"https://admin.insights.ubuntu.com/{slug}.xml",
+                timeout=15,
             )
 
             if response.status_code == 404:

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -39,9 +39,7 @@ class CalendarAPI:
             delegated_credentials = credentials.with_subject(WPE_EMAIL)
             http = httplib2.Http(timeout=15)
             authed_http = AuthorizedHttp(delegated_credentials, http=http)
-            service = build(
-                "calendar", "v3", http=authed_http
-            )
+            service = build("calendar", "v3", http=authed_http)
         except HttpError as error:
             print("An error occurred: %s" % error)
 

--- a/webapp/google_calendar.py
+++ b/webapp/google_calendar.py
@@ -1,5 +1,7 @@
 import os
+import httplib2
 
+from google_auth_httplib2 import AuthorizedHttp
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
@@ -35,8 +37,10 @@ class CalendarAPI:
         )
         try:
             delegated_credentials = credentials.with_subject(WPE_EMAIL)
+            http = httplib2.Http(timeout=15)
+            authed_http = AuthorizedHttp(delegated_credentials, http=http)
             service = build(
-                "calendar", "v3", credentials=delegated_credentials
+                "calendar", "v3", http=authed_http
             )
         except HttpError as error:
             print("An error occurred: %s" % error)

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -180,7 +180,9 @@ class Greenhouse:
         Get all jobs from the API and parse them into vacancies
         Filter out vacancies without an office and a department
         """
-        feed = self.session.get(f"{self.base_url}?content=true", timeout=15).json()
+        feed = self.session.get(
+            f"{self.base_url}?content=true", timeout=15
+        ).json()
 
         vacancies = []
 
@@ -231,7 +233,9 @@ class Greenhouse:
         Retrieve a single job from Greenhouse by ID
         convert it to a Vacancy and return it
         """
-        response = self.session.get(f"{self.base_url}/{job_id}?questions=true", timeout=15)
+        response = self.session.get(
+            f"{self.base_url}/{job_id}?questions=true", timeout=15
+        )
 
         response.raise_for_status()
 

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -180,7 +180,7 @@ class Greenhouse:
         Get all jobs from the API and parse them into vacancies
         Filter out vacancies without an office and a department
         """
-        feed = self.session.get(f"{self.base_url}?content=true").json()
+        feed = self.session.get(f"{self.base_url}?content=true", timeout=15).json()
 
         vacancies = []
 
@@ -231,7 +231,7 @@ class Greenhouse:
         Retrieve a single job from Greenhouse by ID
         convert it to a Vacancy and return it
         """
-        response = self.session.get(f"{self.base_url}/{job_id}?questions=true")
+        response = self.session.get(f"{self.base_url}/{job_id}?questions=true", timeout=15)
 
         response.raise_for_status()
 
@@ -270,6 +270,7 @@ class Greenhouse:
                 "Content-Type": "application/json",
                 "Authorization": f"Basic {self.base64_key}",
             },
+            timeout=30,
         )
 
 
@@ -293,6 +294,7 @@ class Harvest:
         response = self.session.get(
             f"{self.base_url}custom_field/155450",
             headers={"Authorization": f"Basic {self.base64_key}"},
+            timeout=15,
         )
         response.raise_for_status()
         departments = json.loads(response.text)["custom_field_options"]
@@ -309,6 +311,7 @@ class Harvest:
                 f"/{application_id}/scheduled_interviews"
             ),
             headers={"Authorization": f"Basic {self.base64_key}"},
+            timeout=15,
         )
         response.raise_for_status()
 
@@ -318,6 +321,7 @@ class Harvest:
         response = self.session.get(
             f"{self.base_url}applications/{application_id}",
             headers={"Authorization": f"Basic {self.base64_key}"},
+            timeout=15,
         )
         response.raise_for_status()
         response_json = response.json()
@@ -331,6 +335,7 @@ class Harvest:
         response = self.session.get(
             f"{self.base_url}job_posts/{job_post_id}",
             headers={"Authorization": f"Basic {self.base64_key}"},
+            timeout=15,
         )
         response.raise_for_status()
         response_json = response.json()
@@ -344,6 +349,7 @@ class Harvest:
         response = self.session.get(
             f"{self.base_url}candidates/{candidate_id}",
             headers={"Authorization": f"Basic {self.base64_key}"},
+            timeout=15,
         )
         response.raise_for_status()
         response_json = response.json()
@@ -357,6 +363,7 @@ class Harvest:
         response = self.session.get(
             f"{self.base_url}jobs/{job_id}",
             headers={"Authorization": f"Basic {self.base64_key}"},
+            timeout=15,
         )
         response.raise_for_status()
         response_json = response.json()
@@ -370,6 +377,7 @@ class Harvest:
         response = self.session.get(
             f"{self.base_url}jobs/{job_id}/stages",
             headers={"Authorization": f"Basic {self.base64_key}"},
+            timeout=15,
         )
         response.raise_for_status()
         return response.json()
@@ -378,6 +386,7 @@ class Harvest:
         response = self.session.get(
             f"{self.base_url}users/{user_id}",
             headers={"Authorization": f"Basic {self.base64_key}"},
+            timeout=15,
         )
         response.raise_for_status()
         response_json = response.json()
@@ -412,6 +421,7 @@ class Harvest:
                 "On-Behalf-Of": f"{user_id}",
                 "Authorization": f"Basic {self.base64_key}",
             },
+            timeout=30,
         )
 
         return response

--- a/webapp/partners.py
+++ b/webapp/partners.py
@@ -21,9 +21,9 @@ class Partners:
 
     def _get(self, query=""):
         if query:
-            return self.session.get(f"{self.base_url}?{query}").json()[:10]
+            return self.session.get(f"{self.base_url}?{query}", timeout=15).json()[:10]
         else:
-            return self.session.get(self.base_url).json()
+            return self.session.get(self.base_url, timeout=15).json()
 
     def get_partner_list(self):
         return self._get()

--- a/webapp/partners.py
+++ b/webapp/partners.py
@@ -21,7 +21,9 @@ class Partners:
 
     def _get(self, query=""):
         if query:
-            return self.session.get(f"{self.base_url}?{query}", timeout=15).json()[:10]
+            return self.session.get(
+                f"{self.base_url}?{query}", timeout=15
+            ).json()[:10]
         else:
             return self.session.get(self.base_url, timeout=15).json()
 


### PR DESCRIPTION
## Done

Specify timeouts on all http requests. 15s for get requests, 30s for post requests. It is a good practice to always set timeouts on network operations. In case a request hangs it might cause a connections/ram leak. It might also cause stale cache pages if cache validation request happens to hang.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Check everything works as before. (careers pages, blog pages, partners pages)

