### PR TITLE
bug: Fix missing subnav

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -116,7 +116,7 @@ postgresql:
     - title: Support
       path: /data/postgresql/support
 
-kafka:
+spark:
   title: Spark
   path: /data/spark
 


### PR DESCRIPTION
## Done

- Fixed missing /data/spark subnav

## QA

- View the site locally in your web browser at: https://canonical-com-1420.demos.haus/data/spark
- See that the subnav appears as expected

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
