### PR TITLE
copy update: /data/spark/support

### DIFF
--- a/templates/data/spark/support.html
+++ b/templates/data/spark/support.html
@@ -1,456 +1,454 @@
 {% extends 'base_index.html' %}
 
 {% block meta_copydoc %}
-    https://docs.google.com/document/d/1EcgdnMdW5jfZLLhcisUNMMtsPT-4alaPm3zirtvXEMk/edit?tab=t.0#heading=h.3ppydbf0tgen
+  https://docs.google.com/document/d/1EcgdnMdW5jfZLLhcisUNMMtsPT-4alaPm3zirtvXEMk/edit?tab=t.0#heading=h.3ppydbf0tgen
 {% endblock meta_copydoc %}
 
 {% block title %}Get support for Apache Spark, an open parallel, distributed data processing framework.{% endblock %}
 
 {% block meta_description %}
-    Get support for Apache Spark, from Canonical. 24/7 or weekday support and up to ten years security patching per release track.
+  Get support for Apache Spark, from Canonical. 24/7 or weekday support and up to ten years security patching per release track.
 {% endblock %}
 
-{% block canonical_url %}{{ request.host_url }}data/spark/support{% endblock %}
-
 {% block body_class %}
-    is-paper
+  is-paper
 {% endblock body_class %}
 
 {% block content %}
-    <section class="p-section--hero">
-        <div class="row--50-50">
-            <div class="col">
-                <div class="p-section--shallow">
-                    <h1>Support for Spark</h1>
-                </div>
-                <div class="p-section--shallow">
-                    <p>
-                        Run Spark securely in your enterprise. Get advanced support for critical data infrastructure with Ubuntu Pro + Support. Subscribe and benefit from long term security and 24/7 phone/ticket support.
-                    </p>
-                </div>
-                <hr class="p-rule--muted" />
-                <a class="p-button--positive"
-                   href="/contact-us"
-                   aria-controls="data-spark-modal">Get Spark support</a>
-            </div>
-            <div class="col">
-                <div class="p-image-container is-highlighted u-hide--small">
-                    {{ image(url="https://assets.ubuntu.com/v1/42e708f1-hero img.png",
-                                        alt="",
-                                        width="1800",
-                                        height="1128",
-                                        hi_def=True,
-                                        attrs={"class": "p-image-container__image"},
-                                        loading="auto") | safe
-                    }}
-                </div>
-            </div>
+  <section class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col">
+        <div class="p-section--shallow">
+          <h1>Support for Spark</h1>
         </div>
-    </section>
+        <div class="p-section--shallow">
+          <p>
+            Run Spark securely in your enterprise. Get advanced support for critical data infrastructure with Ubuntu Pro + Support. Subscribe and benefit from long term security and 24/7 phone/ticket support.
+          </p>
+        </div>
+        <hr class="p-rule--muted" />
+        <a class="p-button--positive"
+           href="/contact-us"
+           aria-controls="data-spark-modal">Get Spark support</a>
+      </div>
+      <div class="col">
+        <div class="p-image-container is-highlighted u-hide--small">
+          {{ image(url="https://assets.ubuntu.com/v1/42e708f1-hero img.png",
+                    alt="",
+                    width="1800",
+                    height="1128",
+                    hi_def=True,
+                    attrs={"class": "p-image-container__image"},
+                    loading="auto") | safe
+          }}
+        </div>
+      </div>
+    </div>
+  </section>
 
-    <section class="p-section">
-        <div class="row">
-            <hr class="p-rule" />
-            <div class="col-3 col-medium-2">
-                <h2 class="p-text--small-caps">
-                    Why choose Canonical
-                    <br class="u-hide-small" />
-                    for Spark support
-                </h2>
-            </div>
-            <div class="col-9 col-medium-4">
-                <ul class="p-list--divided">
-                    <li class="p-list__item u-no-padding">
-                        <p class="p-heading--2 u-no-padding">Up to 10 years support & security maintenance</p>
-                    </li>
-                    <li class="p-list__item u-no-padding">
-                        <p class="p-heading--2 u-no-padding">Low total cost of ownership</p>
-                    </li>
-                    <li class="p-list__item u-no-padding">
-                        <p class="p-heading--2 u-no-padding">Full stack open source expertise</p>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </section>
+  <section class="p-section">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-2">
+        <h2 class="p-text--small-caps">
+          Why choose Canonical
+          <br class="u-hide-small" />
+          for Spark support
+        </h2>
+      </div>
+      <div class="col-9 col-medium-4">
+        <ul class="p-list--divided">
+          <li class="p-list__item u-no-padding">
+            <p class="p-heading--2 u-no-padding">Up to 10 years support & security maintenance</p>
+          </li>
+          <li class="p-list__item u-no-padding">
+            <p class="p-heading--2 u-no-padding">Low total cost of ownership</p>
+          </li>
+          <li class="p-list__item u-no-padding">
+            <p class="p-heading--2 u-no-padding">Full stack open source expertise</p>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
 
-    <section class="p-section">
-        <div class="p-section--shallow u-fixed-width">
-            <hr class="p-rule" />
-            <h2>Our support offering for Apache Spark</h2>
+  <section class="p-section">
+    <div class="p-section--shallow u-fixed-width">
+      <hr class="p-rule" />
+      <h2>Our support offering for Apache Spark</h2>
+    </div>
+    <div class="u-fixed-width">
+      <div class="p-section--shallow u-hide--small u-hide--medium">
+        <div class="p-image-container is-highlighted">
+          {{ image(url="https://assets.ubuntu.com/v1/4949f3b9-our spark support offering.png",
+                    alt="",
+                    width="2464",
+                    height="1027",
+                    hi_def=True,
+                    attrs={"class": "p-image-container__image"},
+                    loading="lazy") | safe
+          }}
         </div>
-        <div class="u-fixed-width">
-            <div class="p-section--shallow u-hide--small u-hide--medium">
-                <div class="p-image-container is-highlighted">
-                    {{ image(url="https://assets.ubuntu.com/v1/4949f3b9-our spark support offering.png",
-                                        alt="",
-                                        width="2464",
-                                        height="1027",
-                                        hi_def=True,
-                                        attrs={"class": "p-image-container__image"},
-                                        loading="lazy") | safe
-                    }}
-                </div>
-            </div>
-            <hr class="p-rule--muted u-hide--medium" />
+      </div>
+      <hr class="p-rule--muted u-hide--medium" />
+    </div>
+    <div class="p-equal-height-row p-section--shallow">
+      <div class="p-equal-height-row__col">
+        <div class="p-equal-height-row__item">
+          <h3 class="p-heading--5">Technical support</h3>
         </div>
+        <p class="p-equal-height-row__item">
+          Your data, our expertise. Included in the Ubuntu Pro pricing is phone and ticket support for Spark. Canonical uses the follow-the-sun support model to ensure 24/7 coverage so that your issues are resolved quickly.
+        </p>
+      </div>
+      <div class="p-equal-height-row__col">
+        <div class="p-equal-height-row__item">
+          <h3 class="p-heading--5">Full-stack support</h3>
+        </div>
+        <p class="p-equal-height-row__item">
+          As the publisher of Ubuntu, Canonical uniquely supports the full stack. Complex issues in enterprise data platforms require analysis and fixes all the way down the stack. Get a single solution for best in class support &ndash; with no loose ends.
+
+        </p>
+      </div>
+      <div class="p-equal-height-row__col">
+        <div class="p-equal-height-row__item">
+          <h3 class="p-heading--5">10 years of security</h3>
+        </div>
+        <p class="p-equal-height-row__item">
+          Not every organisation is willing or able to upgrade their critical data infrastructure on a regular basis. With Canonical, your service stays secure for up to 10 years with no need for major upgrades.
+        </p>
+      </div>
+      <div class="p-equal-height-row__col">
+        <div class="p-equal-height-row__item">
+          <h3 class="p-heading--5">Fast response time</h3>
+        </div>
+        <p class="p-equal-height-row__item">
+          We guarantee 1 hour response time for the most critical issues. Our expertise underpins your SLA.
+        </p>
+      </div>
+    </div>
+    <div class="row">
+      <hr class="p-rule--muted" />
+      <div class="col-6 col-start-large-7 col-medium-3 col-start-medium-4">
+        <a class="p-button"
+           href="https://assets.ubuntu.com/v1/83834ab4-B%20Ubuntu%20Pro%20DS%2028.10.22.pdf">
+        Download the Ubuntu Pro datasheet</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="p-section--shallow u-fixed-width">
+      <hr class="p-rule" />
+      <h2>Managed services</h2>
+    </div>
+    <div class="row--25-75-on-large">
+      <div class="col">
         <div class="p-equal-height-row p-section--shallow">
-            <div class="p-equal-height-row__col">
-                <div class="p-equal-height-row__item">
-                    <h3 class="p-heading--5">Technical support</h3>
-                </div>
-                <p class="p-equal-height-row__item">
-                    Your data, our expertise. Included in the Ubuntu Pro pricing is phone and ticket support for Spark. Canonical uses the follow-the-sun support model to ensure 24/7 coverage so that your issues are resolved quickly.
-                </p>
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item p-image-container is-highlighted u-hide--small">
+              <img src="https://assets.ubuntu.com/v1/f914a490-go%20further.png"
+                   alt=""
+                   class="p-image-container__image" />
             </div>
-            <div class="p-equal-height-row__col">
-                <div class="p-equal-height-row__item">
-                    <h3 class="p-heading--5">Full-stack support</h3>
-                </div>
-                <p class="p-equal-height-row__item">
-                    As the publisher of Ubuntu, Canonical uniquely supports the full stack. Complex issues in enterprise data platforms require analysis and fixes all the way down the stack. Get a single solution for best in class support &mdash; with no loose ends.
-
-                </p>
-            </div>
-            <div class="p-equal-height-row__col">
-                <div class="p-equal-height-row__item">
-                    <h3 class="p-heading--5">10 years of security</h3>
-                </div>
-                <p class="p-equal-height-row__item">
-                    Not every organisation is willing or able to upgrade their critical data infrastructure on a regular basis. With Canonical, your service stays secure for up to 10 years with no need for major upgrades.
-                </p>
-            </div>
-            <div class="p-equal-height-row__col">
-                <div class="p-equal-height-row__item">
-                    <h3 class="p-heading--5">Fast response time</h3>
-                </div>
-                <p class="p-equal-height-row__item">
-                    We guarantee 1 hour response time for the most critical issues. Our expertise underpins your SLA.
-                </p>
-            </div>
-        </div>
-        <div class="row">
-            <hr class="p-rule--muted" />
-            <div class="col-6 col-start-large-7 col-medium-3 col-start-medium-4">
-                <a class="p-button"
-                   href="https://assets.ubuntu.com/v1/83834ab4-B%20Ubuntu%20Pro%20DS%2028.10.22.pdf">
-                Download the Ubuntu Pro datasheet</a>
-            </div>
-        </div>
-    </section>
-
-    <section class="p-section">
-        <div class="p-section--shallow u-fixed-width">
-            <hr class="p-rule" />
-            <h2>Managed services</h2>
-        </div>
-        <div class="row--25-75-on-large">
-            <div class="col">
-                <div class="p-equal-height-row p-section--shallow">
-                    <div class="p-equal-height-row__col">
-                        <div class="p-equal-height-row__item p-image-container is-highlighted u-hide--small">
-                            <img src="https://assets.ubuntu.com/v1/f914a490-go%20further.png"
-                                 alt=""
-                                 class="p-image-container__image" />
-                        </div>
-                        <hr class="p-rule--highlight u-hide--medium u-hide--small" />
-                        <h3 class="p-equal-height-row__item p-heading--5">Go further</h3>
-                        <p class="p-equal-height-row__item">
-                            Focus on your core business needs by outsourcing Spark data lake house operational management. With managed services from Canonical, our engineers deploy and manage your MongoDB lake house solution efficiently and securely &mdash; in your cloud tenancy or physical data centre.
-                        </p>
-                    </div>
-                    <div class="p-equal-height-row__col">
-                        <div class="p-equal-height-row__item p-image-container is-highlighted u-hide--small">
-                            <img src="https://assets.ubuntu.com/v1/e68ed270-backed%20by%20an%20sla.png"
-                                 alt=""
-                                 class="p-image-container__image" />
-                        </div>
-                        <hr class="p-rule--highlight u-hide--medium u-hide--small" />
-                        <h3 class="p-equal-height-row__item p-heading--5">Backed by an SLA</h3>
-                        <p class="p-equal-height-row__item">
-                            Canonical delivers through a global team. Thanks to our deep expertise on MongoDB operational service delivery, your service is backed by industry leading compliance and SLA guarantees.
-                        </p>
-                    </div>
-                    <div class="p-equal-height-row__col">
-                        <div class="p-equal-height-row__item p-image-container is-highlighted u-hide--small">
-                            <img src="https://assets.ubuntu.com/v1/da8f6c14-firefighting%20support.png"
-                                 alt=""
-                                 class="p-image-container__image" />
-
-                        </div>
-                        <hr class="p-rule--highlight u-hide--medium u-hide--small" />
-                        <h3 class="p-equal-height-row__item p-heading--5">Firefighting support</h3>
-                        <p class="p-equal-height-row__item">
-                            The best alternative to fully managed services. Our experienced engineers work alongside your team to help resolve your most critical issues while you continue to manage your own environments.
-                        </p>
-                    </div>
-                </div>
-                <hr class="p-rule--muted" />
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-6 col-start-large-7 col-medium-3 col-start-medium-4">
-                <p>
-                    <a href="https://ubuntu.com/managed/apps">Read about Canonical's Managed Apps&nbsp;&rsaquo;</a>
-                </p>
-            </div>
-        </div>
-    </section>
-
-    <section class="p-section">
-        <div class="row">
-            <hr class="p-rule" />
-            <div class="col-3 col-medium-2">
-                <h2>Consulting</h2>
-            </div>
-            <div class="col-9 col-medium-6">
-                <div class="row">
-                    <div class="col-3 col-medium-3">
-                        <h3 class="p-heading--5">Spark data lake platform architecture consulting</h3>
-                    </div>
-                    <div class="col-6 col-medium-3">
-                        <p>
-                            Work with a Canonical platform architect to design the open source data solution that works best for you. Design services covering requirements analysis, environment planning, initial dimensioning and solution design. Fully documented and aligned with your needs.
-                        </p>
-                    </div>
-                </div>
-                <hr class="p-rule--muted" />
-                <div class="row">
-                    <div class="col-3 col-medium-3">
-                        <h3 class="p-heading--5">Spark data lake platform deployment service</h3>
-                    </div>
-                    <div class="col-6 col-medium-3">
-                        <p>
-                            Canonical engineers deploy Charmed Spark to the cloud or data centre of your choice. Kubernetes and air-gapped environments are fully supported.
-                        </p>
-                        <hr class="p-rule--muted" />
-                        <p>
-                            <a href="https://ubuntu.com/pricing/consulting">Explore pricing&nbsp;&rsaquo;<span class="u-off-screen">explore pricing for consultancy</span></a>
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <section class="p-section">
-        <div class="row">
-            <hr class="p-rule" />
-            <div class="col-3 col-medium-6">
-                <h2>Training</h2>
-            </div>
-            <div class="col-3 col-medium-3">
-                <h3 class="p-heading--5">Charmed Spark training</h3>
-            </div>
-            <div class="col-6 col-medium-3">
-                <p>
-                    Get hands-on training with Spark and Charmed Spark, Canonical's solution for Apache Spark, in a three day workshop delivered remotely or on-site.
-                </p>
-                <hr class="p-rule--muted" />
-                <p>
-                    <a class="p-button" href="/contact-us" aria-controls="data-spark-modal">Get in touch<span class="u-off-screen">Get in touch</span></a>
-                </p>
-            </div>
-        </div>
-    </section>
-
-    <hr class="p-rule is-fixed-width" />
-
-    <section class="p-strip is-deep">
-        <div class="u-fixed-width">
-            <p class="p-heading--2">
-                <a href="/contact-us" aria-controls="data-spark-modal">Contact us to get support for Spark&nbsp;&rsaquo;</a>
+            <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+            <h3 class="p-equal-height-row__item p-heading--5">Go further</h3>
+            <p class="p-equal-height-row__item">
+              Focus on your core business by outsourcing Spark data lake house operational management. With managed services from Canonical, our engineers deploy and manage your Spark lake house solution efficiently and securely &ndash; in your cloud tenancy or physical data centre.
             </p>
-        </div>
-    </section>
+          </div>
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item p-image-container is-highlighted u-hide--small">
+              <img src="https://assets.ubuntu.com/v1/e68ed270-backed%20by%20an%20sla.png"
+                   alt=""
+                   class="p-image-container__image" />
+            </div>
+            <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+            <h3 class="p-equal-height-row__item p-heading--5">Backed by an SLA</h3>
+            <p class="p-equal-height-row__item">
+              Canonical delivers through a global, follow the sun team, with deep expertise on Spark operational service delivery. Your service is backed by industry leading compliance and SLA guarantees.
+            </p>
+          </div>
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item p-image-container is-highlighted u-hide--small">
+              <img src="https://assets.ubuntu.com/v1/da8f6c14-firefighting%20support.png"
+                   alt=""
+                   class="p-image-container__image" />
 
-    <section class="p-section">
-        <div class="row--50-50 p-section">
-            <hr class="p-rule" />
-            <div class="col">
-                <h2>
-                    Come for Spark support,
-                    <br class="u-hide-small" />
-                    get the full stack
-                </h2>
             </div>
-            <div class="col">
-                <p>
-                    With Ubuntu Pro + Support for Apache Spark, you get an all-access pass to everything Canonical has to offer, including best-in-class open source solutions for enterprise data management and AI. Ubuntu Pro subscriptions are competitively priced per server, not per application.
-                </p>
-            </div>
+            <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+            <h3 class="p-equal-height-row__item p-heading--5">Firefighting support</h3>
+            <p class="p-equal-height-row__item">
+              The best alternative to fully managed services. Our experienced engineers work alongside your team to help resolve your most critical issues while you continue to manage your own environments.
+            </p>
+          </div>
         </div>
+        <hr class="p-rule--muted" />
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-6 col-start-large-7 col-medium-3 col-start-medium-4">
+        <p>
+          <a href="https://ubuntu.com/managed/apps">Read about Canonical's Managed Apps&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-2">
+        <h2>Consulting</h2>
+      </div>
+      <div class="col-9 col-medium-6">
         <div class="row">
-            <div class="col-3 col-medium-2 col-small-2">
-                <a href="https://charmed-kubeflow.io/">
-                    <div class="p-image-container is-highlighted">
-                        {{ image(url="https://assets.ubuntu.com/v1/cd89477e-kubeflow-logo-container-vert-fill.png",
-                                                alt="Kubeflow",
-                                                width="349",
-                                                height="481",
-                                                hi_def=True,
-                                                loading="lazy",
-                                                attrs={"class": "p-logo-section__logo"}) | safe
-                        }}
-                    </div>
-                    <hr class="p-rule--muted" />
-                    <p>Learn more&nbsp;&rsaquo;</p>
-                </a>
-            </div>
-            <div class="col-3 col-medium-2 col-small-2">
-                <a href="/data/spark">
-                    <div class="p-image-container is-highlighted">
-                        {{ image(url="https://assets.ubuntu.com/v1/855deda8-apache-spark-logo-container-vert-fill.png",
-                                                alt="Apache Spark",
-                                                width="240",
-                                                height="481",
-                                                hi_def=True,
-                                                loading="lazy",
-                                                attrs={"class": "p-logo-section__logo"}) | safe
-                        }}
-                    </div>
-                    <hr class="p-rule--muted" />
-                    <p>Learn more&nbsp;&rsaquo;</p>
-                </a>
-            </div>
-            <div class="col-3 col-medium-2 col-small-2">
-                <a href="https://ubuntu.com/ai/mlflow">
-                    <div class="p-image-container is-highlighted">
-                        {{ image(url="https://assets.ubuntu.com/v1/104192d9-mlflow-logo-container-vert-fill.png",
-                                                alt="MLflow",
-                                                width="222",
-                                                height="481",
-                                                hi_def=True,
-                                                loading="lazy",
-                                                attrs={"class": "p-logo-section__logo"}) | safe
-                        }}
-                    </div>
-                    <hr class="p-rule--muted" />
-                    <p>Learn more&nbsp;&rsaquo;</p>
-                </a>
-            </div>
-            <div class="col-3 col-medium-2 col-small-2">
-                <a href="/data/opensearch">
-                    <div class="p-image-container is-highlighted">
-                        {{ image(url="https://assets.ubuntu.com/v1/a8185f91-opensearch-logo-container-vert-fill.png",
-                                                alt="OpenSearch",
-                                                width="330",
-                                                height="481",
-                                                hi_def=True,
-                                                loading="lazy",
-                                                attrs={"class": "p-logo-section__logo"}) | safe
-                        }}
-                    </div>
-                    <hr class="p-rule--muted" />
-                    <p>Learn more&nbsp;&rsaquo;</p>
-                </a>
-            </div>
-            <div class="col-3 col-medium-2 col-small-2">
-                <a href="/data/kafka">
-                    <div class="p-image-container is-highlighted">
-                        {{ image(url="https://assets.ubuntu.com/v1/d30de1f1-kafka-logo-container-vert-fill.png",
-                                                alt="Kafka",
-                                                width="294",
-                                                height="481",
-                                                hi_def=True,
-                                                loading="lazy",
-                                                attrs={"class": "p-logo-section__logo"}) | safe
-                        }}
-                    </div>
-                    <hr class="p-rule--muted" />
-                    <p>Learn more&nbsp;&rsaquo;</p>
-                </a>
-            </div>
-            <div class="col-3 col-medium-2 col-small-2">
-                <a href="/data/mongodb">
-                    <div class="p-image-container is-highlighted">
-                        {{ image(url="https://assets.ubuntu.com/v1/efdc8292-mongodb-logo-container-vert-fill.png",
-                                                alt="MongoDB",
-                                                width="413",
-                                                height="481",
-                                                hi_def=True,
-                                                loading="lazy",
-                                                attrs={"class": "p-logo-section__logo"}) | safe
-                        }}
-                    </div>
-                    <hr class="p-rule--muted" />
-                    <p>Learn more&nbsp;&rsaquo;</p>
-                </a>
-            </div>
-            <div class="col-3 col-medium-2 col-small-2">
-                <a href="/data/postgresql">
-                    <div class="p-image-container is-highlighted">
-                        {{ image(url="https://assets.ubuntu.com/v1/f5605b7e-postgre-sql-container-vert-fill.png",
-                                                alt="PostgreSQL",
-                                                width="432",
-                                                height="481",
-                                                hi_def=True,
-                                                loading="lazy",
-                                                attrs={"class": "p-logo-section__logo"}) | safe
-                        }}
-                    </div>
-                    <hr class="p-rule--muted" />
-                    <p>Learn more&nbsp;&rsaquo;</p>
-                </a>
-            </div>
-            <div class="col-3 col-medium-2 col-small-2">
-                <a href="/data/mysql">
-                    <div class="p-image-container is-highlighted">
-                        {{ image(url="https://assets.ubuntu.com/v1/692e2b1d-mysql-logo-container-vert-fill.png",
-                                                alt="MySQL",
-                                                width="300",
-                                                height="481",
-                                                hi_def=True,
-                                                loading="lazy",
-                                                attrs={"class": "p-logo-section__logo"}) | safe
-                        }}
-                    </div>
-                    <hr class="p-rule--muted" />
-                    <p>Learn more&nbsp;&rsaquo;</p>
-                </a>
-            </div>
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">Spark data lake platform architecture consulting</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Work with a Canonical platform architect to design the open source data solution that works best for you. Design services covering requirements analysis, environment planning, initial dimensioning and solution design. Fully documented and aligned with your needs.
+            </p>
+          </div>
         </div>
-    </section>
-
-    <section class="p-section">
-        <div class="row--50-50">
-            <hr class="p-rule" />
-            <div class="col">
-                <h2>Learn more about Spark</h2>
-            </div>
-            <div class="col">
-                <p class="p-heading--5 u-no-margin--bottom">
-                    <a href="/blog/tag/spark">Spark in the Canonical blog</a>
-                </p>
-                <p>Read articles about Apache Spark from our blog</p>
-                <hr class="p-rule--muted" />
-                <p class="p-heading--5 u-no-margin--bottom">
-                    <a href="https://ubuntu.com/engage?tag=spark&resource=webinar">Browse webinars</a>
-                </p>
-                <p>Watch recent webinars delivered by our Spark product and services teams</p>
-                <hr class="p-rule--muted" />
-                <p class="p-heading--5 u-no-margin--bottom">
-                    <a href="/data/spark#get-in-touch">Discuss your needs with our team</a>
-                </p>
-                <p>Contact sales and make an appointment to meet with our Spark solutions team to explain your needs in full.</p>
-            </div>
-        </div>
-    </section>
-    <section class="p-section--deep">
+        <hr class="p-rule--muted" />
         <div class="row">
-            <hr class="p-rule" />
-            <div class="col-6 col-start-large-7">
-                <p class="u-text--muted">
-                    Apache<sup>&reg;</sup>, Apache Spark, Spark<sup>&reg;</sup>, and the Spark logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.
-                </p>
-            </div>
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">Spark data lake platform deployment service</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Canonical engineers deploy Charmed Spark to the cloud or data centre of your choice. Kubernetes and air-gapped environments are fully supported.
+            </p>
+            <hr class="p-rule--muted" />
+            <p>
+              <a href="https://ubuntu.com/pricing/consulting">Explore pricing&nbsp;&rsaquo;<span class="u-off-screen">explore pricing for consultancy</span></a>
+            </p>
+          </div>
         </div>
-    </section>
-    <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+      </div>
+    </div>
+  </section>
 
-    {% with %}
-        {% set returnURL = "https://canonical.com/data/spark#success" %}
-        {% include "data/_form-data-spark.html" %}
-    {% endwith %}
+  <section class="p-section">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-6">
+        <h2>Training</h2>
+      </div>
+      <div class="col-3 col-medium-3">
+        <h3 class="p-heading--5">Charmed Spark training</h3>
+      </div>
+      <div class="col-6 col-medium-3">
+        <p>
+          Get hands-on training with Spark and Charmed Spark, Canonical's solution for Apache Spark, in a three day workshop delivered remotely or on-site.
+        </p>
+        <hr class="p-rule--muted" />
+        <p>
+          <a class="p-button" href="/contact-us" aria-controls="data-spark-modal">Get in touch<span class="u-off-screen">Get in touch</span></a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="p-rule is-fixed-width" />
+
+  <section class="p-strip is-deep">
+    <div class="u-fixed-width">
+      <p class="p-heading--2">
+        <a href="/contact-us" aria-controls="data-spark-modal">Contact us to get support for Spark&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50 p-section">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>
+          Come for Spark support,
+          <br class="u-hide-small" />
+          get the full stack
+        </h2>
+      </div>
+      <div class="col">
+        <p>
+          With Ubuntu Pro + Support for Apache Spark, you get an all-access pass to everything Canonical has to offer, including best-in-class open source solutions for enterprise data management and AI. Ubuntu Pro subscriptions are competitively priced per server, not per application.
+        </p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-3 col-medium-2 col-small-2">
+        <a href="https://charmed-kubeflow.io/">
+          <div class="p-image-container is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/cd89477e-kubeflow-logo-container-vert-fill.png",
+                        alt="Kubeflow",
+                        width="349",
+                        height="481",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <hr class="p-rule--muted" />
+          <p>Learn more&nbsp;&rsaquo;</p>
+        </a>
+      </div>
+      <div class="col-3 col-medium-2 col-small-2">
+        <a href="/data/spark">
+          <div class="p-image-container is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/855deda8-apache-spark-logo-container-vert-fill.png",
+                        alt="Apache Spark",
+                        width="240",
+                        height="481",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <hr class="p-rule--muted" />
+          <p>Learn more&nbsp;&rsaquo;</p>
+        </a>
+      </div>
+      <div class="col-3 col-medium-2 col-small-2">
+        <a href="https://ubuntu.com/ai/mlflow">
+          <div class="p-image-container is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/104192d9-mlflow-logo-container-vert-fill.png",
+                        alt="MLflow",
+                        width="222",
+                        height="481",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <hr class="p-rule--muted" />
+          <p>Learn more&nbsp;&rsaquo;</p>
+        </a>
+      </div>
+      <div class="col-3 col-medium-2 col-small-2">
+        <a href="/data/opensearch">
+          <div class="p-image-container is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/a8185f91-opensearch-logo-container-vert-fill.png",
+                        alt="OpenSearch",
+                        width="330",
+                        height="481",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <hr class="p-rule--muted" />
+          <p>Learn more&nbsp;&rsaquo;</p>
+        </a>
+      </div>
+      <div class="col-3 col-medium-2 col-small-2">
+        <a href="/data/kafka">
+          <div class="p-image-container is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/d30de1f1-kafka-logo-container-vert-fill.png",
+                        alt="Kafka",
+                        width="294",
+                        height="481",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <hr class="p-rule--muted" />
+          <p>Learn more&nbsp;&rsaquo;</p>
+        </a>
+      </div>
+      <div class="col-3 col-medium-2 col-small-2">
+        <a href="/data/mongodb">
+          <div class="p-image-container is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/efdc8292-mongodb-logo-container-vert-fill.png",
+                        alt="MongoDB",
+                        width="413",
+                        height="481",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <hr class="p-rule--muted" />
+          <p>Learn more&nbsp;&rsaquo;</p>
+        </a>
+      </div>
+      <div class="col-3 col-medium-2 col-small-2">
+        <a href="/data/postgresql">
+          <div class="p-image-container is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/f5605b7e-postgre-sql-container-vert-fill.png",
+                        alt="PostgreSQL",
+                        width="432",
+                        height="481",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <hr class="p-rule--muted" />
+          <p>Learn more&nbsp;&rsaquo;</p>
+        </a>
+      </div>
+      <div class="col-3 col-medium-2 col-small-2">
+        <a href="/data/mysql">
+          <div class="p-image-container is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/692e2b1d-mysql-logo-container-vert-fill.png",
+                        alt="MySQL",
+                        width="300",
+                        height="481",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <hr class="p-rule--muted" />
+          <p>Learn more&nbsp;&rsaquo;</p>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Learn more about Spark</h2>
+      </div>
+      <div class="col">
+        <p class="p-heading--5 u-no-margin--bottom">
+          <a href="/blog/tag/spark">Spark in the Canonical blog</a>
+        </p>
+        <p>Read articles about Apache Spark from our blog</p>
+        <hr class="p-rule--muted" />
+        <p class="p-heading--5 u-no-margin--bottom">
+          <a href="https://ubuntu.com/engage?tag=spark&resource=webinar">Browse webinars</a>
+        </p>
+        <p>Watch recent webinars delivered by our Spark product and services teams</p>
+        <hr class="p-rule--muted" />
+        <p class="p-heading--5 u-no-margin--bottom">
+          <a href="/data/spark#get-in-touch">Discuss your needs with our team</a>
+        </p>
+        <p>Contact sales and make an appointment to meet with our Spark solutions team to explain your needs in full.</p>
+      </div>
+    </div>
+  </section>
+  <section class="p-section--deep">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-6 col-start-large-7">
+        <p class="u-text--muted">
+          Apache<sup>&reg;</sup>, Apache Spark, Spark<sup>&reg;</sup>, and the Spark logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.
+        </p>
+      </div>
+    </div>
+  </section>
+  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+
+  {% with %}
+    {% set returnURL = "https://canonical.com/data/spark#success" %}
+    {% include "data/_form-data-spark.html" %}
+  {% endwith %}
 
 {% endblock %}


### PR DESCRIPTION
## Done

- Fix incorrect copy in "Managed services" section
- Drive by:
  - Fixed indentation
  - Removed stale `canonical_url` jinja block

## QA

- View the site locally in your web browser at: https://canonical-com-1421.demos.haus/data/spark/support
- See that the text under "Go further" and "Backed by an SLA" matches the [doc](https://docs.google.com/document/d/1EcgdnMdW5jfZLLhcisUNMMtsPT-4alaPm3zirtvXEMk/edit?disco=AAABU_UlafU) 

## Issue / Card

Fixes #

