### PR TITLE
chore: Refresh valkey page

### DIFF
--- a/templates/data/valkey.html
+++ b/templates/data/valkey.html
@@ -35,7 +35,7 @@
           <p>
             We are experts in Valkey. From providing everyday support to offering hands-on assistance for complex projects, our experienced database performance specialists are prepared to assist you with any challenge.
           </p>
-          <p>Deal with issues faster and guarantee the ongoing performance of your Valkey deployments with 24/7/365 support.</p>
+          <p>Deal with issues faster and guarantee the ongoing performance of your Valkey deployments with 24/7/365 support across clouds, on premises, and hybrid environments.</p>
         </div>
         <div class="p-cta-block">
           <a class="p-button--positive"
@@ -57,35 +57,6 @@
           Valkey is an open source (Berkeley Source Distribution-BSD license) high-performance,  in-memory data store that supports a variety of workloads such as caching and message queues.  It can act as a primary database. Valkey can run as either a standalone daemon or in a cluster, with options for replication and high availability.
         </p>
         <p>Valkey 7.2 is the drop-in replacement for the last open source Redis version 7.2 and for earlier Redis versions.</p>
-      </div>
-    </div>
-  </section>
-
-  <section class="p-section">
-    <div class="row--50-50">
-      <hr class="p-rule" />
-      <div class="col">
-        <h2>
-          Flexible, long-term
-          <br />
-          Valkey&trade; support
-        </h2>
-      </div>
-      <div class="col">
-        <p>
-          Canonical supports Valkey 7.2.5, which can be deployed on-premises, across clouds, and in hybrid environments. We provide 10 years of maintenance for Valkey related artifacts in the format of your choice:
-        </p>
-        <ul class="p-list--divided">
-          <li class="p-list__item is-ticked">
-            <strong>Deb packages</strong> for seamless integration with your Ubuntu installations. Currently fully supported in Ubuntu.
-          </li>
-          <li class="p-list__item is-ticked">
-            <strong>Snaps</strong> for added confinement and atomic updates that can run in any linux environment.
-          </li>
-          <li class="p-list__item is-ticked">
-            <strong>OCI-compliant image</strong> for Kubernetes and your containerised environments.
-          </li>
-        </ul>
       </div>
     </div>
   </section>
@@ -183,6 +154,75 @@
           Support for Valkey is priced per node, per year. There are no per-socket or per-core limitations, and no software licence fees.
         </p>
         <p>Run Valkey with more control over your Total Cost of Ownership (TCO).</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50 p-section--shallow">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Multiple packaging formats</h2>
+      </div>
+      <div class="col">
+        <p>We provide maintained and supported Valkey packages in deb, snap, and container formats:</p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3">
+            <h3 class="p-heading--5">Debs</h3>
+          </div>
+          <div class="col-6">
+            <p>We offer deb packages for a seamless integration with your Ubuntu installations. Our Valkey debs help you:</p>
+            <ul class="p-list--divided">
+              <li class="p-list__item is-ticked">
+                Deploy a working Valkey instance in a single command
+                <pre class="u-no-margin--bottom">sudo apt install valkey</pre>
+              </li>
+              <li class="p-list__item is-ticked">
+                Use readily available libraries to run Valkey
+              </li>
+            </ul>
+            <hr class="p-rule--muted" />
+            <p class="u-no-margin--bottom"><a href="https://ubuntu.com/blog/valkey-ubuntu">Read more&nbsp;&rsaquo;</a></p>
+          </div>
+        </div>
+      </div>
+      <div class="col-start-large-4 col-9">
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3">
+            <h3 class="p-heading--5">Snaps</h3>
+          </div>
+          <div class="col-6">
+            <p>Get snaps for added confinement and atomic updates on all major <a href="https://snapcraft.io/docs/distro-support">Linux distributions</a>.</p>
+            <hr class="p-rule--muted u-no-margin--bottom" />
+            <ul class="p-list--divided u-no-margin--bottom">
+              <li class="p-list__item is-ticked">Valkey-only snap for the smallest possible footprint and attack surface.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="col-start-large-4 col-9">
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3">
+            <h3 class="p-heading--5">Containers</h3>
+          </div>
+          <div class="col-6">
+            <p>
+              We deliver OCI-compliant images for your containerized environment.<br />
+              We provide several supported options:
+            </p>
+            <ul class="p-list--divided u-no-margin--bottom">
+              <li class="p-list__item is-ticked">Valkey-only regular container.</li>
+              <li class="p-list__item is-ticked u-no-padding--bottom">Valkey-only chiselled container for the smallest possible footprint and attack surface.</li>
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

Refreshed the /data/valkey page

## QA

- Go to https://canonical-com-1432.demos.haus/data/valkey
- Compare to [the design](https://www.figma.com/design/uJUwbUAGDog4KCMivrMpnl/24.10-Data-Fabric?node-id=1340-1155&node-type=frame)
- Compare to [the copy doc](https://docs.google.com/document/d/1zu_5LIjlcTwyJzJfX3jveX2HfMO8XxkXg5A7E5ZjE6g/edit?tab=t.0)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-16792

## Screenshots

![valkey](https://github.com/user-attachments/assets/85a2ed94-f710-4c46-a146-6df1e414a3ee)
