### PR TITLE
fix: candidate dashboard step counter

### DIFF
--- a/static/sass/_pattern_application.scss
+++ b/static/sass/_pattern_application.scss
@@ -25,6 +25,8 @@
     }
 
     .p-stepped-list__item {
+      counter-increment: list-item;
+
       p.p-stepped-list__content,
       div.p-stepped-list__content {
         margin-left: 0 !important;
@@ -32,6 +34,18 @@
 
       &:first-child::after {
         content: none;
+      }
+    }
+
+    .p-stepped-list {
+      counter-reset: inner-list;
+
+      .p-stepped-list__item {
+        counter-increment: inner-list;
+      }
+
+      .p-stepped-list__title::before {
+        content: counter(inner-list) ".";
       }
     }
 


### PR DESCRIPTION
## Rationale
A candidate pointed out that the number of steps on their candidate page is always set to zero. Looking into this, the main step numbers in the stepped list component displaying application stages were missing the proper counter increment. Adding this caused the nested list numbers to display as zero as well, so I needed to add a separate counter for them as well.

## Done

- Added counter increment for main stepped list
- Added separate counter for nested lists

## QA

- Check out this feature branch
- Run the site with `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Navigate to test candidate (Bruno Fernandes) dashboard and verify that the main stepped list numbers are no longer showing up as zero

## Issue / Card

[WD-16959](https://warthogs.atlassian.net/browse/WD-16959)

## Screenshots
### Before fix:
![image](https://github.com/user-attachments/assets/fd36ed28-ac97-479d-9c0e-32032db8c058)
---
### After fix:
![image](https://github.com/user-attachments/assets/f3e78147-d690-4774-84a2-93ef4d538768)



[WD-16959]: https://warthogs.atlassian.net/browse/WD-16959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ