### PR TITLE
Rebrand /multipass landing page

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -178,3 +178,15 @@ ai:
       path: /solutions/ai/genai
     - title: Big data analytics
       path: /solutions/ai/big-data-ai
+
+multipass:
+  title: Multipass
+  path: /multipass
+
+  children:
+    - title: Install
+      path: /multipass/install
+    - title: Docs
+      path: /multipass/docs
+    - title: Discourse
+      path: https://discourse.ubuntu.com/c/multipass

--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -14,6 +14,22 @@
 #     - title: Child page
 #       path: /child-page-url
 
+ai:
+  title: AI
+  path: /solutions/ai
+
+  children:
+    - title: Overview
+      path: /solutions/ai
+    - title: AI infrastructure
+      path: /solutions/ai/infrastructure
+    - title: Edge AI
+      path: /solutions/ai/edge
+    - title: GenAI infrastructure
+      path: /solutions/ai/genai
+    - title: Big data analytics
+      path: /solutions/ai/big-data-ai
+
 data:
   title: Data
   path: /data
@@ -38,16 +54,23 @@ data:
     - title: Docs
       path: /data/docs
 
-microcloud:
-  title: MicroCloud
-  path: /microcloud
-  icon: https://assets.ubuntu.com/v1/6eb42b12-microcloud-logomark.svg
+kafka:
+  title: Kafka
+  path: /data/kafka
 
-  children:
-    - title: Resources
-      path: /microcloud/resources
-    - title: Docs
-      path: https://canonical-microcloud.readthedocs-hosted.com/en/latest
+  parent:
+    - title: All data solutions
+    - path: /data
+
+  children: 
+    - title: Overview
+      path: /data/kafka
+    - title: What is Kafka
+      path: /data/kafka/what-is-kafka
+    - title: Managed
+      path: /data/kafka/managed  
+    - title: Support
+      path: /data/kafka/support    
 
 lxd:
   title: LXD
@@ -80,6 +103,29 @@ mongodb:
       path: /data/mongodb/managed
     - title: Support
       path: /data/mongodb/support
+
+microcloud:
+  title: MicroCloud
+  path: /microcloud
+  icon: https://assets.ubuntu.com/v1/6eb42b12-microcloud-logomark.svg
+
+  children:
+    - title: Resources
+      path: /microcloud/resources
+    - title: Docs
+      path: https://canonical-microcloud.readthedocs-hosted.com/en/latest
+
+multipass:
+  title: Multipass
+  path: /multipass
+
+  children:
+    - title: Install
+      path: /multipass/install
+    - title: Docs
+      path: /multipass/docs
+    - title: Discourse
+      path: https://discourse.ubuntu.com/c/multipass
 
 opensearch:
   title: OpenSearch
@@ -133,24 +179,6 @@ spark:
     - title: Support
       path: /data/spark/support 
 
-kafka:
-  title: Kafka
-  path: /data/kafka
-
-  parent:
-    - title: All data solutions
-    - path: /data
-
-  children: 
-    - title: Overview
-      path: /data/kafka
-    - title: What is Kafka
-      path: /data/kafka/what-is-kafka
-    - title: Managed
-      path: /data/kafka/managed  
-    - title: Support
-      path: /data/kafka/support    
-
 telco:
   title: Telco
   path: /solutions/telco
@@ -162,31 +190,3 @@ telco:
       path: /solutions/telco/5g-edge
     - title: Open RAN
       path: /solutions/telco/open-ran
-
-ai:
-  title: AI
-  path: /solutions/ai
-
-  children:
-    - title: Overview
-      path: /solutions/ai
-    - title: AI infrastructure
-      path: /solutions/ai/infrastructure
-    - title: Edge AI
-      path: /solutions/ai/edge
-    - title: GenAI infrastructure
-      path: /solutions/ai/genai
-    - title: Big data analytics
-      path: /solutions/ai/big-data-ai
-
-multipass:
-  title: Multipass
-  path: /multipass
-
-  children:
-    - title: Install
-      path: /multipass/install
-    - title: Docs
-      path: /multipass/docs
-    - title: Discourse
-      path: https://discourse.ubuntu.com/c/multipass

--- a/templates/multipass/index.html
+++ b/templates/multipass/index.html
@@ -1,0 +1,224 @@
+{% extends 'base_index.html' %}
+
+{% block title %}Multipass orchestrates virtual Ubuntu instances{% endblock %}
+
+{% block meta_description %}
+  Multipass is a CLI to launch and manage VMs on Windows, Mac and Linux that simulates a cloud environment with support for cloud-init. Get Ubuntu on-demand with clean integration to your IDE and version control on your native platform.
+{% endblock %}
+
+{% block meta_keywords %}microcloud, scalable cloude, cloud infrastructure{% endblock %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1uI5hsuhe5VUpFSSiQas6FVB2F7RhlbNXcr5Pvr_Lm2c/edit?tab=t.0#
+{% endblock meta_copydoc %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block content %}
+  <section class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col">
+        <div class="p-section--shallow">
+          <h1>
+            Ubuntu VMs on demand
+            <br class="u-hide--small u-hide--medium" />
+            for any workstation
+          </h1>
+        </div>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <p>
+            Get an instant Ubuntu VM with a single command.
+            Multipass can launch and run virtual machines and configure them with <a href="https://cloud-init.io/">cloud-init</a> like a public cloud.
+          </p>
+        </div>
+        <div class="p-cta-block">
+          <a href="/multipass/install" class="p-button--positive">Install now</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Cloud-style VMs at your fingertips</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <div class="p-image-container is-highlighted u-hide--small">
+            {{ image(url="https://assets.ubuntu.com/v1/a2899d5d-cloud-style-VMs.png",
+                        alt="",
+                        width="1800",
+                        height="1015",
+                        hi_def=True,
+                        attrs={"class": "p-image-container__image"},
+                        loading="lazy") | safe
+            }}
+          </div>
+        </div>
+        <p class="p-heading--5">Spin up cloud instances with a single command</p>
+        <p>
+          Launch instances of Ubuntu and <a href="https://ubuntu.com/blog/using-cloud-init-with-multipass">initialise them with cloud-init metadata</a>
+          in the same way you would on AWS, Azure, Google, IBM and Oracle. Simulate your own cloud deployment on your workstation.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>VMs for Windows, macOS and Linux</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <div class="p-image-container is-highlighted u-hide--small">
+            {{ image(url="https://assets.ubuntu.com/v1/d2490035-vms-for.png",
+                        alt="",
+                        width="1800",
+                        height="1015",
+                        hi_def=True,
+                        attrs={"class": "p-image-container__image"},
+                        loading="lazy") | safe
+            }}
+          </div>
+        </div>
+        <p class="p-heading--5">Start Ubuntu VMs with each platform’s native hypervisor</p>
+        <p>
+          Multipass uses Hyper-V on Windows, QEMU on macOS and Linux for minimal overhead and the fastest possible start time.
+          <a href="/multipass/docs/set-up-the-driver">Switching your hypervisor to Virtualbox</a> is a breeze.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+          <h2>
+            Get started with Ubuntu
+            <br class="u-hide--medium u-hide--small" />
+            the fast way
+          </h2>
+        </div>
+        <div class="col">
+          <p>
+            The “Ubuntu Server CLI cheat sheet” is your fast path to learning the Linux command line - from basic file management to deploying Kubernetes and OpenStack.
+          </p>
+          <div class="p-cta-block">
+            <a href="https://assets.ubuntu.com/v1/3bd0daaf-Ubuntu%20Server%20CLI%20cheat%20sheet%202024%20v6.pdf"
+               class="p-button--positive">Download cheat sheet</a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-start-large-4 col-9 col-medium-5 col-start-medium-2">
+        <hr class="p-rule" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Optimised VM performance</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Multipass uses images tuned for cloud usage. Each image has software baked in with all the tools to deploy a cloud.
+            </p>
+            <p>
+              Most notably cloud-init, a tool with utilities to initialize cloud instances. Pass multipass a custom cloud-init definition and turn a generic Ubuntu image into a custom-configured server in seconds.
+            </p>
+            <hr class="p-rule" />
+            <p>
+              <a class="p-button" href="https://cloud-init.io/">Learn more about cloud-init</a>
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Designed for developer convenience</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Share files and folders between your host and your instances.
+              <br />
+              Your ‘primary’ instance gets special treatment with integration to your native filesystem and dedicated hot-key access.
+            </p>
+            <p>Multipass automatically fetches the latest Ubuntu images from Canonical, minimising initial update time.</p>
+          </div>
+        </div>
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">A curated catalogue of images</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Multipass is growing a catalogue of images to initialise pre-installed applications to get started with a single command. Want to integrate your project?
+            </p>
+            <hr class="p-rule" />
+            <p>
+              <a class="p-button" href="https://discourse.ubuntu.com/c/multipass/21">Explore Multipass on Discourse</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Appliances in VMs</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <div class="p-image-container is-highlighted u-hide--small">
+            {{ image(url="https://assets.ubuntu.com/v1/58ce6315-appliances-in-vms.png",
+                        alt="",
+                        width="1800",
+                        height="1015",
+                        hi_def=True,
+                        attrs={"class": "p-image-container__image"},
+                        loading="lazy") | safe
+            }}
+          </div>
+        </div>
+        <p class="p-heading--5">Ubuntu Appliance images to try before you Pi</p>
+        <p>
+          Run a Virtual Ubuntu Appliance on your workstation without affecting your existing system. No need for spare hardware, just follow the steps and you’ll be up and running in minutes.
+        </p>
+        <div class="p-cta-block">
+          <a href="https://ubuntu.com/appliance/vm" class="p-button">Try Ubuntu appliances</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Join our community</h2>
+      </div>
+      <div class="col">
+        <p>
+          Multipass is built by a team of engineers at Canonical and a community of contributors. We appreciate your interest in Multipass,
+          and if you want to join the discussion or contribute, come and say hi. We don’t bite.
+        </p>
+        <div class="p-cta-block">
+          <a href="https://github.com/canonical/multipass" class="p-button">Join on GitHub</a>
+          <a href="https://discourse.ubuntu.com/c/multipass/21" class="p-button">Join our Discourse forum</a>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}

--- a/templates/multipass/index.html
+++ b/templates/multipass/index.html
@@ -122,7 +122,7 @@
     </div>
     <div class="row">
       <div class="col-start-large-4 col-9 col-medium-5 col-start-medium-2">
-        <hr class="p-rule" />
+        <hr class="p-rule--muted" />
         <div class="row p-section--shallow">
           <div class="col-3 col-medium-2">
             <h3 class="p-heading--5">Optimised VM performance</h3>
@@ -134,13 +134,13 @@
             <p>
               Most notably cloud-init, a tool with utilities to initialize cloud instances. Pass multipass a custom cloud-init definition and turn a generic Ubuntu image into a custom-configured server in seconds.
             </p>
-            <hr class="p-rule" />
+            <hr class="p-rule--muted" />
             <p>
               <a class="p-button" href="https://cloud-init.io/">Learn more about cloud-init</a>
             </p>
           </div>
         </div>
-        <hr class="p-rule" />
+        <hr class="p-rule--muted" />
         <div class="row p-section--shallow">
           <div class="col-3 col-medium-2">
             <h3 class="p-heading--5">Designed for developer convenience</h3>
@@ -154,7 +154,7 @@
             <p>Multipass automatically fetches the latest Ubuntu images from Canonical, minimising initial update time.</p>
           </div>
         </div>
-        <hr class="p-rule" />
+        <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-3 col-medium-2">
             <h3 class="p-heading--5">A curated catalogue of images</h3>
@@ -163,10 +163,9 @@
             <p>
               Multipass is growing a catalogue of images to initialise pre-installed applications to get started with a single command. Want to integrate your project?
             </p>
-            <hr class="p-rule" />
-            <p>
+            <div class="p-cta-block">
               <a class="p-button" href="https://discourse.ubuntu.com/c/multipass/21">Explore Multipass on Discourse</a>
-            </p>
+            </div>
           </div>
         </div>
       </div>
@@ -215,7 +214,7 @@
           and if you want to join the discussion or contribute, come and say hi. We don’t bite.
         </p>
         <div class="p-cta-block">
-          <a href="https://github.com/canonical/multipass" class="p-button">Join on GitHub</a>
+          <a href="https://github.com/canonical/multipass" class="p-button--positive">Join on GitHub</a>
           <a href="https://discourse.ubuntu.com/c/multipass/21" class="p-button">Join our Discourse forum</a>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Rebranded multipass landing page
- Migrate from multipass.run to c.com/multipass
- Create secondary navigation for multipass bubble
- Reordered secondary-navigation.yaml by alphabetical order

## QA

- Go to https://canonical-com-1437.demos.haus/multipass
- Check against design file and copy doc
- [Design](https://www.figma.com/design/LGm1MP262JtWfrCxQ3MvqQ/Multipass-Bubble?node-id=1-10105&node-type=instance&m=dev) and [copy docs](https://docs.google.com/document/d/1uI5hsuhe5VUpFSSiQas6FVB2F7RhlbNXcr5Pvr_Lm2c/edit?tab=t.0)
- See that secondary navigation matches https://multipass.run/
- Click on Discourse and see that it links to the discourse forum for multipass
- The other links on the secondary nav are not live yet so will return 404

## Issue / Card

Fixes [WD-16605](https://warthogs.atlassian.net/browse/WD-16605) and [WD-16620](https://warthogs.atlassian.net/browse/WD-16620)

## Screenshots

[if relevant, include a screenshot]


[WD-16605]: https://warthogs.atlassian.net/browse/WD-16605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-16620]: https://warthogs.atlassian.net/browse/WD-16620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ