### PR TITLE
Migrate multipass docs pages

### DIFF
--- a/templates/multipass/docs/document.html
+++ b/templates/multipass/docs/document.html
@@ -1,8 +1,8 @@
 {% with
   document=document,
   nav_items=nav_items,
-  search_action="https://canonical.com/multipass/docs/search",
-  siteSearch="https://canonical.com/multipass/docs",
+  search_action="/multipass/docs/search",
+  siteSearch="/multipass/docs",
   placeholder="Search Multipass docs",
   navigation=navigation
 %}

--- a/templates/multipass/docs/document.html
+++ b/templates/multipass/docs/document.html
@@ -1,0 +1,10 @@
+{% with
+  document=document,
+  nav_items=nav_items,
+  search_action="https://canonical.com/multipass/docs/search",
+  siteSearch="https://canonical.com/multipass/docs",
+  placeholder="Search Multipass docs",
+  navigation=navigation
+%}
+  {% include "docs/shared/_docs.html" %}
+{% endwith %}

--- a/templates/multipass/docs/search-results.html
+++ b/templates/multipass/docs/search-results.html
@@ -1,0 +1,12 @@
+{% with
+  title="Multipass Docs",
+  query=query,
+  results=results,
+  search_action="https://canonical.com/multipass/docs/search",
+  siteSearch="https://canonical.com/multipass/docs/spark",
+  placeholder="Search Multipass Docs",
+  search_path="https://canonical.com/multipass/docs/search",
+  forum_link="https://discourse.ubuntu.com/c/multipass/21"
+%}
+  {% include "docs/shared/_search-results.html" %}
+{% endwith %}

--- a/templates/multipass/docs/search-results.html
+++ b/templates/multipass/docs/search-results.html
@@ -2,10 +2,10 @@
   title="Multipass Docs",
   query=query,
   results=results,
-  search_action="https://canonical.com/multipass/docs/search",
-  siteSearch="https://canonical.com/multipass/docs/spark",
+  search_action="/multipass/docs/search",
+  siteSearch="/multipass/docs/spark",
   placeholder="Search Multipass Docs",
-  search_path="https://canonical.com/multipass/docs/search",
+  search_path="/multipass/docs/search",
   forum_link="https://discourse.ubuntu.com/c/multipass/21"
 %}
   {% include "docs/shared/_search-results.html" %}

--- a/templates/multipass/docs/search-results.html
+++ b/templates/multipass/docs/search-results.html
@@ -3,7 +3,7 @@
   query=query,
   results=results,
   search_action="/multipass/docs/search",
-  siteSearch="/multipass/docs/spark",
+  siteSearch="/multipass/docs",
   placeholder="Search Multipass Docs",
   search_path="/multipass/docs/search",
   forum_link="https://discourse.ubuntu.com/c/multipass/21"

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -872,6 +872,31 @@ def allow_src(tag, name, value):
     return False
 
 
+# Multipass docs
+multipass_docs = Docs(
+    parser=DocParser(
+        api=DiscourseAPI(
+            base_url="https://discourse.ubuntu.com/", session=search_session
+        ),
+        index_topic_id=8294,
+        url_prefix="/multipass/docs",
+    ),
+    document_template="/multipass/docs/document.html",
+    url_prefix="/multipass/docs",
+    blueprint_name="multipass-docs",
+)
+app.add_url_rule(
+    "/multipass/docs/search",
+    "multipass-docs-search",
+    build_search_view(
+        app=app,
+        session=search_session,
+        site="canonical.com/multipass/docs",
+        template_path="/multipass/docs/search-results.html",
+    ),
+)
+multipass_docs.init_app(app)
+
 # Data Platform Spark on K8s docs
 data_spark_k8s_docs = Docs(
     parser=DocParser(


### PR DESCRIPTION
Need to add new doc site to Google Custom Search Engine (https://github.com/canonical/canonicalwebteam.search?tab=readme-ov-file#new-sites)
## Done

- Migrate multipass.run/docs to c.com/multipass/docs
- Including Multipass docs and search

## QA

- Go to https://canonical-com-1440.demos.haus/multipass/docs
- Check that Multipass docs content load as expected
- Use the docs search bar
- See that it returns search results as expected

## Issue / Card

Fixes [WD-16619](https://warthogs.atlassian.net/browse/WD-16619)

## Screenshots

[if relevant, include a screenshot]


[WD-16619]: https://warthogs.atlassian.net/browse/WD-16619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ