### PR TITLE
fix the link to copy doc for /openstack

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -462,7 +462,7 @@
             </p>
           </div>
           <div class="p-cta-block">
-            <a href="" class="p-button--positive">Start with Canonical</a>
+            <a aria-controls="openstack-modal" href="/contact-us" class="p-button--positive">Start with Canonical</a>
           </div>
         </div>
       </div>

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -1,7 +1,7 @@
 {% extends 'base_index.html' %}
 
 {% block meta_copydoc %}
-  https://docs.google.com/document/d/1bfo97XdFdKlzrMcMoRxiTdzt_bPVndx6j55IPsapuAE/edit
+  https://docs.google.com/document/d/1v1G2y465b_VYVUG9TIV-A_X1dU4kg5Zvrwd2latidCk/edit
 {% endblock meta_copydoc %}
 
 {% block title %}Canonical OpenStack{% endblock %}


### PR DESCRIPTION
## Done

- The link that leads to a copy doc was not correct for /openstack page, so fixed that
- Added a link to open a contact form modal

## QA

- open the page
- Make sure you have "Ubuntu Copy Docs" extension installed in your browser
- click on "copy document" link below the screen
- check that the copy document belongs to /openstack webpage
- Click on "Start with Canonical" button at the very bottom of the page and check that it opens a modal with contact form
