### PR TITLE
fix the link on /openstack page

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -443,7 +443,7 @@
              style="padding: 1.5rem">
           <h3>Self-deployed</h3>
           <p>
-            You deploy Canonical OpenStack yourself by relying on public-facing materials, such as <a href="https://microstack.run/docs">product documentation</a> and <a href="/openstack/tutorials">tutorials</a>. Once deployed according to Canonical's best practices, your cloud qualifies for various levels of <a href="">commercial services</a>.
+            You deploy Canonical OpenStack yourself by relying on public-facing materials, such as <a href="https://microstack.run/docs">product documentation</a> and <a href="https://ubuntu.com/openstack/tutorials">tutorials</a>. Once deployed according to Canonical's best practices, your cloud qualifies for various levels of <a href="">commercial services</a>.
           </p>
           <div class="p-cta-block">
             <a href="https://microstack.run/docs/single-node"


### PR DESCRIPTION
## Done

Fixed the link to Tutorials on /openstack page according to [copy doc](https://docs.google.com/document/d/1v1G2y465b_VYVUG9TIV-A_X1dU4kg5Zvrwd2latidCk/edit?disco=AAABWi2_9zI).

## QA

- Open 
- Scroll down to the bottom of the page and click on "tutorials" link
- Check that it opens a tutorial page on ubuntu.com as specified in the copy doc