### PR TITLE
fix(openstack): copy updates (including BE -> AE spelling), logos [WD-17510]

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -26,7 +26,7 @@
       <div class="col">
         <div class="p-section--shallow">
           <p>
-            Get a public cloud-like experience while hosting your applications in your own data centre. Strengthen your business with a flexible infrastructure that meets the highest industry standards.
+            Get a public cloud-like experience while hosting your applications in your own data center. Strengthen your business with a flexible infrastructure that meets the highest industry standards.
           </p>
         </div>
         <div class="p-cta-block">
@@ -50,9 +50,9 @@
           <div class="col-3 col-medium-2">
             <hr class="p-rule--highlight" />
             <p class="p-heading--2 u-sv-1">
-              <strong>100&plus;</strong>
+              <strong>10&plus;</strong>
             </p>
-            <p class="u-no-padding--top">Happy customers</p>
+            <p class="u-no-padding--top">Years on the market</p>
           </div>
           <div class="col-3 col-medium-2">
             <hr class="p-rule--highlight" />
@@ -81,7 +81,7 @@
       </div>
       <div class="col">
         <p>
-          Transform your data centre into a fully functional and professional cloud environment. Take advantage of cloud-based operations, while retaining all the benefits of owning your computing infrastructure.
+          Transform your data center into a fully functional and professional cloud environment. Take advantage of cloud-based operations, while retaining all the benefits of owning your computing infrastructure.
         </p>
         <div class="p-cta-block">
           <a class="p-button--positive"
@@ -106,11 +106,11 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-3 col-medium-3">
-            <h3 class="p-heading--5">You reduce and optimise your infrastructure costs</h3>
+            <h3 class="p-heading--5">Reduce and optimize your infrastructure costs</h3>
           </div>
           <div class="col-6 col-medium-3">
             <p>
-              Deploy it in your existing multi-cloud ecosystem and benefit from a long-term TCO reduction. With Canonical OpenStack there is no hidden licence or subscription cost.
+              Deploy it in your existing multi-cloud ecosystem and benefit from a long-term TCO reduction. With Canonical OpenStack there is no hidden license or subscription cost.
             </p>
           </div>
         </div>
@@ -266,11 +266,11 @@
       <div class="col">
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">General-purpose cloud computing on your premises</li>
-          <li class="p-list__item is-ticked">An alternative to proprietary virtualisation solutions</li>
+          <li class="p-list__item is-ticked">An alternative to proprietary virtualization solutions</li>
           <li class="p-list__item is-ticked">Implementing a sovereign cloud for digital sovereignty</li>
           <li class="p-list__item is-ticked">Building a local/regional public cloud for your customers</li>
           <li class="p-list__item is-ticked">Performance-intensive workloads such as HPC and AI/ML</li>
-          <li class="p-list__item is-ticked">Telco network function virtualisation infrastructure (NFVI)</li>
+          <li class="p-list__item is-ticked">Telco network function virtualization infrastructure (NFVI)</li>
           <li class="p-list__item is-ticked">Edge infrastructure distributed across thousands of sides</li>
         </ul>
       </div>
@@ -331,29 +331,13 @@
         </a>
       </div>
       <div class="col-3 col-medium-3 col-small-2">
-        <a href="/blog/telefonica-brazil-selects-charmed-openstack"
-           aria-label="Read the Telefonica annoucement">
+        <a href="https://ubuntu.com/case-study/sbi-bits"
+           aria-label="Read the SBI BITS case study">
           <div class="p-image-container--16-9 is-highlighted">
-            {{ image(url="https://assets.ubuntu.com/v1/e91919f4-telefonica-logo%20.png",
+            {{ image(url="https://assets.ubuntu.com/v1/2839f807-sbi-bits.png",
                         alt="",
-                        width="132",
-                        height="104",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-image-container__image"}) | safe
-            }}
-          </div>
-          <p>Read the announcement&nbsp;&rsaquo;</p>
-        </a>
-      </div>
-      <div class="col-3 col-medium-3 col-small-2">
-        <a href="https://ubuntu.com/engage/sicredi-openstack-case-study"
-           aria-label="Read the Sicredi case study">
-          <div class="p-image-container--16-9 is-highlighted">
-            {{ image(url="https://assets.ubuntu.com/v1/9a219e83-sicredi-logo-new.png",
-                        alt="Sicredi",
-                        width="104",
-                        height="104",
+                        width="852",
+                        height="480",
                         hi_def=True,
                         loading="lazy",
                         attrs={"class": "p-image-container__image"}) | safe
@@ -368,19 +352,9 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/44ee0936-mercedes-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/3b6e70ee-mercedes-logo.png",
                         alt="Mercedes Benz",
-                        width="604",
-                        height="313",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/2311ff1f-Bloomberg-Logo%20.png",
-                        alt="Bloomberg",
-                        width="314",
+                        width="630",
                         height="312",
                         hi_def=True,
                         loading="lazy",
@@ -388,7 +362,37 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/80b0c768-bnp-paribas-logo%20.png",
+            {{ image(url="https://assets.ubuntu.com/v1/30b9be5d-gamma-logo.png",
+                        alt="Gamma",
+                        width="309",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/b5fac278-Bloomberg-Logo.png",
+                        alt="Bloomberg",
+                        width="310",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/1fe52e76-bsi-logo.png",
+                        alt="Bundesamt für Sicherheit in der Informationstechnik (BSI)",
+                        width="338",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/ff8921fa-bnp-paribas-logo.png",
                         alt="BNP Paribas",
                         width="486",
                         height="312",
@@ -398,9 +402,9 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/ae9b96b6-kings-college-london-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/75778d8c-kcl-logo.png",
                         alt="Kings College London",
-                        width="196",
+                        width="211",
                         height="312",
                         hi_def=True,
                         loading="lazy",
@@ -408,7 +412,7 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/b831f28b-pthl-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/ea10e051-dggn-logo.png",
                         alt="Gendarmerie",
                         width="328",
                         height="312",
@@ -443,7 +447,7 @@
              style="padding: 1.5rem">
           <h3>Self-deployed</h3>
           <p>
-            You deploy Canonical OpenStack yourself by relying on public-facing materials, such as <a href="https://microstack.run/docs">product documentation</a> and <a href="https://ubuntu.com/openstack/tutorials">tutorials</a>. Once deployed according to Canonical's best practices, your cloud qualifies for various levels of <a href="">commercial services</a>.
+            You deploy Canonical OpenStack yourself by relying on public-facing materials, such as <a href="https://microstack.run/docs">product documentation</a> and <a href="https://ubuntu.com/openstack/tutorials">tutorials</a>. Once deployed according to Canonical's best practices, your cloud qualifies for various levels of <a href="#get-in-touch">commercial services</a>.
           </p>
           <div class="p-cta-block">
             <a href="https://microstack.run/docs/single-node"
@@ -462,7 +466,9 @@
             </p>
           </div>
           <div class="p-cta-block">
-            <a aria-controls="openstack-modal" href="/contact-us" class="p-button--positive">Start with Canonical</a>
+            <a aria-controls="openstack-modal"
+               href="/contact-us"
+               class="p-button--positive">Start with Canonical</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Updated BE spelling to AE spelling.
- Applied all the copy updates requested recently (from November 29th onward) in the [copy doc](https://docs.google.com/document/d/1v1G2y465b_VYVUG9TIV-A_X1dU4kg5Zvrwd2latidCk/edit?tab=t.0).
- Added and replaced logos in the "Proven record of success" section ~~- this probably needs design input, as it doesn't look particularly good after the changes~~.

## QA

- Open https://canonical-com-1448.demos.haus/openstack
- Check that all the recent suggestions in the copy doc linked above have been addressed

## Issue / Card

Fixes [WD-17510](https://warthogs.atlassian.net/browse/WD-17510)

[WD-17510]: https://warthogs.atlassian.net/browse/WD-17510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ