### PR TITLE
Add a testimonial to open source security page

### DIFF
--- a/templates/solutions/open-source-security/index.html
+++ b/templates/solutions/open-source-security/index.html
@@ -71,7 +71,7 @@
                     allowfullscreen></iframe>
           </div>
           <p>
-            Open source offers the world's innovation in code. But ensuring you remain compliant and auditable can be a challenge. 
+            Open source offers the world's innovation in code. But ensuring you remain compliant and auditable can be a challenge.
           </p>
           <p>
             We maintain and apply timely security patches on <b>the vastest open source library.</b>
@@ -498,6 +498,32 @@
               </div>
               <div class="col-6">
                 <span>Staff Security Engineer, LaunchDarkly</span>
+              </div>
+            </cite>
+          </blockquote>
+        </div>
+      </div>
+      <div class="row">
+        <hr class="p-rule" />
+        <div class="col-3 col-medium-2">
+        </div>
+        <div class="col-9 col-medium-4">
+          <blockquote class="p-pull-quote u-no-margin u-no-padding">
+            <div class="p-section--shallow">
+              <p class="p-heading--4">
+                <i>“The biggest surprise was that there was no surprise. The systems just work as before, and the developers got an extra two years added to their time frame for migration. It was amazing. Once it became clear that Ubuntu Pro’s per-server cost included hypervisors with unlimited VMs, we did our cost analysis and it ended up being the go-to solution.”</i>
+              </p>
+            </div>
+            <hr class="p-rule--muted u-hide--small" />
+            <cite class="row p-section--shallow">
+              <div class="col-3">
+                <span class="p-heading--5">Company spokesperson</span>
+              </div>
+              <div class="col-3">
+                <span>A large games publisher</span>
+              </div>
+              <div class="col-3">
+                <a href="https://ubuntu.com/case-study/ubuntu-pro-support-for-games-developer">Read the case study&nbsp;&rsaquo;</a>
               </div>
             </cite>
           </blockquote>


### PR DESCRIPTION
## Done

Adds new testimonial based on copy doc.

Fixes WD-17399 

Copy doc: https://docs.google.com/document/d/1mrvhkrVjCCJE39h96CPG_b_ZHWVN0GHzZ_6TdoudeYs/edit?tab=t.0

## QA

- Check the demo: https://canonical-com-1449.demos.haus/solutions/open-source-security
- Scroll down to "What customers say" section and review the last testimonial against the [copy doc](https://docs.google.com/document/d/1mrvhkrVjCCJE39h96CPG_b_ZHWVN0GHzZ_6TdoudeYs/edit?tab=t.0)
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)


## Screenshots

<img width="1287" alt="image" src="https://github.com/user-attachments/assets/5196a346-e570-464e-b079-19b3cb71e8ab">
