### PR TITLE
feat: migrate multipass download functionality

### DIFF
--- a/static/files/latest-multipass-releases.json
+++ b/static/files/latest-multipass-releases.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.13.1",
+  "title": "Multipass 1.13.1 release",
+  "description": "Bug fix release, add Apple M3 support, fix regressions",
+  "download_url": "https://canonical.com/multipass/install",
+  "release_url": "https://github.com/canonical/multipass/releases/tag/v1.13.1",
+  "installer_urls": {
+    "windows": "https://github.com/canonical/multipass/releases/download/v1.13.1/multipass-1.13.1%2Bwin-win64.exe",
+    "macos": "https://github.com/canonical/multipass/releases/download/v1.13.1/multipass-1.13.1%2Bmac-Darwin.pkg"
+  }
+}

--- a/templates/multipass/install.html
+++ b/templates/multipass/install.html
@@ -109,7 +109,7 @@
                 <ol class="p-stepped-list u-no-margin--left">
                   <li class="p-stepped-list__item u-no-padding--bottom">
                     <p class="p-stepped-list__title p-heading--5 u-no-margin--bottom">
-                      <a href="https://multipass.run/download/windows">Download Multipass for Windows</a>
+                      <a href="/multipass/download/windows">Download Multipass for Windows</a>
                     </p>
                     <div class="p-stepped-list__content">
                       <p>You need Windows 10 Pro/Enterprise/Education v 1803 or later, or any Windows 10 with VirtualBox.</p>
@@ -143,7 +143,7 @@
                 <ol class="p-stepped-list u-no-margin--left">
                   <li class="p-stepped-list__item u-no-padding--bottom">
                     <p class="p-stepped-list__title p-heading--5 u-no-margin--bottom">
-                      <a href="https://multipass.run/download/macos">Download Multipass for MacOS</a>
+                      <a href="/multipass/download/macos">Download Multipass for MacOS</a>
                     </p>
                     <div class="p-stepped-list__content">
                       <p>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1265,7 +1265,7 @@ def osredirect(osname):
 
 @app.after_request
 def no_cache(response):
-    if flask.request.path == "/static/files/latest-release.json":
+    if flask.request.path == "/static/files/latest-multipass-release.json":
         response.cache_control.max_age = None
         response.cache_control.no_store = True
         response.cache_control.public = False

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1251,3 +1251,23 @@ def set_form_rules():
 # on /data/opensearch and /data/postresql
 # see: https://github.com/canonical/canonical.com/issues/1399
 # set_form_rules()
+
+
+@app.route("/multipass/download/<regex('windows|macos'):osname>")
+def osredirect(osname):
+    SITE_ROOT = os.path.realpath(os.path.dirname(__file__))
+    json_path = os.path.join(
+        SITE_ROOT, "../static/files/latest-multipass-releases.json"
+    )
+    release = json.load(open(json_path))
+    return flask.redirect(release["installer_urls"][osname], code=302)
+
+
+@app.after_request
+def no_cache(response):
+    if flask.request.path == "/static/files/latest-release.json":
+        response.cache_control.max_age = None
+        response.cache_control.no_store = True
+        response.cache_control.public = False
+
+    return response


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
