### PR TITLE
[WD-17199] job apply recaptcha

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,10 @@
 PORT=8002
 FLASK_DEBUG=true
 DEVEL=true
+
+# Disables POST/PATCH requests to greenhouse:
+GREENHOUSE_DEBUG=true
+
 SECRET_KEY=local_development_fake_key
 
 # https://canonical.greenhouse.io/configure/dev_center/credentials
@@ -9,3 +13,7 @@ APPLICATION_CRYPTO_SECRET_KEY=super_secret
 
 SERVICE_ACCOUNT_EMAIL=test_email@email.com
 SERVICE_ACCOUNT_PRIVATE_KEY=test_private_key
+
+
+# Use this flag to wait for cached pages to expire (does not affect frontend):
+RECAPTCHA_ENABLED="false"

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -69,6 +69,23 @@ env:
       key: scheduler_account_private_key
       name: greenhouse-credentials
 
+  - name: RECAPTCHA_ENABLED
+    value: "false"
+
+  - name: RECAPTCHA_SITE_KEY
+    value: "6LcOo40qAAAAAKN6mBrlbr-npUv1zyWSxJknU959"
+
+  - name: RECAPTCHA_PROJECT_ID
+    value: "site-canonical-c-1732626873862"
+
+  - name: RECAPTCHA_API_KEY
+    secretKeyRef:
+      key: api-key
+      name: canonical-com-gcloud
+
+  - name: RECAPTCHA_SCORE_THRESHOLD
+    value: "0.5"
+
 extraHosts:
   - domain: blog.canonical.com
   - domain: design.canonical.com
@@ -154,6 +171,9 @@ staging:
 
         - name: FLASK_DEBUG
           value: True
+        
+        - name: GREENHOUSE_DEBUG
+          value: "true"
 
         - name: SERVICE_ACCOUNT_EMAIL
           secretKeyRef:
@@ -181,3 +201,6 @@ demo:
 
     - name: FLASK_DEBUG
       value: True
+
+    - name: GREENHOUSE_DEBUG
+      value: "true"

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.5.1
 pytz==2024.1
 djlint==1.34.1
+responses==0.25.3

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -42,7 +42,7 @@
               f.parentNode.insertBefore(j, f);
             })(window, document, 'script', 'dataLayer', 'GTM-M5BPGQ6');
           </script>
-
+          
           <title>
 
             {% block title %}Canonical | Trusted open source for enterprises{% endblock %}
@@ -75,6 +75,7 @@
 
           {% set current_path = url_for(request.endpoint, **request.view_args) %}
           {% if "/careers" in current_path %}
+            <script src="https://www.google.com/recaptcha/enterprise.js?render={{ recaptcha_site_key }}"></script>
             <meta name="twitter:image"
                   content="https://assets.ubuntu.com/v1/c17ef7b4-careers-meta-image-resized.png" />
             <meta property="og:image"

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -79,7 +79,7 @@
   <div class="col-6">
     <hr class="p-rule"/>
     <h3 class="p-heading--5">Apply for this role</h3>
-    <form action="{{ request.path }}" method="POST" enctype="multipart/form-data" class="js-roles-list--form" onsubmit="dataLayer.push({
+    <form id="job-apply-form" action="/careers/{{ job.id }}" method="POST" enctype="multipart/form-data" class="js-roles-list--form" onsubmit="dataLayer.push({
           'event': 'GAEvent',
           'eventCategory': 'Form',
           'eventAction': 'job application: {{ job.id }}',
@@ -120,11 +120,24 @@
           {% endfor %}
         {% endif %}
         <hr style="margin: 1rem 0;" />
-        <input type="submit" class="p-button--positive u-no-margin--bottom js-submit-button" name="submit" value="Submit application"/>
+        <input type="submit" class="p-button--positive u-no-margin--bottom js-submit-button" name="submit_button" value="Submit application"/>
+        <input type="hidden" name="recaptcha_token" id="recaptcha_token">
       </fieldset>
     </form>
   </div>
 </div>
+
+<script>
+  const formEl = document.getElementById("job-apply-form");
+  formEl.addEventListener('submit', (event) => {
+    event.preventDefault();
+    grecaptcha.enterprise.ready(async () => {
+      const token = await grecaptcha.enterprise.execute("{{ recaptcha_site_key }}", {action: "JOB_APPLY"});
+      document.getElementById("recaptcha_token").value = token;
+      formEl.submit();
+    });
+  });
+</script>
 
 <script defer>
     document.querySelectorAll('a[href*="legal"]').forEach(function (a) {

--- a/tests/test_recaptcha.py
+++ b/tests/test_recaptcha.py
@@ -1,0 +1,374 @@
+import unittest
+import requests
+import responses
+from webapp.recaptcha import verify_recaptcha
+
+
+class TestRecaptcha(unittest.TestCase):
+    @responses.activate
+    def test_verify_recaptcha_enabled_pass(self):
+        url = (
+            "https://recaptchaenterprise.googleapis.com/v1/projects/"
+            "project-id-001/assessments?key=api-key-001"
+        )
+        responses.post(
+            url,
+            json={
+                "tokenProperties": {
+                    "valid": True,
+                    "action": "TEST_ACTION",
+                },
+                "riskAnalysis": {
+                    "score": 0.9,
+                },
+            },
+        )
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": True,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, "asdf", "TEST_ACTION", recaptcha_config
+        )
+        self.assertTrue(recaptcha_passed)
+
+    @responses.activate
+    def test_verify_recaptcha_enabled_score(self):
+        url = (
+            "https://recaptchaenterprise.googleapis.com/v1/projects/"
+            "project-id-001/assessments?key=api-key-001"
+        )
+        responses.post(
+            url,
+            json={
+                "tokenProperties": {
+                    "valid": True,
+                    "action": "TEST_ACTION",
+                },
+                "riskAnalysis": {
+                    "score": 0.8,
+                },
+            },
+        )
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": True,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, "asdf", "TEST_ACTION", recaptcha_config
+        )
+        self.assertFalse(recaptcha_passed)
+
+    @responses.activate
+    def test_verify_recaptcha_enabled_action(self):
+        url = (
+            "https://recaptchaenterprise.googleapis.com/v1/projects/"
+            "project-id-001/assessments?key=api-key-001"
+        )
+        responses.post(
+            url,
+            json={
+                "tokenProperties": {
+                    "valid": True,
+                    "action": "TEST_ACTION_BAD",
+                },
+                "riskAnalysis": {
+                    "score": 0.9,
+                },
+            },
+        )
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": True,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, "asdf", "TEST_ACTION", recaptcha_config
+        )
+        self.assertFalse(recaptcha_passed)
+
+    @responses.activate
+    def test_verify_recaptcha_enabled_invalid(self):
+        url = (
+            "https://recaptchaenterprise.googleapis.com/v1/projects/"
+            "project-id-001/assessments?key=api-key-001"
+        )
+        responses.post(
+            url,
+            json={
+                "tokenProperties": {
+                    "valid": False,
+                    "action": "TEST_ACTION",
+                },
+                "riskAnalysis": {
+                    "score": 0.9,
+                },
+            },
+        )
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": True,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, "asdf", "TEST_ACTION", recaptcha_config
+        )
+        self.assertFalse(recaptcha_passed)
+
+    @responses.activate
+    def test_verify_recaptcha_enabled_big_token(self):
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": True,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, "asdf" * 100, "TEST_ACTION", recaptcha_config
+        )
+        self.assertFalse(recaptcha_passed)
+
+    @responses.activate
+    def test_verify_recaptcha_enabled_no_token(self):
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": True,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, None, "TEST_ACTION", recaptcha_config
+        )
+        self.assertFalse(recaptcha_passed)
+
+    @responses.activate
+    def test_verify_recaptcha_enabled_exception(self):
+        url = (
+            "https://recaptchaenterprise.googleapis.com/v1/projects/"
+            "project-id-001/assessments?key=api-key-001"
+        )
+        responses.post(
+            url,
+            body=requests.exceptions.Timeout,
+        )
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": True,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, "asdf", "TEST_ACTION", recaptcha_config
+        )
+        self.assertTrue(recaptcha_passed)
+
+    @responses.activate
+    def test_verify_recaptcha_disabled_pass(self):
+        url = (
+            "https://recaptchaenterprise.googleapis.com/v1/projects/"
+            "project-id-001/assessments?key=api-key-001"
+        )
+        responses.post(
+            url,
+            json={
+                "tokenProperties": {
+                    "valid": True,
+                    "action": "TEST_ACTION",
+                },
+                "riskAnalysis": {
+                    "score": 0.9,
+                },
+            },
+        )
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": False,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, "asdf", "TEST_ACTION", recaptcha_config
+        )
+        self.assertTrue(recaptcha_passed)
+
+    @responses.activate
+    def test_verify_recaptcha_disabled_score(self):
+        url = (
+            "https://recaptchaenterprise.googleapis.com/v1/projects/"
+            "project-id-001/assessments?key=api-key-001"
+        )
+        responses.post(
+            url,
+            json={
+                "tokenProperties": {
+                    "valid": True,
+                    "action": "TEST_ACTION",
+                },
+                "riskAnalysis": {
+                    "score": 0.8,
+                },
+            },
+        )
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": False,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, "asdf", "TEST_ACTION", recaptcha_config
+        )
+        self.assertTrue(recaptcha_passed)
+
+    @responses.activate
+    def test_verify_recaptcha_disabled_action(self):
+        url = (
+            "https://recaptchaenterprise.googleapis.com/v1/projects/"
+            "project-id-001/assessments?key=api-key-001"
+        )
+        responses.post(
+            url,
+            json={
+                "tokenProperties": {
+                    "valid": True,
+                    "action": "TEST_ACTION_BAD",
+                },
+                "riskAnalysis": {
+                    "score": 0.9,
+                },
+            },
+        )
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": False,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, "asdf", "TEST_ACTION", recaptcha_config
+        )
+        self.assertTrue(recaptcha_passed)
+
+    @responses.activate
+    def test_verify_recaptcha_disabled_invalid(self):
+        url = (
+            "https://recaptchaenterprise.googleapis.com/v1/projects/"
+            "project-id-001/assessments?key=api-key-001"
+        )
+        responses.post(
+            url,
+            json={
+                "tokenProperties": {
+                    "valid": False,
+                    "action": "TEST_ACTION",
+                },
+                "riskAnalysis": {
+                    "score": 0.9,
+                },
+            },
+        )
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": False,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, "asdf", "TEST_ACTION", recaptcha_config
+        )
+        self.assertTrue(recaptcha_passed)
+
+    @responses.activate
+    def test_verify_recaptcha_disabled_big_token(self):
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": False,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, "asdf" * 100, "TEST_ACTION", recaptcha_config
+        )
+        self.assertTrue(recaptcha_passed)
+
+    @responses.activate
+    def test_verify_recaptcha_disabled_no_token(self):
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": False,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, None, "TEST_ACTION", recaptcha_config
+        )
+        self.assertTrue(recaptcha_passed)
+
+    @responses.activate
+    def test_verify_recaptcha_disabled_exception(self):
+        url = (
+            "https://recaptchaenterprise.googleapis.com/v1/projects/"
+            "project-id-001/assessments?key=api-key-001"
+        )
+        responses.post(
+            url,
+            body=requests.exceptions.Timeout,
+        )
+        session = requests.Session()
+        recaptcha_config = {
+            "enabled": False,
+            "site_key": "site-key-001",
+            "project_id": "project-id-001",
+            "api_key": "api-key-001",
+            "score_threshold": 0.9,
+            "max_token_size": 100,
+        }
+        recaptcha_passed = verify_recaptcha(
+            session, "asdf", "TEST_ACTION", recaptcha_config
+        )
+        self.assertTrue(recaptcha_passed)

--- a/webapp/recaptcha.py
+++ b/webapp/recaptcha.py
@@ -1,0 +1,86 @@
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+RECAPTCHA_CONFIG = {
+    "enabled": os.getenv("RECAPTCHA_ENABLED", "false").lower() != "false",
+    "site_key": os.getenv("RECAPTCHA_SITE_KEY"),
+    "project_id": os.getenv("RECAPTCHA_PROJECT_ID"),
+    "api_key": os.getenv("RECAPTCHA_API_KEY"),
+    "score_threshold": float(os.getenv("RECAPTCHA_SCORE_THRESHOLD", 0.5)),
+    "max_token_size": 100000,
+}
+
+logger.info(
+    "RECAPTCHA "
+    f"enabled={RECAPTCHA_CONFIG['enabled']} "
+    f"score_threshold={RECAPTCHA_CONFIG['score_threshold']}"
+)
+
+
+def verify_recaptcha(
+    session, recaptcha_token, expected_action, recaptcha_config=None
+):
+    # interpreting assesment:
+    # https://cloud.google.com/recaptcha/docs/interpret-assessment-website
+    try:
+        if recaptcha_config is None:
+            recaptcha_config = RECAPTCHA_CONFIG
+
+        enabled = recaptcha_config["enabled"]
+        site_key = recaptcha_config["site_key"]
+        project_id = recaptcha_config["project_id"]
+        api_key = recaptcha_config["api_key"]
+        score_threshold = recaptcha_config["score_threshold"]
+        max_token_size = recaptcha_config["max_token_size"]
+
+        if recaptcha_token is None:
+            logger.debug("recaptcha_token is None")
+            return not enabled
+
+        if len(recaptcha_token) > max_token_size:
+            logger.debug("len(recaptcha_token) > RECAPTCHA_MAX_TOKEN_SIZE")
+            # a large token can be forged to trigger a timeout
+            return not enabled
+
+        verify_url = (
+            "https://recaptchaenterprise.googleapis.com/v1/projects/"
+            f"{project_id}/assessments?key={api_key}"
+        )
+        response = session.post(
+            verify_url,
+            json={
+                "event": {
+                    "token": recaptcha_token,
+                    "expectedAction": expected_action,
+                    "siteKey": site_key,
+                }
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        assessment = response.json()
+
+        token_valid = assessment["tokenProperties"]["valid"]
+        if not token_valid:
+            logger.debug("not token_valid")
+            return not enabled
+
+        token_action = assessment["tokenProperties"]["action"]
+        if token_action != expected_action:
+            logger.debug(f"{token_action=} {expected_action=}")
+            return not enabled
+
+        token_score = assessment["riskAnalysis"]["score"]
+        if token_score < score_threshold:
+            logger.debug(f"{score_threshold=} {token_score=}")
+            return not enabled
+
+        return True
+
+    except Exception:
+        logger.exception("verify_recaptcha")
+        # do not restrict in case of error in the implementation
+        return True


### PR DESCRIPTION
## Done

Added recaptcha verification on job application submit. Recaptcha is activated on /careers pages.

A flying recaptcha logo is visible in the bottom right:
![image](https://github.com/user-attachments/assets/e2929921-68cd-4dce-aee6-e7de1dc785a0)

Error template is re-used to display failed recaptcha verification:
![image](https://github.com/user-attachments/assets/064d7f8b-2e07-49eb-b04a-0372e8d289f4)



## QA

- Check out this feature branch
- Check if GREENHOUSE_DEBUG=true (There should be a message in the logs to indicate that)
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Navigate to /careers and try to apply for a job.
- To simulate failed recaptcha set RECAPTCHA_SCORE_THRESHOLD="1.1"
- To simulate cached page (without recaptcha) - revert `templates/base_index.html` and `templates/careers/job-detail.html`. Submit should succeed when RECAPTCHA_ENABLED="false"


