### PR TITLE
Update to the latest multipass release

### DIFF
--- a/static/files/latest-multipass-releases.json
+++ b/static/files/latest-multipass-releases.json
@@ -1,11 +1,11 @@
 {
-  "version": "1.13.1",
-  "title": "Multipass 1.13.1 release",
-  "description": "Bug fix release, add Apple M3 support, fix regressions",
-  "download_url": "https://canonical.com/multipass/install",
-  "release_url": "https://github.com/canonical/multipass/releases/tag/v1.13.1",
+  "version": "1.14.1",
+  "title": "Multipass 1.14.1 release",
+  "description": "New GUI, bridge addition, force-stop, snapshots extended to VirtualBox",
+  "download_url": "https://multipass.run/#install",
+  "release_url": "https://github.com/canonical/multipass/releases/tag/v1.14.1",
   "installer_urls": {
-    "windows": "https://github.com/canonical/multipass/releases/download/v1.13.1/multipass-1.13.1%2Bwin-win64.exe",
-    "macos": "https://github.com/canonical/multipass/releases/download/v1.13.1/multipass-1.13.1%2Bmac-Darwin.pkg"
+    "windows": "https://github.com/canonical/multipass/releases/download/v1.14.1/multipass-1.14.1+win-win64.exe",
+    "macos": "https://github.com/canonical/multipass/releases/download/v1.14.1/multipass-1.14.1+mac-Darwin.pkg"
   }
 }


### PR DESCRIPTION
## Done

Updated the latest-multipass-releases with the latest version of the file from https://multipass.run/static/latest-release.json.

## QA

- Go to /static/files/latest-multipass-releases.json
- Check it matches the latest version of the JSON.
