### PR TITLE
Update latest Multipass release

### DIFF
--- a/static/files/latest-multipass-releases.json
+++ b/static/files/latest-multipass-releases.json
@@ -1,11 +1,11 @@
 {
-  "version": "1.14.1",
-  "title": "Multipass 1.14.1 release",
-  "description": "New GUI, bridge addition, force-stop, snapshots extended to VirtualBox",
-  "download_url": "https://multipass.run/#install",
-  "release_url": "https://github.com/canonical/multipass/releases/tag/v1.14.1",
+  "version": "1.15.0",
+  "title": "Multipass 1.15.0 release",
+  "description": "Clone, bridging on QEMU/Linux, Updated GUI, MSI installer.",
+  "download_url": "https://canonical.com/multipass/install",
+  "release_url": "https://github.com/canonical/multipass/releases/tag/v1.15.0",
   "installer_urls": {
-    "windows": "https://github.com/canonical/multipass/releases/download/v1.14.1/multipass-1.14.1+win-win64.exe",
-    "macos": "https://github.com/canonical/multipass/releases/download/v1.14.1/multipass-1.14.1+mac-Darwin.pkg"
+    "windows": "https://github.com/canonical/multipass/releases/download/v1.15.0/multipass-1.15.0+win-win64.msi",
+    "macos": "https://github.com/canonical/multipass/releases/download/v1.15.0/multipass-1.15.0+mac-Darwin.pkg"
   }
 }


### PR DESCRIPTION
## Done

1. Update Multipass release to 1.15.0
2. Revert download link to canonical.com
