### PR TITLE
[WD-17291] replace heavy images in navigation with lighter versions

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -534,13 +534,13 @@ solutions:
     links:
       - description: Sicredi transforms its infrastructure strategy with open source.
         url: https://ubuntu.com/engage/sicredi-openstack-case-study
-        image_url: https://assets.ubuntu.com/v1/5f9121cc-Sicredi-@3x.png
+        image_url: https://assets.ubuntu.com/v1/60d05687-Sicredi.png
       - description: LaunchDarkly becomes the first FedRAMP-authorised feature management platform thanks to Ubuntu Pro.
         url: https://ubuntu.com/engage/LaunchDarkly-FedRAMP-case-study
-        image_url: https://assets.ubuntu.com/v1/4032e441-LaunchDarkly-@3x.png
+        image_url: https://assets.ubuntu.com/v1/fa174e02-LaunchDarkly.png
       - description: Canonical deploys infrastructure solutions and managed IT services for ESA's critical space mission operations.
         url: https://ubuntu.com/engage/European-space-agency-case-study
-        image_url: https://assets.ubuntu.com/v1/c9b7ff7f-ESA-@3x.png
+        image_url: https://assets.ubuntu.com/v1/cf544550-ESA.png
 
 partners:
   cta: Explore our partners
@@ -668,10 +668,10 @@ company:
     links:
       - description: Canonical offers 12 year LTS for any open source Docker image.
         url: /blog/canonical-offers-12-year-lts-for-any-open-source-docker-image
-        image_url: https://assets.ubuntu.com/v1/e128b9e5-Shield-@3x.png
+        image_url: https://assets.ubuntu.com/v1/8f5a6839-Shield.png
       - description: BT Group and Canonical deliver 5G to UK stadiums.
         url: /blog/bt-group-and-canonical-deliver-5g-to-uk-stadiums
-        image_url: https://assets.ubuntu.com/v1/a3e8bbe4-BT-5G-@3x.png
+        image_url: https://assets.ubuntu.com/v1/fe25c9e1-BT-5G.png
       - description: Canonical releases Ubuntu 24.04 LTS Noble Numbat.
         url: https://ubuntu.com/blog/canonical-releases-ubuntu-24-04-noble-numbat
         image_url: https://assets.ubuntu.com/v1/697f9812-Noble-Numbat-V2-@3x.png


### PR DESCRIPTION
## Done

Replaced heavy images in navigation to their lighter version to reduce the load time of the home page. 

## QA

- Open the Network tab in dev console and select All or Img to see images
- Open the home page
- Sort by Size and check how big the loaded images are
- The biggest one slightly exceeds 500 kB, while as before it was over 900 kB.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-17291