### PR TITLE
[WD-17699] Copy update on homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -59,19 +59,6 @@ meta_copydoc %}
                     width: 100%" />
       </div>
     </section>
-    <section class="p-section">
-      <div class="u-fixed-width">
-        <div class="p-notification--information">
-          <div class="p-notification__content">
-            <h2 class="p-notification__title">
-              <a href="/blog/canonical-offers-12-year-lts-for-any-open-source-docker-image">Canonical announces 12 year LTS
-                for open source Docker images</a>
-            </h2>
-            <p class="p-notification__message">Get a custom built container and let us handle the maintenance.</p>
-          </div>
-        </div>
-      </div>
-    </section>
     <section class="p-section" id="products">
       <div class="u-fixed-width">
         <hr class="p-rule" />
@@ -141,7 +128,7 @@ meta_copydoc %}
               </p>
               <hr class="p-rule--muted u-hide--medium" />
               <p class="p-heading--2">
-                <a href="https://ubuntu.com/openstack">OpenStack&nbsp;&rsaquo;</a>
+                <a href="https://canonical.com/openstack">OpenStack&nbsp;&rsaquo;</a>
               </p>
               <hr class="p-rule--muted u-hide--medium" />
               <p class="p-heading--2">

--- a/templates/index.html
+++ b/templates/index.html
@@ -128,7 +128,7 @@ meta_copydoc %}
               </p>
               <hr class="p-rule--muted u-hide--medium" />
               <p class="p-heading--2">
-                <a href="https://canonical.com/openstack">OpenStack&nbsp;&rsaquo;</a>
+                <a href="/openstack">OpenStack&nbsp;&rsaquo;</a>
               </p>
               <hr class="p-rule--muted u-hide--medium" />
               <p class="p-heading--2">


### PR DESCRIPTION
## Done

- Remove `12 year LTS for open source docker images` notification banner
- Update **OpenStack** link to `canonical.com`

## QA

- Go to https://canonical-com-1463.demos.haus
- Compare page against [copy doc](https://docs.google.com/document/d/1GNa1FaTkARdrVwYgHXf5H-6sqOLjkJENDistDDcsi4o/edit?tab=t.0)

## Issue / Card

Fixes [WD-17699](https://warthogs.atlassian.net/browse/WD-17699)

[WD-17699]: https://warthogs.atlassian.net/browse/WD-17699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ