### PR TITLE
feat: Install and implement discourse-rad-parser in _docs.html template

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@canonical/cookie-policy": "^3.6.4",
     "@canonical/global-nav": "3.6.4",
     "@canonical/latest-news": "1.5.0",
+    "@canonical/discourse-rad-parser": "1.0.2",
     "@testing-library/cypress": "9.0.0",
     "autoprefixer": "10.4.17",
     "concurrently": "7.6.0",

--- a/scripts/build-modules.sh
+++ b/scripts/build-modules.sh
@@ -15,3 +15,6 @@ cp node_modules/@canonical/global-nav/dist/global-nav.js static/js/modules/globa
 
 mkdir -p static/js/modules/intl-tel-input
 cp node_modules/intl-tel-input/build/js/utils.js static/js/modules/intl-tel-input
+
+mkdir -p static/js/modules/discourse-rad-parser
+cp node_modules/@canonical/discourse-rad-parser/build/js/discourse-rad-parser.js static/js/modules/discourse-rad-parser

--- a/templates/docs/shared/_docs.html
+++ b/templates/docs/shared/_docs.html
@@ -227,4 +227,8 @@
     }
   </script>
   <script src="{{ versioned_static('js/side-navigation.js') }}"></script>
+  <script src="{{ versioned_static('js/modules/discourse-rad-parser/discourse-rad-parser.js')}}"></script>
+  <script>
+    drpNs.DiscourseRADParser();
+  </script>
 {% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -321,6 +321,11 @@
   resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.6.4.tgz#895c3770f621b73d88b0d5843c43a32d99e4a462"
   integrity sha512-kfwamTpAaBhtH5TzlMb8wE814a8lIbONUuSYnS7VPiHDfcdmw4NoBPNpldmNY1j3CAT5vMKOx5kulRTWpEXpag==
 
+"@canonical/discourse-rad-parser@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@canonical/discourse-rad-parser/-/discourse-rad-parser-1.0.2.tgz#f4e32478dd569facbf22f066115a38e6ef8900ef"
+  integrity sha512-MCeJKcyerLfOVJ90PS2VnVvk2x8ek4Brah1V5UcbnspTBaV4Cju/lWqwAQcCC/jhSz74OcgW0n9wsp15Yy1Acg==
+
 "@canonical/global-nav@3.6.4":
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-3.6.4.tgz#347401d20a01c51a9d0024f7867ddebd3b407dcf"


### PR DESCRIPTION
## Done

- Adds [discourse-rad-parser](https://www.npmjs.com/package/@canonical/discourse-rad-parser) as a dependency
- Include it in the `_docs.html` template

## QA

- Go to https://canonical-com-1466.demos.haus/multipass/docs/tutorial
- See there is a dropdown to select operating system
- Check that selecting a different OS changes the content

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-17714

## Screenshots

![image](https://github.com/user-attachments/assets/e6dd6398-aebe-48d2-8e81-5f6c294f2dbd)

