### PR TITLE
WIP: refactor(/data/postregesql/what-is-postgresql): Update image tags to use 'e_sharpen'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 canonicalwebteam.flask-base==2.0.0
 canonicalwebteam.blog==6.4.2
 canonicalwebteam.http==1.0.4
-canonicalwebteam.image-template==1.3.1
-canonicalwebteam.templatefinder==1.0.0
+canonicalwebteam.image-template @ git+https://github.com/canonical/canonicalwebteam.image-template/@wd-14585
 canonicalwebteam.discourse==5.6.1
 canonicalwebteam.search==2.1.1
 bleach==5.0.1

--- a/templates/data/postgresql/what-is-postgresql.html
+++ b/templates/data/postgresql/what-is-postgresql.html
@@ -120,8 +120,7 @@
                             alt="",
                             width="568",
                             height="852",
-                            hi_def=True,
-                            e_sharpen=True,
+                            hi_def=False,
                             attrs={"class": "p-image-container__image"},
                             loading="lazy") | safe
               }}
@@ -143,8 +142,7 @@
                         alt="",
                         width="568",
                         height="852",
-                        hi_def=True,
-                        e_sharpen=True,
+                        hi_def=False,
                         attrs={"class": "p-image-container__image"},
                         loading="lazy") | safe
             }}
@@ -165,8 +163,7 @@
                         alt="",
                         width="568",
                         height="852",
-                        hi_def=True,
-                        e_sharpen=True,
+                        hi_def=False,
                         attrs={"class": "p-image-container__image"},
                         loading="lazy") | safe
             }}
@@ -187,8 +184,7 @@
                         alt="",
                         width="568",
                         height="852",
-                        hi_def=True,
-                        e_sharpen=True,
+                        hi_def=False,
                         attrs={"class": "p-image-container__image"},
                         loading="lazy") | safe
             }}

--- a/templates/data/postgresql/what-is-postgresql.html
+++ b/templates/data/postgresql/what-is-postgresql.html
@@ -120,7 +120,7 @@
                             alt="",
                             width="568",
                             height="852",
-                            hi_def=False,
+                            hi_def=True,
                             attrs={"class": "p-image-container__image"},
                             loading="lazy") | safe
               }}
@@ -142,7 +142,7 @@
                         alt="",
                         width="568",
                         height="852",
-                        hi_def=False,
+                        hi_def=True,
                         attrs={"class": "p-image-container__image"},
                         loading="lazy") | safe
             }}
@@ -163,7 +163,7 @@
                         alt="",
                         width="568",
                         height="852",
-                        hi_def=False,
+                        hi_def=True,
                         attrs={"class": "p-image-container__image"},
                         loading="lazy") | safe
             }}
@@ -184,7 +184,7 @@
                         alt="",
                         width="568",
                         height="852",
-                        hi_def=False,
+                        hi_def=True,
                         attrs={"class": "p-image-container__image"},
                         loading="lazy") | safe
             }}

--- a/templates/data/postgresql/what-is-postgresql.html
+++ b/templates/data/postgresql/what-is-postgresql.html
@@ -115,9 +115,17 @@
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
           <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
-            <img class="p-image-container__image"
-                 src="https://assets.ubuntu.com/v1/5a4a1fb3-analytics.png"
-                 alt="" />
+            <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
+              {{ image(url="https://assets.ubuntu.com/v1/5a4a1fb3-analytics.png",
+                            alt="",
+                            width="568",
+                            height="852",
+                            hi_def=True,
+                            e_sharpen=True,
+                            attrs={"class": "p-image-container__image"},
+                            loading="lazy") | safe
+              }}
+            </div>
           </div>
         </div>
         <div class="p-equal-height-row__item">
@@ -131,9 +139,15 @@
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
           <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
-            <img class="p-image-container__image"
-                 src="https://assets.ubuntu.com/v1/f43e63db-banking.png"
-                 alt="" />
+            {{ image(url="https://assets.ubuntu.com/v1/f43e63db-banking.png",
+                        alt="",
+                        width="568",
+                        height="852",
+                        hi_def=True,
+                        e_sharpen=True,
+                        attrs={"class": "p-image-container__image"},
+                        loading="lazy") | safe
+            }}
           </div>
         </div>
         <div class="p-equal-height-row__item">
@@ -147,9 +161,15 @@
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
           <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
-            <img class="p-image-container__image"
-                 src="https://assets.ubuntu.com/v1/87f1a153-geospatial-data.png"
-                 alt="" />
+            {{ image(url="https://assets.ubuntu.com/v1/87f1a153-geospatial-data.png",
+                        alt="",
+                        width="568",
+                        height="852",
+                        hi_def=True,
+                        e_sharpen=True,
+                        attrs={"class": "p-image-container__image"},
+                        loading="lazy") | safe
+            }}
           </div>
         </div>
         <div class="p-equal-height-row__item">
@@ -163,9 +183,15 @@
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
           <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
-            <img class="p-image-container__image"
-                 src="https://assets.ubuntu.com/v1/05d1de66-search.png"
-                 alt="" />
+            {{ image(url="https://assets.ubuntu.com/v1/05d1de66-search.png",
+                        alt="",
+                        width="568",
+                        height="852",
+                        hi_def=True,
+                        e_sharpen=True,
+                        attrs={"class": "p-image-container__image"},
+                        loading="lazy") | safe
+            }}
           </div>
         </div>
         <div class="p-equal-height-row__item">


### PR DESCRIPTION
## Done

This is an attempt to resolve the issue detailed [here](https://warthogs.atlassian.net/browse/WD-14585)

- Replace images using the `<img>` tag with the `image_template()` function and pass 'e_sharpen=True' to maintain quality

## QA

- Open [the demo](https://canonical-com-1467.demos.haus/data/postgresql/what-is-postgresql)
- Scroll down to the section 'How do companies use PostgreSQL?'
- See that the images are sharp and have a quality that matches the images on [the live site](https://canonical.com/data/postgresql/what-is-postgresql) (these are using `<img>`, not `image_template()`)

## Issue / Card

Fixes #
