### PR TITLE
WD-17850 Copy update on the Docs link at /lxd page

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -84,7 +84,7 @@ lxd:
     - title: Manage
       path: /lxd/manage
     - title: Docs
-      path: https://documentation.ubuntu.com/lxd/en/latest/?_ga=2.91941594.1329653141.1700868845-1063360542.1700868845
+      path: https://canonical-lxd.readthedocs-hosted.com/en/
     - title: Forum
       path: https://discourse.ubuntu.com/c/lxd/126?_ga=2.69179345.1978494405.1700868870-354120313.1700868870
 


### PR DESCRIPTION
## Done

- Changed Docs link in /lxd page to direct to stable version instead of latest version

## QA

- Go to /lxd or https://canonical-com-1468.demos.haus/lxd
- Compare page against [copy doc](https://docs.google.com/document/d/1LJ6ajHYAmKdxSNDaD5kbriDod1t7RcmIwVJtevAeKFQ/edit?tab=t.0). Consists of "Docs" link change

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-17850
