### PR TITLE
chore(/openstack/architecture): Replace image used for 'Openstack under the hood'

### DIFF
--- a/templates/openstack/architecture.html
+++ b/templates/openstack/architecture.html
@@ -127,10 +127,10 @@
       <div class="col">
         <div class="p-section--shallow">
           <div class="p-image-container--cinematic is-highlighted u-hide--medium u-hide--small">
-            {{ image(url="https://assets.ubuntu.com/v1/ccb38017-openstack-under-the-hood.png",
+            {{ image(url="https://assets.ubuntu.com/v1/a7083ce1-Canonical-OpenStack-architecture-diagram.svg",
                         alt="",
-                        width="1200",
-                        height="501",
+                        width="897",
+                        height="280",
                         hi_def=True,
                         attrs={"class": "p-image-container__image"},
                         loading="lazy") | safe
@@ -164,24 +164,36 @@
       </div>
       <div class="col">
         <ul class="p-list--divided">
-          <li class="p-list__item is-ticked"><strong>Services</strong> expose APIs and handle user requests</li>
-          <li class="p-list__item is-ticked"><strong>Processes</strong> create a service and implement atomic cloud functions</li>
-          <li class="p-list__item is-ticked"><strong>Dashboard</strong> provides a web-based user interface to services</li>
-          <li class="p-list__item is-ticked"><strong>Client</strong> provides a command-line user interface to services</li>
-          <li class="p-list__item is-ticked"><strong>Databases</strong> store various types of records created by services</li>
-          <li class="p-list__item is-ticked"><strong>Queues</strong> facilitate communication between processes within a service</li>
+          <li class="p-list__item is-ticked">
+            <strong>Services</strong> expose APIs and handle user requests
+          </li>
+          <li class="p-list__item is-ticked">
+            <strong>Processes</strong> create a service and implement atomic cloud functions
+          </li>
+          <li class="p-list__item is-ticked">
+            <strong>Dashboard</strong> provides a web-based user interface to services
+          </li>
+          <li class="p-list__item is-ticked">
+            <strong>Client</strong> provides a command-line user interface to services
+          </li>
+          <li class="p-list__item is-ticked">
+            <strong>Databases</strong> store various types of records created by services
+          </li>
+          <li class="p-list__item is-ticked">
+            <strong>Queues</strong> facilitate communication between processes within a service
+          </li>
         </ul>
       </div>
     </div>
     <div class="u-fixed-width">
       <div class="p-image-container u-hide--small">
         {{ image(url="https://assets.ubuntu.com/v1/aa31dc00-1.2.2.png",
-                  alt="",
-                  width="1846",
-                  height="1053",
-                  hi_def=True,
-                  attrs={"class": "p-image-container__image"},
-                  loading="lazy") | safe
+                alt="",
+                width="1846",
+                height="1053",
+                hi_def=True,
+                attrs={"class": "p-image-container__image"},
+                loading="lazy") | safe
         }}
       </div>
     </div>
@@ -268,7 +280,8 @@
           </p>
         </div>
         <hr class="p-rule--muted" />
-        <a class="p-button--positive" href="https://microstack.run/docs/single-node">Start today</a>
+        <a class="p-button--positive"
+           href="https://microstack.run/docs/single-node">Start today</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

- Replace image used for 'Openstack under the hood' to match the [copydoc](https://docs.google.com/document/d/1i8rjvhw3N2gDA5NXuKEPcftXY95zePjsURmQu4dSgGo/edit?tab=t.0#heading=h.8bq4er39iavh)

## QA

- Go to https://canonical-com-1469.demos.haus/openstack/architecture
- Check the image used in the section 'Openstack under the hood' matches that in the [copydoc](https://docs.google.com/document/d/1i8rjvhw3N2gDA5NXuKEPcftXY95zePjsURmQu4dSgGo/edit?tab=t.0#heading=h.8bq4er39iavh)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-17511