### PR TITLE
feat: Add childrenPaths to form template for shared forms

### DIFF
--- a/static/files/forms-data.json
+++ b/static/files/forms-data.json
@@ -2,6 +2,7 @@
   "forms": {
     "/data/postgresql": {
       "templatePath": "/data/postgresql/index.html",
+      "childrenPaths": ["/data/postgresql/managed", "/data/postgresql/support", "/data/postgresql/what-is-postgresql"],
       "isModal": true,
       "modalId": "data-relational-dbs-modal",
       "formData": {

--- a/templates/data/postgresql/managed.html
+++ b/templates/data/postgresql/managed.html
@@ -453,9 +453,6 @@ Learn about Canonical’s managed services for PostgreSQL, the world's most accl
 
 <script defer src="{{ versioned_static('js/modals.js') }}"></script>
 
-{% with %}
-  {% set returnURL = "https://canonical.com/data/postgresql/managed#success" %}
-  {% include "data/_form-data-relational-dbs.html" %}
-{% endwith %}
+{% include "/shared/forms/form-template.html" %}
 
 {% endblock %}

--- a/templates/data/postgresql/support.html
+++ b/templates/data/postgresql/support.html
@@ -690,9 +690,6 @@ Get support for PostgreSQL from Canonical, the experts in open-source. We provid
 
 <script defer src="{{ versioned_static('js/modals.js') }}"></script>
 
-{% with %}
-  {% set returnURL = "https://canonical.com/data/postgresql/support#success" %}
-  {% include "data/_form-data-relational-dbs.html" %}
-{% endwith %}
+{% include "/shared/forms/form-template.html" %}
 
 {% endblock %}

--- a/templates/data/postgresql/what-is-postgresql.html
+++ b/templates/data/postgresql/what-is-postgresql.html
@@ -635,8 +635,6 @@
 
   <script defer src="{{ versioned_static('js/modals.js') }}"></script>
 
-  {% with %}
-    {% set returnURL = "https://canonical.com/data/postgresql/what-is-postgresql#success" %}
-    {% include "data/_form-data-relational-dbs.html" %}
-  {% endwith %}
+  {% include "/shared/forms/form-template.html" %}
+
 {% endblock %}

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -139,7 +139,7 @@
                        aria-hidden="true"
                        aria-label="hidden field"
                        name="returnURL"
-                       value="{{ formData.returnUrl }}" />
+                       value={% if path %}"{{ path }}/#contact-form-success"{% else %}{{ formData.returnUrl }}{% endif %} />
                 <input type="hidden"
                        aria-hidden="true"
                        aria-label="hidden field"

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1254,17 +1254,27 @@ app.add_url_rule("/user-country-tz.json", view_func=get_user_country_by_tz)
 
 
 # Form template
-def render_form(form):
+def render_form(form, template_path, child=False):
     @wraps(render_form)
     def wrapper_func():
         try:
-            return flask.render_template(
-                form["templatePath"],
-                fieldsets=form["fieldsets"],
-                formData=form["formData"],
-                isModal=form.get("isModal"),
-                modalId=form.get("modalId"),
-            )
+            if child:
+                return flask.render_template(
+                    template_path + ".html",
+                    fieldsets=form["fieldsets"],
+                    formData=form["formData"],
+                    isModal=form.get("isModal"),
+                    modalId=form.get("modalId"),
+                    path=template_path,
+                )
+            else:
+                return flask.render_template(
+                    template_path + ".html",
+                    fieldsets=form["fieldsets"],
+                    formData=form["formData"],
+                    isModal=form.get("isModal"),
+                    modalId=form.get("modalId"),
+                )
         except jinja2.exceptions.TemplateNotFound:
             flask.abort(
                 404, description=f"Template {form['templatePath']} not found."
@@ -1279,8 +1289,21 @@ def set_form_rules():
         data = json.load(forms_json)
         for path, form in data["forms"].items():
             try:
+                if "childrenPaths" in form:
+                    for child_path in form["childrenPaths"]:
+                        app.add_url_rule(
+                            child_path,
+                            view_func=render_form(
+                                form, child_path, child=True
+                            ),
+                            endpoint=child_path,
+                        )
                 app.add_url_rule(
-                    path, view_func=render_form(form), endpoint=path
+                    path,
+                    view_func=render_form(
+                        form, form["templatePath"].split(".")[0]
+                    ),
+                    endpoint=path,
                 )
             except AssertionError:
                 app.logger.error(


### PR DESCRIPTION
## Done

- This is work that is brought over from https://github.com/canonical/ubuntu.com/pull/14575
- Add `childrenPaths` param to `forms-data.json`
- Allow correct form redirect on submission if `childrenPaths` is present

## QA

- Go to https://canonical-com-1472.demos.haus/data/postgresql/managed
- Submit form and see that it works as expected
- Repeat for https://canonical-com-1472.demos.haus/data/postgresql/support and https://canonical-com-1472.demos.haus/data/postgresql/what-is-postgresql

## Issue / Card

Fixes [WD-17882](https://warthogs.atlassian.net/browse/WD-17882)

## Screenshots

[if relevant, include a screenshot]


[WD-17882]: https://warthogs.atlassian.net/browse/WD-17882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ