### PR TITLE
[WD-17951] use different footer for docs pages

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -177,7 +177,9 @@
             {% endblock content %}
           </div>
 
-          {% include 'partial/_footer.html' %}
+          {% block footer %}
+            {% include 'partial/_footer.html' %}
+          {% endblock footer %}
 
           <script defer src="{{ versioned_static('js/dist/navigation.js') }}"></script>
           <script src="{{ versioned_static('js/dist/forms.js') }}"></script>

--- a/templates/docs/shared/_docs.html
+++ b/templates/docs/shared/_docs.html
@@ -232,3 +232,7 @@
     drpNs.DiscourseRADParser();
   </script>
 {% endblock %}
+
+{% block footer %}
+  {% include "docs/shared/_footer.html" %}
+{% endblock footer %}

--- a/templates/docs/shared/_footer.html
+++ b/templates/docs/shared/_footer.html
@@ -1,0 +1,40 @@
+<div class="p-strip is-dark l-docs__footer">
+  <div class="row">
+    <footer class="l-docs__subgrid">
+      <div class="l-docs__sidebar">
+        <p style="padding-left: 1.5rem">
+          Copyright &copy; {{ now("%Y") }}
+          <br />
+          CC-BY-SA 3.0, Canonical Ltd.
+        </p>
+      </div>
+      <div class="l-docs__main">
+        <nav aria-label="Footer">
+          <div class="has-cookie">
+            <ul class="p-inline-list--middot">
+              <li class="p-inline-list__item">
+                <a aria-label="External link to the Ubuntu legal information page"
+                   href="https://www.ubuntu.com/legal">Legal information</a>
+              </li>
+              <li class="p-inline-list__item">
+                <a class="js-revoke-cookie-manager" href="">Manage your tracker settings</a>
+              </li>
+              <li class="p-inline-list__item">
+                <a href="https://github.com/canonical/multipass/issues/new/choose">Report a bug on Multipass itself</a>
+              </li>
+              <li class="p-inline-list__item">
+                <a aria-label="External link to report a bug on this site"
+                   href="https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md">
+                  Report a bug on this site
+                </a>
+              </li>
+            </ul>
+            <span class="u-off-screen">
+              <a href="#">Go to the top of the page</a>
+            </span>
+          </div>
+        </nav>
+      </div>
+    </footer>
+  </div>
+</div>

--- a/templates/docs/shared/_footer.html
+++ b/templates/docs/shared/_footer.html
@@ -1,40 +1,36 @@
-<div class="p-strip is-dark l-docs__footer">
-  <div class="row">
-    <footer class="l-docs__subgrid">
-      <div class="l-docs__sidebar">
-        <p style="padding-left: 1.5rem">
-          Copyright &copy; {{ now("%Y") }}
-          <br />
-          CC-BY-SA 3.0, Canonical Ltd.
-        </p>
-      </div>
-      <div class="l-docs__main">
-        <nav aria-label="Footer">
-          <div class="has-cookie">
-            <ul class="p-inline-list--middot">
-              <li class="p-inline-list__item">
-                <a aria-label="External link to the Ubuntu legal information page"
-                   href="https://www.ubuntu.com/legal">Legal information</a>
-              </li>
-              <li class="p-inline-list__item">
-                <a class="js-revoke-cookie-manager" href="">Manage your tracker settings</a>
-              </li>
-              <li class="p-inline-list__item">
-                <a href="https://github.com/canonical/multipass/issues/new/choose">Report a bug on Multipass itself</a>
-              </li>
-              <li class="p-inline-list__item">
-                <a aria-label="External link to report a bug on this site"
-                   href="https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md">
-                  Report a bug on this site
-                </a>
-              </li>
-            </ul>
-            <span class="u-off-screen">
-              <a href="#">Go to the top of the page</a>
-            </span>
-          </div>
-        </nav>
-      </div>
-    </footer>
-  </div>
+<div class="p-strip is-dark l-footer--sticky">
+  <footer class="row">
+    <div class="col-3">
+      <p>
+        Copyright &copy; {{ now("%Y") }}
+        <br />
+        CC-BY-SA 3.0, Canonical Ltd.
+      </p>
+    </div>
+    <div class="col-9">
+      <nav aria-label="Footer">
+        <ul class="p-inline-list--middot">
+          <li class="p-inline-list__item">
+            <a aria-label="External link to the Ubuntu legal information page"
+               href="https://www.ubuntu.com/legal">Legal information</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a class="js-revoke-cookie-manager" href="#">Manage your tracker settings</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="https://github.com/canonical/multipass/issues/new/choose">Report a bug on Multipass itself</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a aria-label="External link to report a bug on this site"
+               href="https://github.com/canonical/canonical.com/issues/new?template=ISSUE_TEMPLATE.md">
+              Report a bug on this site
+            </a>
+          </li>
+        </ul>
+        <span class="u-off-screen">
+          <a href="#">Go to the top of the page</a>
+        </span>
+      </nav>
+    </div>
+  </footer>
 </div>


### PR DESCRIPTION
## Done

Moved a footer that was implemented for multipass.run's Docs pages some time ago into canonical.com and used it for all Docs pages on canonical.com.

## QA

- Open demo instance
- Open Docs pages, for example at /multipass/docs or /mircostack/docs and check that they use their own footer
- Open other pages (not Docs) and check that they still use an existing footer (similar to production)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-17951

## Screenshots

Normal footer:
![Screenshot From 2024-12-20 11-18-52](https://github.com/user-attachments/assets/59bd282f-ba2b-4ede-a236-e5546350fa6a)

Docs footer:
![Screenshot From 2024-12-20 11-19-16](https://github.com/user-attachments/assets/6953e556-0a66-4473-8d96-5167e2bb2732)

