### PR TITLE
[WD-17929] Copy update on data/kafka/what-is-kafka

### DIFF
--- a/templates/data/kafka/what-is-kafka.html
+++ b/templates/data/kafka/what-is-kafka.html
@@ -458,12 +458,12 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-3 col-medium-3">
-            <h3 class="p-heading--5 u-no-margin--bottom">Kafka Rock container image</h3>
+            <h3 class="p-heading--5 u-no-margin--bottom">Kafka OCI-compliant container image</h3>
             <p class="u-text--muted u-no-padding--top">Included in Ubuntu Pro + Support</p>
           </div>
           <div class="col-6 col-medium-3">
             <p>
-              Also included in Ubuntu Pro + Support, you get support for Canonical's container image for Kafka in Docker Hub and Amazon ECR public &ndash; the slimmest, fastest, niftiest Kafka container image on the market, based on Ubuntu LTS. So solid and secure, we call it a Rock.
+              Also included in Ubuntu Pro + Support, you get support for Canonical's OCI-compliant container image for Kafka in Docker Hub and Amazon ECR public &ndash; the slimmest, fastest, niftiest Kafka container image on the market, based on Ubuntu LTS.
             </p>
             <hr class="p-rule--muted u-no-margin--bottom" />
             <div class="p-section--shallow">
@@ -477,7 +477,7 @@
             </div>
             <div class="p-section--shallow">
               <div class="p-cta-block">
-                <a href="https://hub.docker.com/r/ubuntu/kafka">Try out the Rock&nbsp;&rsaquo;</a>
+                <a href="https://hub.docker.com/r/ubuntu/kafka">Try the OCI image&nbsp;&rsaquo;</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Done

- Replaced references to `rock` with `OCI-compliant`

## QA

- Go to `data/kafka/what-is-kafka`
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Compare the page against the [copy doc](https://docs.google.com/document/d/1IThZcfKZcv-ArqU_0n8A181AGkQPUn_Iq1O4sqk5GTs/edit?tab=t.0)

## Issue / Card

Fixes [WD-17929](https://warthogs.atlassian.net/browse/WD-17929)


[WD-17929]: https://warthogs.atlassian.net/browse/WD-17929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ