### PR TITLE
Update what is mongodb page

### DIFF
--- a/templates/data/mongodb/what-is-mongodb.html
+++ b/templates/data/mongodb/what-is-mongodb.html
@@ -374,7 +374,7 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-3 col-medium-3">
-            <h3 class="p-heading--5">MongoDB<sup>&#174;</sup> Rock container image</h3>
+            <h3 class="p-heading--5">MongoDB<sup>&#174;</sup> OCI-compliant container image</h3>
           </div>
           <div class="col-6 col-medium-3">
             <p class="p-heading--5">
@@ -382,7 +382,7 @@
             </p>
             <hr class="p-rule--muted" />
             <p>
-              Also included in Ubuntu Pro + Support, you get support for Canonical's container image for MongoDB, based on Ubuntu LTS. So solid and secure, we call it a Rock.
+              Also included in Ubuntu Pro + Support, you get support for Canonical's container image for MongoDB, based on Ubuntu LTS.
             </p>
             <hr class="p-rule--muted" />
             <div class="p-section--shallow">


### PR DESCRIPTION
## Done
- Minor copy update to the "What is MongoDB?" page per [copydoc](https://docs.google.com/document/d/1hET-ylqXq96mOfj4hovqilX5Nl0J8FLw1gkRMJkIjp8/edit?tab=t.0).

## QA
- Go to https://canonical-com-1482.demos.haus/data/mongodb/what-is-mongodb
- Verify "MongoDB® Rock container image" is replaced with "MongoDB® OCI-compliant container image"
- Verify "So solid and secure, we call it a Rock." is deleted 

## Issue / Card

Fixes [#17925](https://warthogs.atlassian.net/browse/WD-17925)
