### PR TITLE
fix: removed repeat linebreak

### DIFF
--- a/templates/blog/featured-articles.html
+++ b/templates/blog/featured-articles.html
@@ -1,9 +1,6 @@
 {% block featured_articles %}
 
 <div class="p-section" id="articles-list">
-  <div class="u-fixed-width">
-    <hr class="p-rule">
-  </div>
   {% for article in featured_articles %}
     {% include 'blog/blog-card.html' %}
   {% endfor %}


### PR DESCRIPTION
## Done

- Removed duplicate line-break on canonical.com/blog

## QA

- Open the demo at https://canonical-com-1502.demos.haus/blog and check that there are no double line-breaks
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes [WD-12149](https://warthogs.atlassian.net/browse/WD-18149)

## Screenshots

![image](https://github.com/user-attachments/assets/6619ad5b-9323-4331-ae91-33a1e6f312c5)
![image](https://github.com/user-attachments/assets/d16a5a99-324a-49a0-a4ca-7561d9e60099)


[WD-12149]: https://warthogs.atlassian.net/browse/WD-12149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ