### PR TITLE
fix(candidate): Remove the bespoke styling: detailed stepped list

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -220,7 +220,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   }
 
   &:nth-child(2) {
-    background-position: -1104px 49px;List of steps
+    background-position: -1104px 49px; //List of steps
 
     @media screen and (max-width: $breakpoint-small) {
       background-position: -1055px 49px;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -220,7 +220,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   }
 
   &:nth-child(2) {
-    background-position: -1104px 49px; //List of steps
+    background-position: -1104px 49px; // List of steps
 
     @media screen and (max-width: $breakpoint-small) {
       background-position: -1055px 49px;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -207,15 +207,6 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   }
 }
 
-.p-stepped-list--detailed {
-  .p-stepped-list__title {
-    &::before {
-      text-align: left;
-    }
-    padding-left: 2rem;
-  }
-}
-
 .p-card--pillar {
   background: url("https://assets.ubuntu.com/v1/8131976a-sustainability-suru.png");
   background-position: -45px 45px;
@@ -229,7 +220,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   }
 
   &:nth-child(2) {
-    background-position: -1104px 49px;
+    background-position: -1104px 49px;List of steps
 
     @media screen and (max-width: $breakpoint-small) {
       background-position: -1055px 49px;


### PR DESCRIPTION
## Done

Remove the bespoke styling applied to the detailed stepped list which was causing issues on the candidate page. This change was introduced for the /openstack/architecture page but this should be addressed differently and upstream.

## QA

- Go to a candidate page in prod and see the numbers are broken
- Go to the demo and see the same candidate page looks correct

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/1451

