### PR TITLE
fix(/blog/article): Disable djlint for json data processing

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -25,7 +25,7 @@
 {%- endblock canonical_url -%}
 
 {% block extra_metatags %}
-
+  {# djlint: off #}
   <script type="application/ld+json">
     {
       "@context": "http://schema.org",
@@ -38,22 +38,17 @@
         "name": "{{ article.author.name }}"
       },
       "datePublished": "{{ article.date_gmt }}",
-      {
-        %
-        if article.image and article.image.source_url %
-      }
+      {% if article.image and article.image.source_url %}
       "image": "{{ article.image.source_url }}",
-      {
-        %
-        endif %
-      }
+      {% endif %}
       "url": "{{ request.url }}",
       "publisher": {
         "@type": "Organization",
         "name": "Ubuntu"
       }
     }
-  </script>
+</script>
+  {# djlint: on #}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Done

- DJlint was changing the format of some logic to handle a piece of JSON we use in metadata. This PR disable Djlint for these lines and reverts the formatting changes

## QA

- Check the code format is the same as before it was formatted, [see git blame](https://github.com/canonical/canonical.com/blame/077fbdf3579c5e226ee3c6a814ced7440be99294/templates/blog/article.html#L24)

## Issue / Card

Fixes https://github.com/canonical/canonical.com/pull/1497#discussion_r1916657572
