### PR TITLE
feat: Build case study index page

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -49,6 +49,16 @@ env:
       key: token
       name: directory-api
 
+  - name: DISCOURSE_API_KEY
+    secretKeyRef:
+      key: ubuntu-api-key
+      name: discourse-api
+
+  - name: DISCOURSE_API_USERNAME
+    secretKeyRef:
+      key: ubuntu-api-username
+      name: discourse-api
+
   - name: CHARMHUB_DISCOURSE_API_KEY
     secretKeyRef:
       key: charmhub-api-key

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.blog==6.4.2
 canonicalwebteam.http==1.0.4
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.discourse==5.6.1
+canonicalwebteam.discourse==5.7.3
 canonicalwebteam.search==2.1.1
 bleach==5.0.1
 markdown==3.5.2

--- a/static/sass/_pattern_blog-card.scss
+++ b/static/sass/_pattern_blog-card.scss
@@ -1,0 +1,136 @@
+@mixin canonical-p-blog-card {
+  .blog-p-card__category {
+    background: url("#{$assets-path}ed42aefa-icon-resource-hub-icon-document.png")
+      left center no-repeat;
+    color: $color-mid-dark;
+    font-size: $sp-medium;
+    line-height: 1.5;
+    padding: 0 0 0 $sp-large;
+    text-transform: uppercase;
+
+    > a:link,
+    > a:visited {
+      color: $color-mid-dark;
+      text-decoration: none;
+    }
+
+    > a:hover,
+    > a:active {
+      color: $color-brand;
+      text-decoration: underline;
+    }
+  }
+
+  %post-card-header {
+    border-radius: 2px;
+    padding: $sp-medium $sp-medium $sp-small;
+  }
+
+  .blog-p-card--post {
+    @extend %p-card--highlighted;
+
+    display: flex !important;
+    flex-direction: column;
+    padding: 0;
+
+    .p-strip--featured & {
+      background-color: rgba(255, 255, 255, 0.9);
+      position: relative;
+      z-index: 1;
+    }
+
+    > .blog-p-card__content {
+      border-top: 1px dotted $color-mid-light;
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      margin: 0 $sp-small;
+      padding: $sp-medium $sp-small $sp-small;
+
+      > a,
+      h3,
+      p {
+        display: block;
+        margin: $sp-small 0;
+      }
+    }
+
+    .blog-p-card__footer {
+      border-top: 1px dotted $color-mid-light;
+      font-size: 0.875rem;
+      margin: auto $sp-small 0;
+      max-width: inherit;
+      padding: $sp-medium $sp-small;
+    }
+  }
+
+  // a fallback to catch any instances where a post.group exists,
+  // but we haven't yet defined a BEM variant to match
+  [class*="blog-p-card__header"] {
+    @extend %post-card-header;
+
+    border-top: 3px solid $color-mid-dark;
+  }
+
+  .blog-p-card__header {
+    border-radius: 2px;
+    border-top: 3px solid $color-mid-dark;
+    padding: $sp-medium $sp-medium $sp-small;
+
+    &.highlight--canonical-announcements {
+      border-color: #ff8936;
+    }
+
+    &.highlight--cloud-and-server {
+      border-color: #a87ca0;
+    }
+
+    &.highlight--desktop {
+      border-color: #faba54;
+    }
+
+    &.highlight--internet-of-things {
+      border-color: #8db255;
+    }
+
+    &.highlight--phone-and-tablet {
+      border-color: $color-mid-light;
+    }
+
+    &.highlight--webinar {
+      border-color: #48929b;
+    }
+
+    &.highlight--tutorials {
+      border-color: #47919e;
+    }
+  }
+
+  .blog-p-card--muted {
+    @extend .p-card;
+
+    background-color: $color-light;
+    box-shadow: 0 1px 2px 0 transparentize($color-dark, 0.8);
+    padding: 0;
+
+    > .blog-p-card__header {
+      border-bottom: 0;
+      border-top: 3px solid $color-light;
+      margin-bottom: 0;
+    }
+
+    > .blog-p-card__content {
+      border-top: 1px dotted $color-mid-light;
+      margin: 0 $sp-small $sp-small;
+      padding: $sp-medium $sp-small $sp-small;
+    }
+  }
+
+  .blog-p-card__date {
+    @extend .p-media-object__meta-list;
+
+    display: flex;
+    margin-top: auto;
+    padding-top: $sp-medium;
+  }
+}

--- a/static/sass/_pattern_blog-card.scss
+++ b/static/sass/_pattern_blog-card.scss
@@ -34,7 +34,7 @@
     padding: 0;
 
     .p-strip--featured & {
-      background-color: rgba(255, 255, 255, 0.9);
+      background-color: rgb(255 255 255 / 90%);
       position: relative;
       z-index: 1;
     }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -3,7 +3,8 @@
   @include canonical-p-strip-suru-topped;
   @include canonical-p-strip-suru-top;
   @include canonical-p-strip-suru-background;
-  @include ubuntu-p-strip-whitesuru;
+  @include canonical-p-strip-whitesuru;
+  @include canonical-p-strip-suru-blog-header;
 
   .p-strip--light {
     &.is-x-shallow {
@@ -230,7 +231,7 @@
   }
 }
 
-@mixin ubuntu-p-strip-whitesuru {
+@mixin canonical-p-strip-whitesuru {
   .p-strip--whitesuru {
     @extend %vf-strip;
 
@@ -249,5 +250,58 @@
       background-repeat: no-repeat;
       background-size: 80vw;
     }
+  }
+}
+
+@mixin canonical-p-strip-suru-blog-header {
+  .p-strip--suru-blog-header {
+    @extend %vf-strip;
+
+    background-blend-mode: multiply, multiply, normal;
+    background-image: linear-gradient(
+        150deg,
+        rgba(228, 228, 228, 0.54) 0%,
+        rgba(228, 228, 228, 0.54) 54.9%,
+        rgba(228, 228, 228, 0) 55%,
+        rgba(228, 228, 228, 0) 100%
+      ),
+      linear-gradient(
+        to bottom left,
+        rgba(216, 216, 216, 0.54) 0%,
+        rgba(216, 216, 216, 0.54) 49.9%,
+        rgba(216, 216, 216, 0) 50%,
+        rgba(216, 216, 216, 0) 100%
+      ),
+      linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%);
+    @supports not (background-blend-mode: multiply) {
+      background-image: linear-gradient(
+          150deg,
+          rgba(228, 228, 228, 0.14) 0%,
+          rgba(228, 228, 228, 0.14) 54.9%,
+          rgba(228, 228, 228, 0) 55%,
+          rgba(228, 228, 228, 0) 100%
+        ),
+        linear-gradient(
+          to bottom left,
+          rgba(216, 216, 216, 0.14) 0%,
+          rgba(216, 216, 216, 0.14) 49.9%,
+          rgba(216, 216, 216, 0) 50%,
+          rgba(216, 216, 216, 0) 100%
+        ),
+        linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%);
+    }
+
+    background-position:
+      bottom left,
+      bottom 0 right,
+      0% 0%;
+    background-repeat: no-repeat;
+    background-size:
+      100% 100%,
+      60% 100%,
+      auto;
+    color: $color-x-light;
+    overflow: hidden;
+    position: relative;
   }
 }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -260,33 +260,33 @@
     background-blend-mode: multiply, multiply, normal;
     background-image: linear-gradient(
         150deg,
-        rgba(228, 228, 228, 0.54) 0%,
-        rgba(228, 228, 228, 0.54) 54.9%,
-        rgba(228, 228, 228, 0) 55%,
-        rgba(228, 228, 228, 0) 100%
+        rgb(228 228 228 / 54%) 0%,
+        rgb(228 228 228 / 54%) 54.9%,
+        rgb(228 228 228 / 0%) 55%,
+        rgb(228 228 228 / 0%) 100%
       ),
       linear-gradient(
         to bottom left,
-        rgba(216, 216, 216, 0.54) 0%,
-        rgba(216, 216, 216, 0.54) 49.9%,
-        rgba(216, 216, 216, 0) 50%,
-        rgba(216, 216, 216, 0) 100%
+        rgb(216 216 216 / 54%) 0%,
+        rgb(216 216 216 / 54%) 49.9%,
+        rgb(216 216 216 / 0%) 50%,
+        rgb(216 216 216 / 0%) 100%
       ),
       linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%);
     @supports not (background-blend-mode: multiply) {
       background-image: linear-gradient(
           150deg,
-          rgba(228, 228, 228, 0.14) 0%,
-          rgba(228, 228, 228, 0.14) 54.9%,
-          rgba(228, 228, 228, 0) 55%,
-          rgba(228, 228, 228, 0) 100%
+          rgb(228 228 228 / 14%) 0%,
+          rgb(228 228 228 / 14%) 54.9%,
+          rgb(228 228 228 / 0%) 55%,
+          rgb(228 228 228 / 0%) 100%
         ),
         linear-gradient(
           to bottom left,
-          rgba(216, 216, 216, 0.14) 0%,
-          rgba(216, 216, 216, 0.14) 49.9%,
-          rgba(216, 216, 216, 0) 50%,
-          rgba(216, 216, 216, 0) 100%
+          rgb(216 216 216 / 14%) 0%,
+          rgb(216 216 216 / 14%) 49.9%,
+          rgb(216 216 216 / 0%) 50%,
+          rgb(216 216 216 / 0%) 100%
         ),
         linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%);
     }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -14,6 +14,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 
 @import "pattern_animations";
 @import "pattern_application";
+@import "pattern_blog-card";
 @import "pattern_cards";
 @import "pattern_careers-modal";
 @import "pattern_footer";
@@ -27,6 +28,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 @import "pattern_global-nav";
 @import "pattern_tabs";
 @import "pattern_homepage-modal";
+@import "pattern_cards";
 
 @include vanilla;
 @include vf-p-icon-status-waiting;
@@ -36,6 +38,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 @include canonical-u-animations;
 @include canonical-p-stepped-list;
 @include canonical-p-card;
+@include canonical-p-blog-card;
 @include canonical-p-careers-modal;
 @include canonical-p-lists;
 @include canonical-p-feedback;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -28,7 +28,6 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 @import "pattern_global-nav";
 @import "pattern_tabs";
 @import "pattern_homepage-modal";
-@import "pattern_cards";
 
 @include vanilla;
 @include vf-p-icon-status-waiting;

--- a/templates/case-study/index.html
+++ b/templates/case-study/index.html
@@ -16,12 +16,20 @@
 
 <section class="p-strip is-shallow" id="posts-list">
   <div class="row u-equal-height">
-    {% for case_study in case_study_info %}
-      {% with title=case_study.title, title_link=case_study.file_path, description=case_study.meta_description %}
+    {% for case_study in metadata %}
+      {% with title=case_study.topic_name, title_link=case_study.path, description=case_study.subtitle, tags=case_study.tags %}
         {% include "case-study/_case-study-card.html" %}
       {% endwith %}
     {% endfor %}
-</div>
+  </div>  
+</section>
+
+<section class="p-strip is-shallow">
+  {% with %}
+    {% set total_pages = total_pages %}
+    {% set current_page = current_page %}
+    {% include "shared/_pagination.html" %}
+  {% endwith %}
 </section>
 {% endblock %}
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -21,7 +21,12 @@ from canonicalwebteam import image_template
 from canonicalwebteam.blog import BlogAPI, BlogViews, build_blueprint
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.templatefinder import TemplateFinder
-from canonicalwebteam.discourse import DiscourseAPI, Docs, DocParser, EngagePages
+from canonicalwebteam.discourse import (
+    DiscourseAPI,
+    Docs,
+    DocParser,
+    EngagePages,
+)
 from canonicalwebteam.search import build_search_view
 from requests.exceptions import HTTPError
 from slugify import slugify
@@ -1307,7 +1312,7 @@ def build_case_study_index(engage_docs):
         page = flask.request.args.get("page", default=1, type=int)
         preview = flask.request.args.get("preview")
         language = flask.request.args.get("language", default=None, type=str)
-        tag = flask.request.args.get("tag", default=None, type=str)
+        # tag = flask.request.args.get("tag", default=None, type=str)
         limit = 20  # adjust as needed
         offset = (page - 1) * limit
 
@@ -1328,7 +1333,6 @@ def build_case_study_index(engage_docs):
             if path.startswith("/engage"):
                 case_study["path"] = "https://ubuntu.com" + path
 
-
         return flask.render_template(
             "case-study/index.html",
             forum_url=engage_docs.api.base_url,
@@ -1343,6 +1347,7 @@ def build_case_study_index(engage_docs):
         )
 
     return case_study_index
+
 
 # Case study
 DISCOURSE_API_KEY = os.getenv("DISCOURSE_API_KEY")
@@ -1362,4 +1367,6 @@ case_studies = EngagePages(
     exclude_topics=[17229, 18033, 17250],
 )
 
-app.add_url_rule(case_study_path, view_func=build_case_study_index(case_studies))
+app.add_url_rule(
+    case_study_path, view_func=build_case_study_index(case_studies)
+)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1323,6 +1323,12 @@ def build_case_study_index(engage_docs):
         tags_list = engage_docs.get_engage_pages_tags()
         total_pages = math.ceil(current_total / limit)
 
+        for case_study in metadata:
+            path = case_study["path"]
+            if path.startswith("/engage"):
+                case_study["path"] = "https://ubuntu.com" + path
+
+
         return flask.render_template(
             "case-study/index.html",
             forum_url=engage_docs.api.base_url,


### PR DESCRIPTION
## Done

- Build case study index page that includes static and Discourse case study

## QA

- Go to https://canonical-com-1509.demos.haus/case-study
- Check that the case studies are showing as expected
- Click through some of them and notice that some are static & some are Discourse-hosted (the old PDF engage pages)

## Issue / Card

Fixes [WD-17189](https://warthogs.atlassian.net/browse/WD-17189)

## Screenshots

[if relevant, include a screenshot]


[WD-17189]: https://warthogs.atlassian.net/browse/WD-17189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ