### PR TITLE
fix: render close button above all input elements

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -744,6 +744,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 
 // Sticky close button for all modals
 .p-modal-close-button {
+  z-index: 1;
   @media screen and (min-width: $breakpoint-small) {
     float: right;
     position: sticky;


### PR DESCRIPTION
## Done

- Added index to modal close button to render above input elements

## QA

- Open the form at http://0.0.0.0:8002/solutions/ai#get-in-touch
- Scroll through the options and confirm that the modal close button renders above all inputs
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes [WD-18103](https://warthogs.atlassian.net/browse/WD-18103)

## Screenshots
![image](https://github.com/user-attachments/assets/3c8bd4d1-b9d3-42c7-9428-d8e3543ca720)

![image](https://github.com/user-attachments/assets/b8be4bb4-dd2a-47ae-b1ad-846d86fd95bc)



[WD-18103]: https://warthogs.atlassian.net/browse/WD-18103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ