### PR TITLE
fix: push correct origin for button events

### DIFF
--- a/static/js/navigation/ga-tracking.js
+++ b/static/js/navigation/ga-tracking.js
@@ -28,22 +28,32 @@ export default function initGATracking() {
     var t = document.querySelector(target);
     if (t) {
       t.querySelectorAll("a").forEach(function (a) {
-        if (a.className.includes("p-button--positive")) {
-          var category = "canonical.com-content-cta-0";
-        } else if (a.className.includes("p-button")) {
-          var category = "canonical.com-content-cta-1";
-        } else {
-          var category = "canonical.com-content-link";
-        }
         if (!a.href.startsWith("#")) {
           a.addEventListener("click", function () {
-            dataLayer.push({
-              event: "GAEvent",
-              eventCategory: category,
-              eventAction: `from:${origin} to:${a.href}`,
-              eventLabel: a.text,
-              eventValue: undefined,
-            });
+            const pushEvent = () => {
+              // for buttons we get the origin from the current page
+              var path = window.location.href.split("#");
+              var actionOrigin = path[0];
+              var actionTarget = window.location.href;
+              if (a.className.includes("p-button--positive")) {
+                var category = "canonical.com-content-cta-0";
+              } else if (a.className.includes("p-button")) {
+                var category = "canonical.com-content-cta-1";
+              } else {
+                var category = "canonical.com-content-link";
+                actionOrigin = origin;
+                actionTarget = a.href;
+              }
+              dataLayer.push({
+                event: "GAEvent",
+                eventCategory: category,
+                eventAction: `from:${actionOrigin} to:${actionTarget}`,
+                eventLabel: a.text,
+                eventValue: undefined,
+              });
+            };
+            // Wait briefly for form to open and location to change
+            setTimeout(pushEvent, 500);
           });
         }
       });


### PR DESCRIPTION
## Done

- Updated values for `origin` and `to` in GAEvents to submit correct paths when the event comes from a button.

## QA

- Open the demo at https://canonical-com-1512.demos.haus/data/opensearch. Open dev tools and type `dataLayer`. Take note of the entries.
- Click `Contact Us` and in dev tools type `dataLayer` again. You should see an entry similar to:
```
eventAction: "from: /data/opensearch to: data/opensearch#get-in-touch"
```
where the `from:` is the url of the page, and the `to:` is the url of the modal
## Issue / Card

Fixes [WD-13714](https://warthogs.atlassian.net/browse/WD-13714)

## Screenshots

![image](https://github.com/user-attachments/assets/dc354ef6-e8bb-442a-b9cb-75b300c00183)


[WD-13714]: https://warthogs.atlassian.net/browse/WD-13714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ