### PR TITLE
Fix: Correct Meta_description for wordpress Blogs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 canonicalwebteam.flask-base==2.0.0
-canonicalwebteam.blog==6.4.2
+canonicalwebteam.blog==6.4.4
 canonicalwebteam.http==1.0.4
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.templatefinder==1.0.0

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -2,7 +2,7 @@
 
 {% block title %}{{ article.title.rendered|safe }}{% endblock %}
 
-{% block meta_description %}{{ article.excerpt.raw }}{% endblock %}
+{% block meta_description %}{{ article.meta_description }}{% endblock %}
 
 {% block body_class %}
   is-paper blog-article


### PR DESCRIPTION
## Done

- Fixes and adds the meta_description coming from wp blogs.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
-  Visit https://canonical-com-1518.demos.haus/blog/what-is-iot-device-management and see if value of `meta_description` is "This post explains the key concepts behind loT device management, why it is important and the best practices organizations should follow."