### PR TITLE
Add links to certified devices on Intel partner page

### DIFF
--- a/templates/partners/silicon/intel/index.html
+++ b/templates/partners/silicon/intel/index.html
@@ -17,9 +17,17 @@
 {% block content %}
 
   {% set breadcrumbs = [
-    {"name": "Partners", "href": "/partners"},
-    {"name": "Silicon", "href": "/partners/silicon"},
-    {"name": "Intel"}
+    {
+      "name": "Partners",
+      "href": "/partners"
+    },
+    {
+      "name": "Silicon",
+      "href": "/partners/silicon"
+    },
+    {
+      "name": "Intel"
+    }
   ] %}
   {% include '/partial/_breadcrumbs.html' %}
 
@@ -34,7 +42,9 @@
       </p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
-      <a href="/contact-us" aria-controls="partners-silicon-intel-modal" class="p-button--positive">Get in touch</a>
+      <a href="/contact-us"
+         aria-controls="partners-silicon-intel-modal"
+         class="p-button--positive">Get in touch</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--3-2 is-highlighted is-cover u-hide--small">
@@ -556,7 +566,9 @@
           </div>
         </div>
         <div class="p-equal-height-row__item">
-          <h3 class="p-heading--5">Laptops</h3>
+          <h3 class="p-heading--5">
+            <a href="https://ubuntu.com/certified/laptops?q=Intel&limit=20&category=Laptop">Laptops</a>
+          </h3>
         </div>
       </div>
       <div class="p-equal-height-row__col">
@@ -573,7 +585,9 @@
           </div>
         </div>
         <div class="p-equal-height-row__item">
-          <h3 class="p-heading--5">Desktops</h3>
+          <h3 class="p-heading--5">
+            <a href="https://ubuntu.com/certified/desktops?q=Intel&limit=20&">Desktops</a>
+          </h3>
         </div>
       </div>
       <div class="p-equal-height-row__col">
@@ -590,7 +604,9 @@
           </div>
         </div>
         <div class="p-equal-height-row__item">
-          <h3 class="p-heading--5">Servers</h3>
+          <h3 class="p-heading--5">
+            <a href="https://ubuntu.com/certified/servers?q=Intel&limit=20&">Servers</a>
+          </h3>
         </div>
       </div>
       <div class="p-equal-height-row__col">
@@ -607,7 +623,9 @@
           </div>
         </div>
         <div class="p-equal-height-row__item">
-          <h3 class="p-heading--5">IoT devices</h3>
+          <h3 class="p-heading--5">
+            <a href="https://ubuntu.com/certified?q=Intel&limit=20&category=Ubuntu+Core">IoT devices</a>
+          </h3>
         </div>
       </div>
     </div>

--- a/templates/partners/silicon/intel/index.html
+++ b/templates/partners/silicon/intel/index.html
@@ -328,7 +328,9 @@
       <hr class="p-rule--muted" />
       <h2>Explore how to optimize performance for Intel platforms in our blog</h2>
       <div class="p-equal-height-row">
-        <div class="p-equal-height-row__col">
+        <a class="p-equal-height-row__col"
+           href="https://ubuntu.com/blog/maximizing-cpu-efficiency-and-energy-savings-with-intel%e2%93%87-quickassist-technology-intel%e2%93%87-qat-on-ubuntu-24-04"
+           aria-label="Maximizing CPU efficiency and energy savings with Intel QuickAssist Technology on Ubuntu 24.04">
           <div class="p-equal-height-row__item u-hide--small u-hide--medium">
             <div class="p-image-container">
               {{ image(url="https://assets.ubuntu.com/v1/16539e8a-maximizing-cpu-efficiency.png",
@@ -343,12 +345,14 @@
           </div>
           <div class="p-equal-height-row__item">
             <h3 class="p-heading--5">
-              <a href="https://ubuntu.com/blog/maximizing-cpu-efficiency-and-energy-savings-with-intel%e2%93%87-quickassist-technology-intel%e2%93%87-qat-on-ubuntu-24-04">Maximizing CPU efficiency and energy savings with Intel<sup>&reg;</sup> QuickAssist Technology on Ubuntu 24.04
-              </a>
+              Maximizing CPU efficiency and energy savings with Intel<sup>&reg;</sup> QuickAssist Technology on Ubuntu 24.04
+
             </h3>
           </div>
-        </div>
-        <div class="p-equal-height-row__col">
+        </a>
+        <a class="p-equal-height-row__col"
+           href="https://ubuntu.com/blog/profile-workloads-on-x86-64-v3-to-enable-future-performance-gains"
+           aria-label="Profile workloads on x86-64-v3 to enable future performance gains">
           <div class="p-equal-height-row__item u-hide--small u-hide--medium">
             <div class="p-image-container">
               {{ image(url="https://assets.ubuntu.com/v1/7ff40d22-profile-workloads.png",
@@ -362,13 +366,12 @@
             </div>
           </div>
           <div class="p-equal-height-row__item">
-            <h3 class="p-heading--5">
-              <a href="https://ubuntu.com/blog/profile-workloads-on-x86-64-v3-to-enable-future-performance-gains">Profile workloads on x86-64-v3 to enable future performance gains
-              </a>
-            </h3>
+            <h3 class="p-heading--5">Profile workloads on x86-64-v3 to enable future performance gains</h3>
           </div>
-        </div>
-        <div class="p-equal-height-row__col">
+        </a>
+        <a class="p-equal-height-row__col"
+           href="https://ubuntu.com/blog/optimised-real-time-ubuntu-is-now-generally-available-on-intel-socs"
+           aria-label="Optimized Real-time Ubuntu is now generally available on Intel SoCs">
           <div class="p-equal-height-row__item u-hide--small u-hide--medium">
             <div class="p-image-container">
               {{ image(url="https://assets.ubuntu.com/v1/72db74d3-optimized-rt-ubuntu.png",
@@ -382,12 +385,12 @@
             </div>
           </div>
           <div class="p-equal-height-row__item">
-            <h3 class="p-heading--5">
-              <a href="https://ubuntu.com/blog/optimised-real-time-ubuntu-is-now-generally-available-on-intel-socs">Optimized Real-time Ubuntu is now generally available on Intel SoCs</a>
-            </h3>
+            <h3 class="p-heading--5">Optimized Real-time Ubuntu is now generally available on Intel SoCs</h3>
           </div>
-        </div>
-        <div class="p-equal-height-row__col">
+        </a>
+        <a class="p-equal-height-row__col"
+           href="https://ubuntu.com/blog/ubuntu-performance-engineering-with-frame-pointers-by-default"
+           aria-label="Performance engineering on Ubuntu leaps forward with frame pointers by default in Ubuntu 24.04 LTS">
           <div class="p-equal-height-row__item u-hide--small u-hide--medium">
             <div class="p-image-container">
               {{ image(url="https://assets.ubuntu.com/v1/cbd961da-performance-engineering.png",
@@ -402,10 +405,10 @@
           </div>
           <div class="p-equal-height-row__item">
             <h3 class="p-heading--5">
-              <a href="https://ubuntu.com/blog/ubuntu-performance-engineering-with-frame-pointers-by-default">Performance engineering on Ubuntu leaps forward with frame pointers by default in Ubuntu 24.04 LTS</a>
+              Performance engineering on Ubuntu leaps forward with frame pointers by default in Ubuntu 24.04 LTS
             </h3>
           </div>
-        </div>
+        </a>
       </div>
     </div>
   </section>

--- a/templates/partners/silicon/intel/index.html
+++ b/templates/partners/silicon/intel/index.html
@@ -54,7 +54,7 @@
                 height="1013",
                 hi_def=True,
                 attrs={"class": "p-image-container__image"},
-                loading="auto|lazy") | safe
+                loading="lazy") | safe
         }}
       </div>
     {%- endif -%}
@@ -552,7 +552,9 @@
       </div>
     </div>
     <div class="p-equal-height-row">
-      <div class="p-equal-height-row__col">
+      <a class="p-equal-height-row__col"
+         href="https://ubuntu.com/certified/laptops?q=Intel&limit=20&category=Laptop"
+         aria-label="Laptops">
         <div class="p-equal-height-row__item u-hide--small u-hide--medium">
           <div class="p-image-container">
             {{ image(url="https://assets.ubuntu.com/v1/01ffd135-laptops.png",
@@ -561,17 +563,17 @@
                         height="1278",
                         hi_def=True,
                         attrs={"class": "p-image-container__image"},
-                        loading="auto|lazy") | safe
+                        loading="lazy") | safe
             }}
           </div>
         </div>
         <div class="p-equal-height-row__item">
-          <h3 class="p-heading--5">
-            <a href="https://ubuntu.com/certified/laptops?q=Intel&limit=20&category=Laptop">Laptops</a>
-          </h3>
+          <h3 class="p-heading--5">Laptops</h3>
         </div>
-      </div>
-      <div class="p-equal-height-row__col">
+      </a>
+      <a class="p-equal-height-row__col"
+         href="https://ubuntu.com/certified/desktops?q=Intel&limit=20&"
+         aria-label="Desktops">
         <div class="p-equal-height-row__item u-hide--small u-hide--medium">
           <div class="p-image-container">
             {{ image(url="https://assets.ubuntu.com/v1/94440f1b-desktops.png",
@@ -580,17 +582,17 @@
                         height="1278",
                         hi_def=True,
                         attrs={"class": "p-image-container__image"},
-                        loading="auto|lazy") | safe
+                        loading="lazy") | safe
             }}
           </div>
         </div>
         <div class="p-equal-height-row__item">
-          <h3 class="p-heading--5">
-            <a href="https://ubuntu.com/certified/desktops?q=Intel&limit=20&">Desktops</a>
-          </h3>
+          <h3 class="p-heading--5">Desktops</h3>
         </div>
-      </div>
-      <div class="p-equal-height-row__col">
+      </a>
+      <a class="p-equal-height-row__col"
+         href="https://ubuntu.com/certified/servers?q=Intel&limit=20&"
+         aria-label="Servers">
         <div class="p-equal-height-row__item u-hide--small u-hide--medium">
           <div class="p-image-container">
             {{ image(url="https://assets.ubuntu.com/v1/a6b2c43b-servers.png",
@@ -598,18 +600,18 @@
                         width="852",
                         height="1278",
                         hi_def=True,
-                        loading="auto|lazy",
+                        loading="lazy",
                         attrs={"class": "p-image-container__image"},) | safe
             }}
           </div>
         </div>
         <div class="p-equal-height-row__item">
-          <h3 class="p-heading--5">
-            <a href="https://ubuntu.com/certified/servers?q=Intel&limit=20&">Servers</a>
-          </h3>
+          <h3 class="p-heading--5">Servers</h3>
         </div>
-      </div>
-      <div class="p-equal-height-row__col">
+      </a>
+      <a class="p-equal-height-row__col"
+         href="https://ubuntu.com/certified?q=Intel&limit=20&category=Ubuntu+Core"
+         aria-label="IoT devices">
         <div class="p-equal-height-row__item u-hide--small u-hide--medium">
           <div class="p-image-container">
             {{ image(url="https://assets.ubuntu.com/v1/04f42dc3-iot-devices.png",
@@ -618,16 +620,14 @@
                         height="1278",
                         hi_def=True,
                         attrs={"class": "p-image-container__image"},
-                        loading="auto|lazy") | safe
+                        loading="lazy") | safe
             }}
           </div>
         </div>
         <div class="p-equal-height-row__item">
-          <h3 class="p-heading--5">
-            <a href="https://ubuntu.com/certified?q=Intel&limit=20&category=Ubuntu+Core">IoT devices</a>
-          </h3>
+          <h3 class="p-heading--5">IoT devices</h3>
         </div>
-      </div>
+      </a>
     </div>
   </section>
 


### PR DESCRIPTION
## Done

Adds links to certified devices.

JIRA: https://warthogs.atlassian.net/browse/WD-18297
Copy doc: https://docs.google.com/document/d/1GstP9FfZfbXO81YcX-9oCJdP9pamlgpl2kKkSqlrWFE/edit?tab=t.0#heading=h.dhplvd7mdy3g


Drive-by: wrap links around images in "Explore how to optimize…" section for consistency. And fixed lazy loading of hero image.

## QA

- Open demo https://canonical-com-1521.demos.haus/partners/silicon/intel
- Scroll down to ["Explore Ubuntu-certified Intel Hardware backed by Ubuntu Pro" section](https://canonical-com-1521.demos.haus/partners/silicon/intel#:~:text=Explore%20Ubuntu%2Dcertified%20Intel%20Hardware%20backed%20by%20Ubuntu%20Pro)
- Make sure all images have link below, as per copy doc

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-18297

## Screenshots

<img width="1319" alt="image" src="https://github.com/user-attachments/assets/f3507231-3198-49fc-b501-4ee352e6d4d2" />
