### PR TITLE
fix: Remove `p-block` usage 

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -56,7 +56,7 @@
   {% set breadcrumbs = [{"name": "Blog", "href": "/blog"}, {"name": "Article"}] %}
   {% include '/partial/_breadcrumbs.html' %}
 
-  <article class="p-block">
+  <article class="p-section--shallow">
     <header class="row">
       <div class="aside col-3 col-medium-2">
         <div class="p-media-object">
@@ -88,52 +88,54 @@
           </div>
         </div>
       </div>
-      <div class="p-block col-9 col-medium-4">
-        <div class="p-block">
-          <h1>{{ article.title.rendered|safe }}</h1>
-        </div>
-
-        {% if tags %}
-          <div class="p-block">
-            {% for tag in tags %}
-              <a class="p-chip--information" href="/blog/tag/{{ tag.slug }}">
-                <span class="p-chip__value">{{ tag.name }}</span>
-              </a>
-            {% endfor %}
+      <div class="col-9 col-medium-4">
+        <div class="p-section--shallow">
+          <div class="p-section--shallow">
+            <h1>{{ article.title.rendered|safe }}</h1>
           </div>
-        {% endif %}
-
-        <ul class="p-inline-list">
-          <span class="p-text--default">Share on:</span>
-          <li class="p-inline-list__item">
-            <a class="p-icon--facebook"
-               title="Share on Facebook"
-               href="https://www.facebook.com/sharer/sharer.php?u=https://www.canonical.com/blog/{{ article.slug }}">
-              Facebook
-            </a>
-          </li>
-          <li class="p-inline-list__item">
-            <a class="p-icon--twitter"
-               title="Share on Twitter"
-               href="https://twitter.com/share?text={{ article.title.rendered|safe|urlencode }}&amp;url=https://www.canonical.com/blog/{{ article.slug }}&amp;hashtags=ubuntu">
-              Twitter
-            </a>
-          </li>
-          <li class="p-inline-list__item">
-            <a class="p-icon--linkedin"
-               title="Share on LinkedIn"
-               href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.canonical.com/blog/{{ article.slug }}&amp;title={{ article.title.rendered|safe|urlencode }}">
-              LinkedIn
-            </a>
-          </li>
-        </ul>
+  
+          {% if tags %}
+            <div class="p-section--shallow">
+              {% for tag in tags %}
+                <a class="p-chip--information" href="/blog/tag/{{ tag.slug }}">
+                  <span class="p-chip__value">{{ tag.name }}</span>
+                </a>
+              {% endfor %}
+            </div>
+          {% endif %}
+  
+          <ul class="p-inline-list">
+            <span class="p-text--default">Share on:</span>
+            <li class="p-inline-list__item">
+              <a class="p-icon--facebook"
+                 title="Share on Facebook"
+                 href="https://www.facebook.com/sharer/sharer.php?u=https://www.canonical.com/blog/{{ article.slug }}">
+                Facebook
+              </a>
+            </li>
+            <li class="p-inline-list__item">
+              <a class="p-icon--twitter"
+                 title="Share on Twitter"
+                 href="https://twitter.com/share?text={{ article.title.rendered|safe|urlencode }}&amp;url=https://www.canonical.com/blog/{{ article.slug }}&amp;hashtags=ubuntu">
+                Twitter
+              </a>
+            </li>
+            <li class="p-inline-list__item">
+              <a class="p-icon--linkedin"
+                 title="Share on LinkedIn"
+                 href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.canonical.com/blog/{{ article.slug }}&amp;title={{ article.title.rendered|safe|urlencode }}">
+                LinkedIn
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
     </header>
     <hr class="p-rule is-fixed-width" />
     <div class="row">
       <aside class="aside col-3 col-medium-2">
         <div class="p-section">
-          <div class="p-block">
+          <div class="p-section--shallow">
             <hr class="p-rule u-hide--medium u-hide--large" />
             <h2 class="p-muted-heading">Newsletter signup</h2>
           </div>

--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -1,10 +1,10 @@
-<div class="p-block">
-  <hr class="p-rule is-fixed-width">
+<div class="p-section--shallow">
+  <hr class="p-rule is-fixed-width" />
   <div class="row">
     <div class="aside col-3 col-medium-2">
       <p>
-        <a href="/blog/author/{{article.author.slug}}">{{ article.author.name }}</a>
-        <br>
+        <a href="/blog/author/{{ article.author.slug }}">{{ article.author.name }}</a>
+        <br />
         {{ article.date }}
       </p>
     </div>
@@ -14,12 +14,12 @@
       </h3>
       <span class="p-chip--information">
         <span class="p-chip__value">
-        {% if request.path == "topic/blog/cloud-and-server" %}
-              Cloud and Server
+          {% if request.path == "topic/blog/cloud-and-server" %}
+            Cloud and Server
           {% elif request.path == "topic/blog/desktop" %}
-              Desktop
+            Desktop
           {% elif request.path == "topic/blog/internet-of-things" %}
-              Internet of Things
+            Internet of Things
           {% else %}
             {% if article.group %}
               {{ article.group.name }}
@@ -30,13 +30,9 @@
         </span>
       </span>
       <span class="p-chip--information">
-        <span class="p-chip__value">
-          {% include 'blog/singular-category.html' %}
-        </span>
+        <span class="p-chip__value">{% include 'blog/singular-category.html' %}</span>
       </span>
-      <p class="u-hide--small u-hide--medium">
-        {{ article.excerpt.raw.replace("[…]", "")|truncate(1000) }}...
-      </p>
+      <p class="u-hide--small u-hide--medium">{{ article.excerpt.raw.replace('[…]', '') |truncate(1000) }}...</p>
     </div>
     <div class="col-3 u-hide--small u-hide--medium">
       {% if article.image and article.image.source_url %}

--- a/templates/careers/_base-department.html
+++ b/templates/careers/_base-department.html
@@ -10,7 +10,7 @@
   <h1 class="p-text--x-small-capitalised u-hide">Careers</h1>
 </div>
 {% if not fast_track_jobs %}
-  <section class="p-section u-no-padding--top">
+  <section class="p-section">
     <hr class="is-fixed-width p-rule" />
     <div class="row p-section">
       <div class="col-6 col-medium-3">
@@ -47,7 +47,7 @@
       {% for paragraph in block_1_text %}<p>{{ paragraph | safe }}</p>{% endfor %}
     </div>
   </div>
-  <div class="p-block">
+  <div class="p-section--shallow">
     <div class="u-fixed-width u-hide--small u-hide--medium">
       {{ image(url=image_url,
             alt="",
@@ -60,7 +60,7 @@
   </div>
 </section>
 {% if block_2_text | length > 0 %}
-  <section class="p-section u-no-padding--top">
+  <section class="p-section">
     <div class="u-fixed-width">
       <hr class="p-rule" />
     </div>
@@ -87,7 +87,7 @@
   </div>
 </section>
 
-<section class="p-section u-no-padding--top">
+<section class="p-section">
   <hr class="is-fixed-width p-rule" />
   <div class="u-fixed-width">
     <h2>See for yourself the work we're doing</h2>

--- a/templates/careers/company-culture/remote-work.html
+++ b/templates/careers/company-culture/remote-work.html
@@ -209,7 +209,7 @@
 
   <section class="p-strip is-deep" style="background-color: #fff;">
     <div class="u-fixed-width">
-      <div class="p-block">
+      <div class="p-section--shallow">
         <h2 class="p-muted-heading">Join us</h2>
         <h3 class="p-heading--2">
           Be part of a company making a difference

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -1,137 +1,179 @@
 {% extends 'careers/base.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1o8ind3Zav-kwrUDWgiMJnkw2QLpniKgdlWrw9byIvlE/edit#heading=h.ov7lrxgwh2dv{% endblock meta_copydoc %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1o8ind3Zav-kwrUDWgiMJnkw2QLpniKgdlWrw9byIvlE/edit#heading=h.ov7lrxgwh2dv
+{% endblock meta_copydoc %}
 
 {% block title %}Canonical Careers{% endblock %}
 
-{% block meta_description %}Looking for a career in open source? Be where the cutting edge is established and amplify the impact of open source. Browse careers at Canonical.{% endblock %}
+{% block meta_description %}
+  Looking for a career in open source? Be where the cutting edge is established and amplify the impact of open source. Browse careers at Canonical.
+{% endblock %}
 
-{% block body_class %}is-paper{% endblock body_class %}
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
-<!-- StackOverflow ad tracking pixel -->
-<script>
-  (function() {
-  var a = String(Math.floor(Math.random() * 10000000000000000));
-  new Image().src = 'https://pubads.g.doubleclick.net/activity;xsp=5024608;ord='+ a +'?';
-  })();
-</script>
-<noscript>
-  <img src='https://pubads.g.doubleclick.net/activity;xsp=5024608;ord=1?' width=1 height=1 border=0>
-</noscript>
+  <!-- StackOverflow ad tracking pixel -->
+  <script>
+    (function() {
+      var a = String(Math.floor(Math.random() * 10000000000000000));
+      new Image().src = 'https://pubads.g.doubleclick.net/activity;xsp=5024608;ord=' + a + '?';
+    })();
+  </script>
+  <noscript>
+    <img src='https://pubads.g.doubleclick.net/activity;xsp=5024608;ord=1?'
+         width="1"
+         height="1"
+         border="0" />
+  </noscript>
 
-<section class="p-section">
-  <div class="u-fixed-width">
-    <div class="p-breadcrumbs" aria-label="Breadcrumbs">
-      <ol class="p-breadcrumbs__items p-text--x-small-capitalised">
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <div class="p-breadcrumbs" aria-label="Breadcrumbs">
+        <ol class="p-breadcrumbs__items p-text--x-small-capitalised">
           <li class="p-breadcrumbs__item ">Careers</li>
-      </ol>
-    </div>
-    <h1 class="p-text--x-small-capitalised u-off-screen">Careers</h1>
-    <hr class="p-rule">
-  </div>
-  <div class="row">
-    <div class="col-9 col-medium-4 col-start-large-4 col-start-medium-3">
-      <div class="p-block">
-      <div class="p-section">
-        <h2 class="u-no-margin--bottom"><strong>Passionate about open source? So are we. </strong><br class="u-hide--small u-hide--medium"><span>Be where the cutting edge is established.</span></h2>
+        </ol>
       </div>
-
-      {% if vacancies %}
-        {% include "careers/_search.html" %}
-      {% endif %}
+      <h1 class="p-text--x-small-capitalised u-off-screen">Careers</h1>
+      <hr class="p-rule" />
     </div>
-  </div>
-  <div class="u-fixed-width u-no-padding u-hide--medium u-hide--small">
-    <img src="https://assets.ubuntu.com/v1/7f34ade9-website_suru_25.jpg" alt="" style="aspect-ratio: 5.1775700934579; width: 100%;"/>
-  </div>
-</section>
+    <div class="row">
+      <div class="col-9 col-medium-4 col-start-large-4 col-start-medium-3">
+        <div class="p-section--shallow">
+          <div class="p-section">
+            <h2 class="u-no-margin--bottom">
+              <strong>Passionate about open source? So are we.</strong>
+              <br class="u-hide--small u-hide--medium" />
+              <span>Be where the cutting edge is established.</span>
+            </h2>
+          </div>
 
-{% if departments_overview %}
-<section class="p-section">
-  <div class="u-fixed-width">
-    <hr class="p-rule">
-  </div>
-  <div class="row">
-    <div class="col-12 col-medium-2 p-block">
-      <h2 class="p-text--x-small-capitalised">Departments</h2>
-    </div>
-    <div class="col-12 col-medium-4">
-      <div class="row">
-        {% for dept in departments_overview %}
-        <div class="col-2 col-medium-12 col-small-12 p-department-cards__container">
-          <a href="/careers/{{dept.slug}}" style="text-decoration: none">
-          <div class="p-department-cards__card">
-            <div class="p-department-cards__image-container">
-              <img src="https://assets.ubuntu.com/v1/{{dept.icon}}" class="p-department-cards__image" alt="">
-              <strong class="p-department-cards__link">{{ dept.name }}</strong><br />
-            </div>
-            <div>
-              <span>{{ dept.count }} roles</span>
+          {% if vacancies %}
+            {% include "careers/_search.html" %}
+          {% endif %}
+        </div>
+      </div>
+      <div class="u-fixed-width u-no-padding u-hide--medium u-hide--small">
+        <img src="https://assets.ubuntu.com/v1/7f34ade9-website_suru_25.jpg"
+             alt=""
+             style="aspect-ratio: 5.1775700934579;
+                    width: 100%" />
+      </div>
+    </section>
+
+    {% if departments_overview %}
+      <section class="p-section">
+        <div class="u-fixed-width">
+          <hr class="p-rule" />
+        </div>
+        <div class="row">
+          <div class="col-12 col-medium-2">
+            <div class="p-section--shallow">
+              <h2 class="p-text--x-small-capitalised">Departments</h2>
             </div>
           </div>
-          {% if not loop.last %}
-            <hr class="p-rule u-hide--large" />
-          {% endif %}
-          </a>
+          <div class="col-12 col-medium-4">
+            <div class="row">
+              {% for dept in departments_overview %}
+                <div class="col-2 col-medium-12 col-small-12 p-department-cards__container">
+                  <a href="/careers/{{ dept.slug }}" style="text-decoration: none">
+                    <div class="p-department-cards__card">
+                      <div class="p-department-cards__image-container">
+                        <img src="https://assets.ubuntu.com/v1/{{ dept.icon }}"
+                             class="p-department-cards__image"
+                             alt="" />
+                        <strong class="p-department-cards__link">{{ dept.name }}</strong>
+                        <br />
+                      </div>
+                      <div>
+                        <span>{{ dept.count }} roles</span>
+                      </div>
+                    </div>
+                    {% if not loop.last %}<hr class="p-rule u-hide--large" />{% endif %}
+                  </a>
+                </div>
+              {% endfor %}
+            </div>
+          </div>
         </div>
-        {% endfor %}
+
+      </section>
+    {% endif %}
+
+    <section class="p-section">
+      <div class="u-fixed-width">
+        <hr class="p-rule" />
       </div>
-    </div>
-</div>
 
-</section>
-{% endif %}
-
-<section class="p-section">
-  <div class="u-fixed-width">
-    <hr class="p-rule">
-  </div>
-
-  <div class="p-block">
-    <div class="row">
-      <div class="col-3 col-medium-2 p-block">
-        <h2 class="p-text--x-small-capitalised">Our Mission</h2>
+      <div class="p-section--shallow">
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <div class="p-section--shallow">
+              <h2 class="p-text--x-small-capitalised">Our Mission</h2>
+            </div>
+          </div>
+          <div class="col-9 col-medium-4">
+            <div class="p-section--shallow">
+              <p class="p-heading--2">
+                We amplify
+                <br class="u-hide--small" />
+                the impact of open source
+              </p>
+            </div>
+            <p>
+              We help people and organisations tap into the power of open source to develop new products at speed and with confidence. Whether it’s powering up self-driving cars or enabling compute for scientific discovery, we are here to deliver the best open source experience.
+            </p>
+            <p>Every team member contributes to this mission with a commitment to excellence.</p>
+            <p>
+              <a class="p-button" href="/careers/company-culture">Our work culture</a>
+            </p>
+          </div>
+        </div>
       </div>
-      <div class="col-9 col-medium-4">
-	<div class="p-block">
-	  <p class="p-heading--2">We amplify <br class="u-hide--small" /> the impact of open source</p>
-	</div>
-        <p>We help people and organisations tap into the power of open source to develop new products at speed and with confidence. Whether it’s powering up self-driving cars or enabling compute for scientific discovery, we are here to deliver the best open source experience.</p>
-        <p>Every team member contributes to this mission with a commitment to excellence.</p>
-        <p>
-          <a class="p-button" href="/careers/company-culture">Our work culture</a>
-        </p>
+      <div class="u-fixed-width">
+        <img src="https://assets.ubuntu.com/v1/da3fbf74-summit2022_crowd.png"
+             width="100%"
+             alt="Canonical employees at Ubuntu Summit 2022" />
       </div>
-    </div>
-  </div>
-  <div class="u-fixed-width">
-    <img src="https://assets.ubuntu.com/v1/da3fbf74-summit2022_crowd.png" width="100%" alt="Canonical employees at Ubuntu Summit 2022">
-  </div>
-</section>
+    </section>
 
-<section class="p-section">
-  <div class="u-fixed-width">
-    <hr class="p-rule">
-  </div>
-  <div class="row">
-    <div class="col-3 col-medium-2 p-block">
-      <h3 class="p-muted-heading">Working here</h3>
-    </div>
-    <div class="col-9 col-medium-4">
-      <p class="p-heading--2"><a href="/careers/company-culture/remote-work">Remote work</a></p>
-      <hr class="p-rule">
-      <p class="p-heading--2"><a href="/careers/progression">Progression</a></p>
-      <hr class="p-rule">
-      <p class="p-heading--2"><a href="/careers/diversity">Diversity</a></p>
-			<hr class="p-rule">
-      <p class="p-heading--2"><a href="/careers/sustainability">Sustainability</a></p>
-      <hr class="p-rule">
-      <p class="p-heading--2"><a href="/careers/application/faq">FAQs</a></p>
-  </div>
-  </div>
-</section>
+    <section class="p-section">
+      <div class="u-fixed-width">
+        <hr class="p-rule" />
+      </div>
+      <div class="row">
+        <div class="col-3 col-medium-2">
+          <div class="p-section--shallow">
+            <h3 class="p-muted-heading">Working here</h3>
+          </div>
+        </div>
+        <div class="col-9 col-medium-4">
+          <p class="p-heading--2">
+            <a href="/careers/company-culture/remote-work">Remote work</a>
+          </p>
+          <hr class="p-rule" />
+          <p class="p-heading--2">
+            <a href="/careers/progression">Progression</a>
+          </p>
+          <hr class="p-rule" />
+          <p class="p-heading--2">
+            <a href="/careers/diversity">Diversity</a>
+          </p>
 
-<script defer src="{{ versioned_static('js/careers-filter-and-sort.js') }}"></script>
+          <hr class="p-rule" />
+          <p class="p-heading--2">
+            <a href="/careers/sustainability">Sustainability</a>
+          </p>
+          <hr class="p-rule" />
+          <p class="p-heading--2">
+            <a href="/careers/application/faq">FAQs</a>
+          </p>
+        </div>
+      </div>
+    </section>
 
-{% endblock %}
+    <script defer src="{{ versioned_static('js/careers-filter-and-sort.js') }}"></script>
+
+  {% endblock %}

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -19,13 +19,14 @@
   <script>
     (function() {
       var a = String(Math.floor(Math.random() * 10000000000000000));
-      new Image().src = 'https://pubads.g.doubleclick.net/activity;xsp=5024608;ord=' + a + '?';
+      new Image().src = "https://pubads.g.doubleclick.net/activity;xsp=5024608;ord=" + a + "?";
     })();
   </script>
   <noscript>
-    <img src='https://pubads.g.doubleclick.net/activity;xsp=5024608;ord=1?'
+    <img src="https://pubads.g.doubleclick.net/activity;xsp=5024608;ord=1?"
          width="1"
          height="1"
+         alt=""
          border="0" />
   </noscript>
 
@@ -61,119 +62,120 @@
              style="aspect-ratio: 5.1775700934579;
                     width: 100%" />
       </div>
-    </section>
+    </div>
+  </section>
 
-    {% if departments_overview %}
-      <section class="p-section">
-        <div class="u-fixed-width">
-          <hr class="p-rule" />
-        </div>
-        <div class="row">
-          <div class="col-12 col-medium-2">
-            <div class="p-section--shallow">
-              <h2 class="p-text--x-small-capitalised">Departments</h2>
-            </div>
-          </div>
-          <div class="col-12 col-medium-4">
-            <div class="row">
-              {% for dept in departments_overview %}
-                <div class="col-2 col-medium-12 col-small-12 p-department-cards__container">
-                  <a href="/careers/{{ dept.slug }}" style="text-decoration: none">
-                    <div class="p-department-cards__card">
-                      <div class="p-department-cards__image-container">
-                        <img src="https://assets.ubuntu.com/v1/{{ dept.icon }}"
-                             class="p-department-cards__image"
-                             alt="" />
-                        <strong class="p-department-cards__link">{{ dept.name }}</strong>
-                        <br />
-                      </div>
-                      <div>
-                        <span>{{ dept.count }} roles</span>
-                      </div>
-                    </div>
-                    {% if not loop.last %}<hr class="p-rule u-hide--large" />{% endif %}
-                  </a>
-                </div>
-              {% endfor %}
-            </div>
-          </div>
-        </div>
-
-      </section>
-    {% endif %}
-
-    <section class="p-section">
-      <div class="u-fixed-width">
-        <hr class="p-rule" />
-      </div>
-
-      <div class="p-section--shallow">
-        <div class="row">
-          <div class="col-3 col-medium-2">
-            <div class="p-section--shallow">
-              <h2 class="p-text--x-small-capitalised">Our Mission</h2>
-            </div>
-          </div>
-          <div class="col-9 col-medium-4">
-            <div class="p-section--shallow">
-              <p class="p-heading--2">
-                We amplify
-                <br class="u-hide--small" />
-                the impact of open source
-              </p>
-            </div>
-            <p>
-              We help people and organisations tap into the power of open source to develop new products at speed and with confidence. Whether it’s powering up self-driving cars or enabling compute for scientific discovery, we are here to deliver the best open source experience.
-            </p>
-            <p>Every team member contributes to this mission with a commitment to excellence.</p>
-            <p>
-              <a class="p-button" href="/careers/company-culture">Our work culture</a>
-            </p>
-          </div>
-        </div>
-      </div>
-      <div class="u-fixed-width">
-        <img src="https://assets.ubuntu.com/v1/da3fbf74-summit2022_crowd.png"
-             width="100%"
-             alt="Canonical employees at Ubuntu Summit 2022" />
-      </div>
-    </section>
-
+  {% if departments_overview %}
     <section class="p-section">
       <div class="u-fixed-width">
         <hr class="p-rule" />
       </div>
       <div class="row">
+        <div class="col-12 col-medium-2">
+          <div class="p-section--shallow">
+            <h2 class="p-text--x-small-capitalised">Departments</h2>
+          </div>
+        </div>
+        <div class="col-12 col-medium-4">
+          <div class="row">
+            {% for dept in departments_overview %}
+              <div class="col-2 col-medium-12 col-small-12 p-department-cards__container">
+                <a href="/careers/{{ dept.slug }}" style="text-decoration: none">
+                  <div class="p-department-cards__card">
+                    <div class="p-department-cards__image-container">
+                      <img src="https://assets.ubuntu.com/v1/{{ dept.icon }}"
+                           class="p-department-cards__image"
+                           alt="" />
+                      <strong class="p-department-cards__link">{{ dept.name }}</strong>
+                      <br />
+                    </div>
+                    <div>
+                      <span>{{ dept.count }} roles</span>
+                    </div>
+                  </div>
+                  {% if not loop.last %}<hr class="p-rule u-hide--large" />{% endif %}
+                </a>
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+
+    </section>
+  {% endif %}
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+    </div>
+
+    <div class="p-section--shallow">
+      <div class="row">
         <div class="col-3 col-medium-2">
           <div class="p-section--shallow">
-            <h3 class="p-muted-heading">Working here</h3>
+            <h2 class="p-text--x-small-capitalised">Our Mission</h2>
           </div>
         </div>
         <div class="col-9 col-medium-4">
-          <p class="p-heading--2">
-            <a href="/careers/company-culture/remote-work">Remote work</a>
+          <div class="p-section--shallow">
+            <p class="p-heading--2">
+              We amplify
+              <br class="u-hide--small" />
+              the impact of open source
+            </p>
+          </div>
+          <p>
+            We help people and organisations tap into the power of open source to develop new products at speed and with confidence. Whether it’s powering up self-driving cars or enabling compute for scientific discovery, we are here to deliver the best open source experience.
           </p>
-          <hr class="p-rule" />
-          <p class="p-heading--2">
-            <a href="/careers/progression">Progression</a>
-          </p>
-          <hr class="p-rule" />
-          <p class="p-heading--2">
-            <a href="/careers/diversity">Diversity</a>
-          </p>
-
-          <hr class="p-rule" />
-          <p class="p-heading--2">
-            <a href="/careers/sustainability">Sustainability</a>
-          </p>
-          <hr class="p-rule" />
-          <p class="p-heading--2">
-            <a href="/careers/application/faq">FAQs</a>
+          <p>Every team member contributes to this mission with a commitment to excellence.</p>
+          <p>
+            <a class="p-button" href="/careers/company-culture">Our work culture</a>
           </p>
         </div>
       </div>
-    </section>
+    </div>
+    <div class="u-fixed-width">
+      <img src="https://assets.ubuntu.com/v1/da3fbf74-summit2022_crowd.png"
+           width="100%"
+           alt="Canonical employees at Ubuntu Summit 2022" />
+    </div>
+  </section>
 
-    <script defer src="{{ versioned_static('js/careers-filter-and-sort.js') }}"></script>
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+    </div>
+    <div class="row">
+      <div class="col-3 col-medium-2">
+        <div class="p-section--shallow">
+          <h3 class="p-muted-heading">Working here</h3>
+        </div>
+      </div>
+      <div class="col-9 col-medium-4">
+        <p class="p-heading--2">
+          <a href="/careers/company-culture/remote-work">Remote work</a>
+        </p>
+        <hr class="p-rule" />
+        <p class="p-heading--2">
+          <a href="/careers/progression">Progression</a>
+        </p>
+        <hr class="p-rule" />
+        <p class="p-heading--2">
+          <a href="/careers/diversity">Diversity</a>
+        </p>
 
-  {% endblock %}
+        <hr class="p-rule" />
+        <p class="p-heading--2">
+          <a href="/careers/sustainability">Sustainability</a>
+        </p>
+        <hr class="p-rule" />
+        <p class="p-heading--2">
+          <a href="/careers/application/faq">FAQs</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <script defer src="{{ versioned_static('js/careers-filter-and-sort.js') }}"></script>
+
+{% endblock %}

--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -19,62 +19,72 @@
 </section>
 
 <section  class="p-section">
-  <div class="row p-block">
-    <hr class="p-rule" />
-    <div class="col-3 col-medium-2">
-      <h2 class="p-muted-heading">Sales</h2>
-    </div>
-    <div class="col-9 col-medium-4">
-      <p><a href="/contact-us" aria-controls="homepage-modal">Get in touch</a> about open source infrastructure, applications, development and operations. We are proud to deliver the world's best pathway to open source success.</p>
-    </div>
-  </div>
-  <div class="row p-block">
-    <hr class="p-rule" />
-    <div class="col-3 col-medium-2">
-      <h2 class="p-muted-heading">Technical assistance</h2>
-    </div>
-    <div class="col-9 col-medium-4">
-      <p>Our <a href="https://www.ubuntu.com/support">support team</a> offers a range of services from enterprise support to fully managed infrastructure and applications.</p>
+  <div class="p-section--shallow">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-2">
+        <h2 class="p-muted-heading">Sales</h2>
+      </div>
+      <div class="col-9 col-medium-4">
+        <p><a href="/contact-us" aria-controls="homepage-modal">Get in touch</a> about open source infrastructure, applications, development and operations. We are proud to deliver the world's best pathway to open source success.</p>
+      </div>
     </div>
   </div>
-  <div class="row p-block">
-    <hr class="p-rule" />
-    <div class="col-3 col-medium-2">
-      <h2 class="p-muted-heading">Trademark and other licenses</h2>
-    </div>
-    <div class="col-9 col-medium-4">
-      <p>Publishing or distributing Ubuntu in any form other than our standard install media and packages requires permission. To license the Ubuntu trademark or any other rights, please <a href="https://www.ubuntu.com/legal/terms-and-policies/contact-us">submit an enquiry</a>.</p>
-    </div>
-  </div>
-
-  <div class="row p-block">
-    <hr class="p-rule" />
-    <div class="col-3 col-medium-2">
-      <h2 class="p-muted-heading">Press and analyst enquiries</h2>
-    </div>
-    <div class="col-9 col-medium-4">
-      <p>Please contact <a href="mailto:pr@canonical.com">pr@canonical.com</a>.</p>
+  <div class="p-section--shallow">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-2">
+        <h2 class="p-muted-heading">Technical assistance</h2>
+      </div>
+      <div class="col-9 col-medium-4">
+        <p>Our <a href="https://www.ubuntu.com/support">support team</a> offers a range of services from enterprise support to fully managed infrastructure and applications.</p>
+      </div>
     </div>
   </div>
-
-  <div class="row p-block">
-    <hr class="p-rule" />
-    <div class="col-3 col-medium-2">
-      <h2 class="p-muted-heading">Data Privacy enquiries</h2>
-    </div>
-    <div class="col-9 col-medium-4">
-      <p>For information about data privacy, please read our <a href="https://www.ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a> or <a href="https://ubuntu.com/legal/data-privacy/enquiry">submit an enquiry</a>. A member of our data privacy team will be in touch with you shortly.</p>
+  <div class="p-section--shallow">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-2">
+        <h2 class="p-muted-heading">Trademark and other licenses</h2>
+      </div>
+      <div class="col-9 col-medium-4">
+        <p>Publishing or distributing Ubuntu in any form other than our standard install media and packages requires permission. To license the Ubuntu trademark or any other rights, please <a href="https://www.ubuntu.com/legal/terms-and-policies/contact-us">submit an enquiry</a>.</p>
+      </div>
     </div>
   </div>
-
-  <div class="row p-block">
-    <hr class="p-rule" />
-    <div class="col-3 col-medium-2">
-      <h2 class="p-muted-heading">Legal enquiries</h2>
+  <div class="p-section--shallow">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-2">
+        <h2 class="p-muted-heading">Press and analyst enquiries</h2>
+      </div>
+      <div class="col-9 col-medium-4">
+        <p>Please contact <a href="mailto:pr@canonical.com">pr@canonical.com</a>.</p>
+      </div>
     </div>
-    <div class="col-9 col-medium-4">
-      <p>Please note that we cannot provide you with legal advice. For any other queries, please contact us on <a
-        href="mailto:legal@canonical.com">legal@canonical.com</a>.</p>
+  </div>
+  
+  <div class="p-section--shallow">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-2">
+        <h2 class="p-muted-heading">Data Privacy enquiries</h2>
+      </div>
+      <div class="col-9 col-medium-4">
+        <p>For information about data privacy, please read our <a href="https://www.ubuntu.com/legal/data-privacy" target="_blank">Privacy Policy</a> or <a href="https://ubuntu.com/legal/data-privacy/enquiry">submit an enquiry</a>. A member of our data privacy team will be in touch with you shortly.</p>
+      </div>
+    </div>
+  </div>
+  <div class="p-section--shallow">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-2">
+        <h2 class="p-muted-heading">Legal enquiries</h2>
+      </div>
+      <div class="col-9 col-medium-4">
+        <p>Please note that we cannot provide you with legal advice. For any other queries, please contact us on <a
+          href="mailto:legal@canonical.com">legal@canonical.com</a>.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/documentation/_documentation-header.html
+++ b/templates/documentation/_documentation-header.html
@@ -1,7 +1,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-start-large-4 col-8 col-medium-4 col-start-medium-3">
-      <div class="p-block">
+      <div class="p-section--shallow">
         <h1>Documentation practice<br class="u-hide--small"> at Canonical</h1>
       </div>
       <p>At Canonical, we have embarked on a comprehensive, long-term project to transform documentation. Our aim is to create and maintain documentation product and practice that will represent a standard of excellence. We want documentation to be the best it possibly can be.</p>

--- a/templates/documentation/beyond-canonical.html
+++ b/templates/documentation/beyond-canonical.html
@@ -4,102 +4,156 @@
 
 {% block title %}Documentation practice beyond Canonical{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/12VyKotmcjOD7zRGl_9vLcrKXZFvhAKJ1ZNnFAiWKWmk/edit#{% endblock %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/12VyKotmcjOD7zRGl_9vLcrKXZFvhAKJ1ZNnFAiWKWmk/edit#
+{% endblock %}
 
-{% block meta_description %}We work beyond Canonical, to disseminate good practice and process, and to learn from the experience and research of others.{% endblock %}
+{% block meta_description %}
+  We work beyond Canonical, to disseminate good practice and process, and to learn from the experience and research of others.
+{% endblock %}
 
 {% block meta_image %}https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg{% endblock %}
 
 {% block documentation_content %}
-<div class="p-strip u-no-padding--top">
-  <div class="row" id="documentation">
-    <aside class="col-3">
-      <div class="p-side-navigation--raw-html is-sticky" id="drawer">
-        <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
-          Toggle side navigation
-        </button>
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-        <nav class="p-side-navigation__drawer" aria-label="documentation side navigation">
-          <div class="p-side-navigation__drawer-header">
-            <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
-              Toggle table of contents
-            </button>
+  <div class="p-strip u-no-padding--top">
+    <div class="row" id="documentation">
+      <aside class="col-3">
+        <div class="p-side-navigation--raw-html is-sticky" id="drawer">
+          <button class="p-side-navigation__toggle js-drawer-toggle"
+                  aria-controls="drawer">Toggle side navigation</button>
+          <div class="p-side-navigation__overlay js-drawer-toggle"
+               aria-controls="drawer"></div>
+          <nav class="p-side-navigation__drawer"
+               aria-label="documentation side navigation">
+            <div class="p-side-navigation__drawer-header">
+              <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle"
+                      aria-controls="drawer">Toggle table of contents</button>
+            </div>
+            <ul>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#encounters-and-dialogue">Encounters and dialogue</a>
+              </li>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#open-source-events">Open-source events</a>
+              </li>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#supporting-open-source-projects">Supporting open-source projects</a>
+              </li>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#collaboration-with-practitioners">Collaboration with practitioners</a>
+              </li>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#scientific-research-community">Scientific research community</a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </aside>
+      <main class="col-9">
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4"
+                style="scroll-margin-top: 3.5rem">Documentation practice beyond Canonical</h2>
+            <div class="col-6 col-medium-4">
+              <p>
+                We're working to establish patterns of excellence in documentation in Canonical, but not just for Canonical. The scale of operations at Canonical makes it an effective proving-ground for the models and ideas that we're developing &mdash; models and ideas that are being noticed and adopted more widely in the industry.
+              </p>
+            </div>
           </div>
-          <ul>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#encounters-and-dialogue">Encounters and dialogue</a>
-            </li>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#open-source-events">Open-source events</a>
-            </li>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#supporting-open-source-projects">Supporting open-source projects</a>
-            </li>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#collaboration-with-practitioners">Collaboration with practitioners</a>
-            </li>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#scientific-research-community">Scientific research community</a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </aside>
-    <main class="col-9">
-      <div class="row p-block">
-        <h2 class="col-3 col-medium-2 p-heading--4" style="scroll-margin-top: 3.5rem;">Documentation practice beyond Canonical</h2>
-        <div class="col-6 col-medium-4">
-          <p>We're working to establish patterns of excellence in documentation in Canonical, but not just for Canonical. The scale of operations at Canonical makes it an effective proving-ground for the models and ideas that we're developing &mdash; models and ideas that are being noticed and adopted more widely in the industry.</p>
         </div>
-      </div>
-      <hr class="p-rule">     
-      <div class="row p-block">
-        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="encounters-and-dialogue" style="scroll-margin-top: 3.5rem;">Encounters and dialogue</h2>
-        <div class="col-6 col-medium-4">
-          <p>We actively seek new encounters with problems in documentation, in order that we may understand how our thinking can apply to them. We need to learn from experiences in other contexts.</p>
-          <p>We think, talk and write about the problems and practices of documentation, openly, and with whoever wants to take part part in that dialogue.</p>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="encounters-and-dialogue"
+                style="scroll-margin-top: 3.5rem">Encounters and dialogue</h2>
+            <div class="col-6 col-medium-4">
+              <p>
+                We actively seek new encounters with problems in documentation, in order that we may understand how our thinking can apply to them. We need to learn from experiences in other contexts.
+              </p>
+              <p>
+                We think, talk and write about the problems and practices of documentation, openly, and with whoever wants to take part part in that dialogue.
+              </p>
+            </div>
+          </div>
         </div>
-      </div>
-      <hr class="p-rule">     
-      <div class="row p-block">
-        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="open-source-events" style="scroll-margin-top: 3.5rem;">Workshops and talks at open-source events</h2>
-        <div class="col-6 col-medium-4">
-          <p>We regularly attend events where the topic of documentation is firmly on the table. Recent examples of participation include <a href="https://2022.pyconuk.org/">PyCon UK 2022</a>, <a href="https://www.youtube.com/watch?v=R4O2WoFC-JQ">DjangoCon Europe 2022</a>, <a href="https://events.canonical.com/event/2/">Ubuntu Summit 2022</a>, <a href="https://www.python.org/events/python-events/1379/">PyCon Namibia 2023</a>.</p>
-          <figure>
-            <img class="p-image" src="https://assets.ubuntu.com/v1/a1630e44-working-at-canonical.jpeg" alt="Workshop participants sitting around a table analyse user needs in documentation situations" width="600" height="400">
-            <figcaption>Diátaxis workshop at the Ubuntu Summit, 2022</figcaption>
-          </figure>
-          <p>Documentation is important for open-source software in several ways. One that's sometimes not properly understood is the value it has as a pathway into open-source participation and contribution. </p>
-          <p>In turn, open-source software also has a lot of significance for documentation. That's because it's one of the great entry-points into documentation practice. Most people in documentation are not trained technical writers, but the barriers to writing documentation in open-source contexts are low, and the context makes first, hesitant steps easier.</p>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="open-source-events"
+                style="scroll-margin-top: 3.5rem">Workshops and talks at open-source events</h2>
+            <div class="col-6 col-medium-4">
+              <p>
+                We regularly attend events where the topic of documentation is firmly on the table. Recent examples of participation include <a href="https://2022.pyconuk.org/">PyCon UK 2022</a>, <a href="https://www.youtube.com/watch?v=R4O2WoFC-JQ">DjangoCon Europe 2022</a>, <a href="https://events.canonical.com/event/2/">Ubuntu Summit 2022</a>, <a href="https://www.python.org/events/python-events/1379/">PyCon Namibia 2023</a>.
+              </p>
+              <figure>
+                <img class="p-image"
+                     src="https://assets.ubuntu.com/v1/a1630e44-working-at-canonical.jpeg"
+                     alt="Workshop participants sitting around a table analyse user needs in documentation situations"
+                     width="600"
+                     height="400" />
+                <figcaption>Diátaxis workshop at the Ubuntu Summit, 2022</figcaption>
+              </figure>
+              <p>
+                Documentation is important for open-source software in several ways. One that's sometimes not properly understood is the value it has as a pathway into open-source participation and contribution.
+              </p>
+              <p>
+                In turn, open-source software also has a lot of significance for documentation. That's because it's one of the great entry-points into documentation practice. Most people in documentation are not trained technical writers, but the barriers to writing documentation in open-source contexts are low, and the context makes first, hesitant steps easier.
+              </p>
+            </div>
+          </div>
         </div>
-      </div>
-      <hr class="p-rule">
-      <div class="row p-block">
-        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="supporting-open-source-projects" style="scroll-margin-top: 3.5rem;">Supporting open-source projects</h2>
-        <div class="col-6 col-medium-4">
-          <p>Open-source projects inevitably find it easier to secure top-class programming contributions than they do to attract the same level of expertise in documentation.</p>
-          <p>We engage with a number of open-source projects, providing guidance, support as well as material documentation contributions. Recent examples include <a href="https://www.python.org/">Python</a> and <a href="https://www.djangoproject.com/">Django</a>.</p>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="supporting-open-source-projects"
+                style="scroll-margin-top: 3.5rem">Supporting open-source projects</h2>
+            <div class="col-6 col-medium-4">
+              <p>
+                Open-source projects inevitably find it easier to secure top-class programming contributions than they do to attract the same level of expertise in documentation.
+              </p>
+              <p>
+                We engage with a number of open-source projects, providing guidance, support as well as material documentation contributions. Recent examples include <a href="https://www.python.org/">Python</a> and <a href="https://www.djangoproject.com/">Django</a>.
+              </p>
+            </div>
+          </div>
         </div>
-      </div>
-      <hr class="p-rule">         
-      <div class="row p-block">
-        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="collaboration-with-practitioners" style="scroll-margin-top: 3.5rem;">Collaboration with other practitioners</h2>
-        <div class="col-6 col-medium-4">
-          <p>We eagerly absorb insight from others in the discipline. The challenges faced by practitioners in other organisations serve to illuminate our own, and we value the exchange of ideas and expertise they offer.</p>
-          <p>In particular, we've benefited from the experiences that others have had implementing <a href="https://diataxis.fr/">Diátaxis</a> at scale, or in very different contexts, as a means to refining our own understanding.</p>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="collaboration-with-practitioners"
+                style="scroll-margin-top: 3.5rem">Collaboration with other practitioners</h2>
+            <div class="col-6 col-medium-4">
+              <p>
+                We eagerly absorb insight from others in the discipline. The challenges faced by practitioners in other organisations serve to illuminate our own, and we value the exchange of ideas and expertise they offer.
+              </p>
+              <p>
+                In particular, we've benefited from the experiences that others have had implementing <a href="https://diataxis.fr/">Diátaxis</a> at scale, or in very different contexts, as a means to refining our own understanding.
+              </p>
+            </div>
+          </div>
         </div>
-      </div>
-      <hr class="p-rule">
-      <div class="row p-block">
-        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="scientific-research-community" style="scroll-margin-top: 3.5rem;">Engagement with the scientific research community</h2>
-        <div class="col-6 col-medium-4">
-          <p>The scientific community faces a problem, that risks becoming a crisis, of <em>reproducibility</em>. Ever-more research relies on computation, and much of it is wholly dependent on it. Despite this fact, and despite the valiant effort of software research engineers, software practices in research in general fall very far behind the standards achieved in industry.</p>
-          <p>Documentation plays an important role in achieving and maintaining reproducibility. Members of our documentation team have held workshops dedicated to research software documentation, and explored the context in particular research institutions. Our Practice Lead for Documentation is <a href="https://software.ac.uk/about/fellows/daniele-procida">a Fellow of the Software Sustainability Institute</a>, running a long-term project to work with researchers, as much to understand the special problems faced in research as to share good practice that can be adopted.</p>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="scientific-research-community"
+                style="scroll-margin-top: 3.5rem">Engagement with the scientific research community</h2>
+            <div class="col-6 col-medium-4">
+              <p>
+                The scientific community faces a problem, that risks becoming a crisis, of <em>reproducibility</em>. Ever-more research relies on computation, and much of it is wholly dependent on it. Despite this fact, and despite the valiant effort of software research engineers, software practices in research in general fall very far behind the standards achieved in industry.
+              </p>
+              <p>
+                Documentation plays an important role in achieving and maintaining reproducibility. Members of our documentation team have held workshops dedicated to research software documentation, and explored the context in particular research institutions. Our Practice Lead for Documentation is <a href="https://software.ac.uk/about/fellows/daniele-procida">a Fellow of the Software Sustainability Institute</a>, running a long-term project to work with researchers, as much to understand the special problems faced in research as to share good practice that can be adopted.
+              </p>
+            </div>
+          </div>
         </div>
-      </div>   
-    </main>
+      </main>
+    </div>
   </div>
-</div>
 
 {% endblock documentation_content %}
-

--- a/templates/documentation/index.html
+++ b/templates/documentation/index.html
@@ -47,143 +47,153 @@
         </div>
       </aside>
       <main class="col-9">
-        <div class="row p-block">
-          <p class="col-6 col-start-large-4 col-medium-4 col-start-medium-3"
-             id="introduction">
-            For too long in our industry, documentation has been allowed to be a secondary aspect of software development. Our approach will make documentation a core engineering concern, governed by systematic principles and requiring conscious practice, whose values inform the work not just of technical authors, but of all our engineering and product teams.
-          </p>
-        </div>
-        <hr class="p-rule" />
-        <div class="row p-block">
-          <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
-              id="documentation-as-practice"
-              style="scroll-margin-top: 3.5rem">Documentation as practice</h2>
-          <div class="col-6 col-medium-4">
-            <p>A central principle we hold is that documentation is an engineering practice, rather than an engineering task.</p>
-            <p>
-              At Canonical, engineers and product managers make real and substantial contributions to documentation, as part of their everyday work. Documentation is not a siloed activity, it's a responsibility shared by everyone who works in engineering, product or support.
-            </p>
-            <p>
-              Everyone is expected to think and care about documentation, specialists and non-specialists alike, in just the same way that quality and security are shared concerns. If you're applying to Canonical for an engineering role, don't be surprised to be asked about your work in &mdash; or your thoughts on &mdash; documentation at a job interview.
+        <div class="p-section--shallow">
+          <div class="row">
+            <p class="col-6 col-start-large-4 col-medium-4 col-start-medium-3"
+               id="introduction">
+              For too long in our industry, documentation has been allowed to be a secondary aspect of software development. Our approach will make documentation a core engineering concern, governed by systematic principles and requiring conscious practice, whose values inform the work not just of technical authors, but of all our engineering and product teams.
             </p>
           </div>
         </div>
         <hr class="p-rule" />
-        <div class="row p-block">
-          <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
-              id="documentation-with-rigour"
-              style="scroll-margin-top: 3.5rem">Documentation with rigour</h2>
-          <div class="col-6 col-medium-4">
-            <p>
-              It's a key part of our project in documentation to understand and define documentation as a rigorous discipline in software engineering, one with rules that apply generally, are derived from sound principles, and are tested in action.
-            </p>
-            <p>
-              Documentation in software deserves &mdash; but has never enjoyed &mdash; a scientific approach. We need our ideas and models to be examined and challenged, not just by us and our colleagues, but beyond Canonical too. Our models are <em>working models</em>, not the last word on the subject.
-            </p>
-            <p>
-              Documentation practitioners at Canonical are not just in the business of producing documentation &mdash; not even just the business of producing excellent documentation. They have a responsibility to advance the state of the art of documentation, and to advance documentation practice itself.
-            </p>
-            <p>
-              We work together towards this end, to define the practice of documentation. Our approach is critical, exploratory, collaborative and iterative.
-            </p>
-            <h3 class="p-heading--4">We're hiring</h3>
-            <p>
-              We're hiring technical authors to join multiple engineering teams, working on products across Canonical's portfolio.
-            </p>
-            <p>
-              <a href="/careers/3798310" class="p-button--positive">Join our team</a>
-            </p>
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="documentation-as-practice"
+                style="scroll-margin-top: 3.5rem">Documentation as practice</h2>
+            <div class="col-6 col-medium-4">
+              <p>A central principle we hold is that documentation is an engineering practice, rather than an engineering task.</p>
+              <p>
+                At Canonical, engineers and product managers make real and substantial contributions to documentation, as part of their everyday work. Documentation is not a siloed activity, it's a responsibility shared by everyone who works in engineering, product or support.
+              </p>
+              <p>
+                Everyone is expected to think and care about documentation, specialists and non-specialists alike, in just the same way that quality and security are shared concerns. If you're applying to Canonical for an engineering role, don't be surprised to be asked about your work in &mdash; or your thoughts on &mdash; documentation at a job interview.
+              </p>
+            </div>
           </div>
         </div>
         <hr class="p-rule" />
-        <div class="row p-block">
-          <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
-              id="pillars"
-              style="scroll-margin-top: 3.5rem">Four pillars</h2>
-          <div class="col-6 col-medium-4">
-            <div class="p-block">
-              <p>Our work identifies four pillars that support documentation success:</p>
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="documentation-with-rigour"
+                style="scroll-margin-top: 3.5rem">Documentation with rigour</h2>
+            <div class="col-6 col-medium-4">
+              <p>
+                It's a key part of our project in documentation to understand and define documentation as a rigorous discipline in software engineering, one with rules that apply generally, are derived from sound principles, and are tested in action.
+              </p>
+              <p>
+                Documentation in software deserves &mdash; but has never enjoyed &mdash; a scientific approach. We need our ideas and models to be examined and challenged, not just by us and our colleagues, but beyond Canonical too. Our models are <em>working models</em>, not the last word on the subject.
+              </p>
+              <p>
+                Documentation practitioners at Canonical are not just in the business of producing documentation &mdash; not even just the business of producing excellent documentation. They have a responsibility to advance the state of the art of documentation, and to advance documentation practice itself.
+              </p>
+              <p>
+                We work together towards this end, to define the practice of documentation. Our approach is critical, exploratory, collaborative and iterative.
+              </p>
+              <h3 class="p-heading--4">We're hiring</h3>
+              <p>
+                We're hiring technical authors to join multiple engineering teams, working on products across Canonical's portfolio.
+              </p>
+              <p>
+                <a href="/careers/3798310" class="p-button--positive">Join our team</a>
+              </p>
             </div>
-            <hr class="p-rule" />
-            <div class="row">
-              <div class="col-3">
-                <h3 class="p-heading--5">Direction</h3>
-              </div>
-              <div class="col-3">
-                <p>Where we want to go &mdash; the standards and quality we seek, so that documentation meets its users' needs.</p>
-              </div>
-            </div>
-            <hr class="p-rule" />
-            <div class="row">
-              <div class="col-3">
-                <h3 class="p-heading--5">Care</h3>
-              </div>
-              <div class="col-3">
-                <p>Our attitude towards documentation, and a culture of documentation discipline that makes it a living concern.</p>
-              </div>
-            </div>
-            <hr class="p-rule" />
-            <div class="row">
-              <div class="col-3">
-                <h3 class="p-heading--5">Execution</h3>
-              </div>
-              <div class="col-3">
-                <p>How we do our work, so that we consistently produce better output with less effort and more satisfaction.</p>
-              </div>
-            </div>
-            <hr class="p-rule" />
-            <div class="row">
-              <div class="col-3">
-                <h3 class="p-heading--5">Equipment</h3>
-              </div>
-              <div class="col-3">
-                <p>The tools and machinery we adopt to write, maintain and publish documentation, that serve our work best.</p>
-              </div>
-            </div>
-            <p>
-              <a href="https://ubuntu.com/blog/the-future-of-documentation-at-canonical">Read about our plan to put these pillars into place at Canonical&nbsp;&rsaquo;</a>
-            </p>
           </div>
         </div>
         <hr class="p-rule" />
-        <div class="row p-block">
-          <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
-              id="readmore"
-              style="scroll-margin-top: 3.5rem">Read more</h2>
-          <div class="col-6 col-medium-4">
-            <div class="row">
-              <div class="col-3">
-                <h3 class="p-heading--5">Diátaxis Framework</h3>
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="pillars"
+                style="scroll-margin-top: 3.5rem">Four pillars</h2>
+            <div class="col-6 col-medium-4">
+              <div class="p-section--shallow">
+                <p>Our work identifies four pillars that support documentation success:</p>
               </div>
-              <div class="col-3">
-                <p>Read more about the Diátaxis authoring framework</p>
-                <p>
-                  <a href="https://diataxis.fr/">Read more&nbsp;&rsaquo;</a>
-                </p>
+              <hr class="p-rule" />
+              <div class="row">
+                <div class="col-3">
+                  <h3 class="p-heading--5">Direction</h3>
+                </div>
+                <div class="col-3">
+                  <p>Where we want to go &mdash; the standards and quality we seek, so that documentation meets its users' needs.</p>
+                </div>
               </div>
+              <hr class="p-rule" />
+              <div class="row">
+                <div class="col-3">
+                  <h3 class="p-heading--5">Care</h3>
+                </div>
+                <div class="col-3">
+                  <p>Our attitude towards documentation, and a culture of documentation discipline that makes it a living concern.</p>
+                </div>
+              </div>
+              <hr class="p-rule" />
+              <div class="row">
+                <div class="col-3">
+                  <h3 class="p-heading--5">Execution</h3>
+                </div>
+                <div class="col-3">
+                  <p>How we do our work, so that we consistently produce better output with less effort and more satisfaction.</p>
+                </div>
+              </div>
+              <hr class="p-rule" />
+              <div class="row">
+                <div class="col-3">
+                  <h3 class="p-heading--5">Equipment</h3>
+                </div>
+                <div class="col-3">
+                  <p>The tools and machinery we adopt to write, maintain and publish documentation, that serve our work best.</p>
+                </div>
+              </div>
+              <p>
+                <a href="https://ubuntu.com/blog/the-future-of-documentation-at-canonical">Read about our plan to put these pillars into place at Canonical&nbsp;&rsaquo;</a>
+              </p>
             </div>
-            <hr class="p-rule" />
-            <div class="row">
-              <div class="col-3">
-                <h3 class="p-heading--5">Documentation articles</h3>
+          </div>
+        </div>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="readmore"
+                style="scroll-margin-top: 3.5rem">Read more</h2>
+            <div class="col-6 col-medium-4">
+              <div class="row">
+                <div class="col-3">
+                  <h3 class="p-heading--5">Diátaxis Framework</h3>
+                </div>
+                <div class="col-3">
+                  <p>Read more about the Diátaxis authoring framework</p>
+                  <p>
+                    <a href="https://diataxis.fr/">Read more&nbsp;&rsaquo;</a>
+                  </p>
+                </div>
               </div>
-              <div class="col-3">
-                <p>Read our documentation articles on the Ubuntu blog</p>
-                <p>
-                  <a href="https://ubuntu.com/blog/tag/documentation">View blog&nbsp;&rsaquo;</a>
-                </p>
+              <hr class="p-rule" />
+              <div class="row">
+                <div class="col-3">
+                  <h3 class="p-heading--5">Documentation articles</h3>
+                </div>
+                <div class="col-3">
+                  <p>Read our documentation articles on the Ubuntu blog</p>
+                  <p>
+                    <a href="https://ubuntu.com/blog/tag/documentation">View blog&nbsp;&rsaquo;</a>
+                  </p>
+                </div>
               </div>
-            </div>
-            <hr class="p-rule" />
-            <div class="row">
-              <div class="col-3">
-                <h3 class="p-heading--5">Careers at Canonical</h3>
-              </div>
-              <div class="col-3">
-                <p>Take a look at our open roles here at Canonical</p>
-                <p>
-                  <a href="/careers/all?search=%22Technical+Author%22">See roles&nbsp;&rsaquo;</a>
-                </p>
+              <hr class="p-rule" />
+              <div class="row">
+                <div class="col-3">
+                  <h3 class="p-heading--5">Careers at Canonical</h3>
+                </div>
+                <div class="col-3">
+                  <p>Take a look at our open roles here at Canonical</p>
+                  <p>
+                    <a href="/careers/all?search=%22Technical+Author%22">See roles&nbsp;&rsaquo;</a>
+                  </p>
+                </div>
               </div>
             </div>
           </div>

--- a/templates/documentation/open-documentation-academy.html
+++ b/templates/documentation/open-documentation-academy.html
@@ -4,122 +4,183 @@
 
 {% block title %}Documentation Practice - Open Documentation Academy{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1nhy653-SOfTmGCIiSZHuGBCrwZlzEZJaA4kFBsw-5dc/edit{% endblock %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1nhy653-SOfTmGCIiSZHuGBCrwZlzEZJaA4kFBsw-5dc/edit
+{% endblock %}
 
-{% block meta_description %}At Canonical, we aim to set a standard of excellence in technical documentation, by treating it as a professional discipline within our engineering practice.{% endblock %}
+{% block meta_description %}
+  At Canonical, we aim to set a standard of excellence in technical documentation, by treating it as a professional discipline within our engineering practice.
+{% endblock %}
 
 {% block meta_image %}https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg{% endblock %}
 
 {% block documentation_content %}
-<section class="p-strip u-no-padding--top">
-  <div class="row" id="documentation">
-    <aside class="col-3">
-      <div class="p-side-navigation--raw-html is-sticky" id="drawer">
-        <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
-          Toggle side navigation
-        </button>
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-        <nav class="p-side-navigation__drawer" aria-label="documentation side navigation">
-          <div class="p-side-navigation__drawer-header">
-            <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
-              Toggle table of contents
-            </button>
+  <section class="p-strip u-no-padding--top">
+    <div class="row" id="documentation">
+      <aside class="col-3">
+        <div class="p-side-navigation--raw-html is-sticky" id="drawer">
+          <button class="p-side-navigation__toggle js-drawer-toggle"
+                  aria-controls="drawer">Toggle side navigation</button>
+          <div class="p-side-navigation__overlay js-drawer-toggle"
+               aria-controls="drawer"></div>
+          <nav class="p-side-navigation__drawer"
+               aria-label="documentation side navigation">
+            <div class="p-side-navigation__drawer-header">
+              <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle"
+                      aria-controls="drawer">Toggle table of contents</button>
+            </div>
+            <ul>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#get-out-of-it">What you'll get out of it</a>
+              </li>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#what-we-offer">What we offer</a>
+              </li>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#what-you-will-do">What you will do</a>
+              </li>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#activities">Activities</a>
+              </li>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#stay-in-touch">Stay in touch</a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </aside>
+      <main class="col-9">
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4"
+                style="scroll-margin-top: 3.5rem">Open Documentation Academy</h2>
+            <div class="col-6 col-medium-4">
+              <p class="p-heading--5">Learn open-source software documentation skills with Canonical</p>
+              <p>
+                The Open Documentation Academy combines Canonical's documentation team with documentation newcomers, experts, and those in-between, to help us all improve documentation practice and become better writers.
+              </p>
+              <p>
+                If you're a newcomer, we can provide help, advice, mentorship, and a hundred different tasks to get started on. If you're an expert, we want to create a place to share knowledge, a place to get involved with new developments, and somewhere you can ask for help on your own projects.
+              </p>
+              <p>
+                A key aim of this initiative is to help lower the barrier into successful open-source software contribution, by making documentation into the gateway.
+              </p>
+              <hr class="p-rule--muted" />
+              <a class="p-button--positive"
+                 href="https://discourse.ubuntu.com/c/open-documentation-academy/166">Join the Academy</a>
+            </div>
           </div>
-          <ul>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#get-out-of-it">What you'll get out of it</a>
-            </li>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#what-we-offer">What we offer</a>
-            </li>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#what-you-will-do">What you will do</a>
-            </li>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#activities">Activities</a>
-            </li>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#stay-in-touch">Stay in touch</a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </aside>
-    <main class="col-9">
-      <div class="row p-block">
-        <h2 class="col-3 col-medium-2 p-heading--4" style="scroll-margin-top: 3.5rem;">Open Documentation Academy</h2>
-        <div class="col-6 col-medium-4">
-          <p class="p-heading--5">Learn open-source software documentation skills with Canonical</p>
-          <p>The Open Documentation Academy combines Canonical's documentation team with documentation newcomers, experts, and those in-between, to help us all improve documentation practice and become better writers.</p>
-          <p>If you're a newcomer, we can provide help, advice, mentorship, and a hundred different tasks to get started on. If you're an expert, we want to create a place to share knowledge, a place to get involved with new developments, and somewhere you can ask for help on your own projects.</p>
-          <p>A key aim of this initiative is to help lower the barrier into successful open-source software contribution, by making documentation into the gateway.</p>
-          <hr class="p-rule--muted" />
-          <a class="p-button--positive" href="https://discourse.ubuntu.com/c/open-documentation-academy/166">Join the Academy</a>
         </div>
-      </div>
-      <hr class="p-rule" />
-      <div class="row p-block">
-        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="get-out-of-it" style="scroll-margin-top: 3.5rem;">What you'll get out of it</h2>
-        <div class="col-6 col-medium-4">
-          <p><strong>Real experience, real skills, real discipline</strong>: Open-source products in the Canonical/Ubuntu industry are highly-respected and used by millions of people. Standards for contributions are high. You'll have a chance to contribute to prestigious projects, and acquire the skills to take part in the development of world-class software.</p>
-          <p><strong>Structured support</strong>: The Open Documentation Academy will include a structured programme of support and development for serious participants, taking them from their first steps to having the confidence to lead their own documentation initiatives.</p>
-          <p><strong>Recognition</strong>: Your contributions will speak for themselves, but we'll vouch for you too. Participants who complete our programme will receive certification from Canonical.</p>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="get-out-of-it"
+                style="scroll-margin-top: 3.5rem">What you'll get out of it</h2>
+            <div class="col-6 col-medium-4">
+              <p>
+                <strong>Real experience, real skills, real discipline</strong>: Open-source products in the Canonical/Ubuntu industry are highly-respected and used by millions of people. Standards for contributions are high. You'll have a chance to contribute to prestigious projects, and acquire the skills to take part in the development of world-class software.
+              </p>
+              <p>
+                <strong>Structured support</strong>: The Open Documentation Academy will include a structured programme of support and development for serious participants, taking them from their first steps to having the confidence to lead their own documentation initiatives.
+              </p>
+              <p>
+                <strong>Recognition</strong>: Your contributions will speak for themselves, but we'll vouch for you too. Participants who complete our programme will receive certification from Canonical.
+              </p>
+            </div>
+          </div>
         </div>
-      </div>
-      <hr class="p-rule" />
-      <div class="row p-block">
-        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="what-we-offer" style="scroll-margin-top: 3.5rem;">What we offer</h2>
-        <div class="col-6 col-medium-4">
-          <p><strong>Mentoring</strong>: You are not alone. Regardless of whether you're writing your first document, or editing your hundredth, we're here to help. Our 1:1 mentorship can help you through your first contributions, provide advice on approaches, and help you build your confidence.</p>
-          <p><strong>Guided contributions</strong>: Help us identify gaps, nominate solutions, and propose documentation of your own. We curate tasks across a variety of different open source projects. Choose a task you're interested in, at a level you're comfortable with, and make a contribution. Research. Write. Commit. Fill blanks in your resume and colour your GitHub Activity tracker golden.</p>
-          <p><strong>Community</strong>: Through our forum and communication channels, you can directly interact with documentation teams and co-conspirators across the globe. We want our community to be friendly, inclusive and always supremely approachable, in accordance with the Ubuntu Code of Conduct.</p>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="what-we-offer"
+                style="scroll-margin-top: 3.5rem">What we offer</h2>
+            <div class="col-6 col-medium-4">
+              <p>
+                <strong>Mentoring</strong>: You are not alone. Regardless of whether you're writing your first document, or editing your hundredth, we're here to help. Our 1:1 mentorship can help you through your first contributions, provide advice on approaches, and help you build your confidence.
+              </p>
+              <p>
+                <strong>Guided contributions</strong>: Help us identify gaps, nominate solutions, and propose documentation of your own. We curate tasks across a variety of different open source projects. Choose a task you're interested in, at a level you're comfortable with, and make a contribution. Research. Write. Commit. Fill blanks in your resume and colour your GitHub Activity tracker golden.
+              </p>
+              <p>
+                <strong>Community</strong>: Through our forum and communication channels, you can directly interact with documentation teams and co-conspirators across the globe. We want our community to be friendly, inclusive and always supremely approachable, in accordance with the Ubuntu Code of Conduct.
+              </p>
+            </div>
+          </div>
         </div>
-      </div>
-      <hr class="p-rule" />
-      <div class="row p-block">
-        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="what-you-will-do" style="scroll-margin-top: 3.5rem;">What you will do</h2>
-        <div class="col-6 col-medium-4">
-          <ul class="p-list--divided">
-            <li class="p-list__item">Participate in our forum, and join our Office Hours discussions</li>
-            <li class="p-list__item">Reach out to our team of mentors, let them know you're interested</li>
-            <li class="p-list__item">Find a project that excites you, and make your first contributions</li>
-          </ul>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="what-you-will-do"
+                style="scroll-margin-top: 3.5rem">What you will do</h2>
+            <div class="col-6 col-medium-4">
+              <ul class="p-list--divided">
+                <li class="p-list__item">Participate in our forum, and join our Office Hours discussions</li>
+                <li class="p-list__item">Reach out to our team of mentors, let them know you're interested</li>
+                <li class="p-list__item">Find a project that excites you, and make your first contributions</li>
+              </ul>
+            </div>
+          </div>
         </div>
-      </div>
-      <hr class="p-rule" />
-      <div class="row p-block">
-        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="activities" style="scroll-margin-top: 3.5rem;">Activities</h2>
-        <div class="col-6 col-medium-4">
-          <p><strong>Podcast</strong>: Take a well-earned tea-break and join our virtual documentation chatter. We record and publish the Open Documentation Academy podcast every other week. Each episode is a fun and fanatical chat about documentation, from process and personas to publishing and personality conflicts.</p>
-	  <p><strong>Weekly Office Hours</strong>: <a href="https://discourse.ubuntu.com/t/documentation-office-hours/42771">Every Friday</a>, join us for interactive discussions about tricky documentation problems and help us to improve documents together. This is the place to solicit feedback from the team, and to share your docs struggles and accomplishments. Everyone is welcome, whether you participate or prefer to listen.</p>
-          <p><strong>Events</strong>: We're planning to host both online and in-person events enabling us all to target specific objectives together. These targets may include improving sets of documentation, creating guides and tutorials, or just discussing and agreeing on a style guide.</p>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="activities"
+                style="scroll-margin-top: 3.5rem">Activities</h2>
+            <div class="col-6 col-medium-4">
+              <p>
+                <strong>Podcast</strong>: Take a well-earned tea-break and join our virtual documentation chatter. We record and publish the Open Documentation Academy podcast every other week. Each episode is a fun and fanatical chat about documentation, from process and personas to publishing and personality conflicts.
+              </p>
+              <p>
+                <strong>Weekly Office Hours</strong>: <a href="https://discourse.ubuntu.com/t/documentation-office-hours/42771">Every Friday</a>, join us for interactive discussions about tricky documentation problems and help us to improve documents together. This is the place to solicit feedback from the team, and to share your docs struggles and accomplishments. Everyone is welcome, whether you participate or prefer to listen.
+              </p>
+              <p>
+                <strong>Events</strong>: We're planning to host both online and in-person events enabling us all to target specific objectives together. These targets may include improving sets of documentation, creating guides and tutorials, or just discussing and agreeing on a style guide.
+              </p>
+            </div>
+          </div>
         </div>
-      </div>
-      <hr class="p-rule" />
-      <div class="row p-block">
-        <h2 class="col-3 col-medium-2 p-heading--4 question-heading" id="stay-in-touch" style="scroll-margin-top: 3.5rem;">Stay in touch</h2>
-        <div class="col-6 col-medium-4">
-          <ul class="p-list--divided">
-            <li class="p-list__item">Subscribe to our calendar: <a href="https://calendar.google.com/calendar/u/0?cid=Y19mYTY4YzE5YWEwY2Y4YWE1ZWNkNzMyNjZmNmM0ZDllOTRhNTIwNTNjODc1ZjM2ZmQ3Y2MwNTQ0MzliOTIzZjMzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20">Open Documentation Academy events</a></li>
-            <li class="p-list__item"><a href="https://matrix.to/#/#documentation:ubuntu.com">Chat to us on Matrix</a></li>
-            <li class="p-list__item"><a href="https://discourse.ubuntu.com/c/open-documentation-academy">Join our discussion forum on the Ubuntu Community Hub</a></li>
-            <li class="p-list__item"><a href="https://fosstodon.org/@CanonicalDocumentation">Follow our progress online through Mastodon</a></li>
-            <li class="p-list__item">Email our academy leadership team directly: <a href="mailto:docsacademy@canonical.com">docsacademy@canonical.com</a></li>
-          </ul>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="stay-in-touch"
+                style="scroll-margin-top: 3.5rem">Stay in touch</h2>
+            <div class="col-6 col-medium-4">
+              <ul class="p-list--divided">
+                <li class="p-list__item">
+                  Subscribe to our calendar: <a href="https://calendar.google.com/calendar/u/0?cid=Y19mYTY4YzE5YWEwY2Y4YWE1ZWNkNzMyNjZmNmM0ZDllOTRhNTIwNTNjODc1ZjM2ZmQ3Y2MwNTQ0MzliOTIzZjMzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20">Open Documentation Academy events</a>
+                </li>
+                <li class="p-list__item">
+                  <a href="https://matrix.to/#/#documentation:ubuntu.com">Chat to us on Matrix</a>
+                </li>
+                <li class="p-list__item">
+                  <a href="https://discourse.ubuntu.com/c/open-documentation-academy">Join our discussion forum on the Ubuntu Community Hub</a>
+                </li>
+                <li class="p-list__item">
+                  <a href="https://fosstodon.org/@CanonicalDocumentation">Follow our progress online through Mastodon</a>
+                </li>
+                <li class="p-list__item">
+                  Email our academy leadership team directly: <a href="mailto:docsacademy@canonical.com">docsacademy@canonical.com</a>
+                </li>
+              </ul>
+            </div>
+          </div>
         </div>
-      </div>
-    </main>
-  </div>
-</section>
+      </main>
+    </div>
+  </section>
 
-<section class="u-fixed-width">
-  <hr class="p-rule" />
-  <div class="p-strip is-deep">
-    <h2>
-      <a href="https://discourse.ubuntu.com/c/open-documentation-academy/166">Join the Academy&nbsp;&rsaquo;</a>
-    </h2>
-  </div>
-</section>
+  <section class="u-fixed-width">
+    <hr class="p-rule" />
+    <div class="p-strip is-deep">
+      <h2>
+        <a href="https://discourse.ubuntu.com/c/open-documentation-academy/166">Join the Academy&nbsp;&rsaquo;</a>
+      </h2>
+    </div>
+  </section>
 
 {% endblock documentation_content %}
-

--- a/templates/documentation/work-and-careers.html
+++ b/templates/documentation/work-and-careers.html
@@ -44,190 +44,200 @@
         </div>
       </aside>
       <main class="col-9">
-        <div class="row p-block">
-          <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
-              id="introduction"
-              style="scroll-margin-top: 3.5rem">Working in documentation at Canonical</h2>
-          <div class="col-6 col-medium-4">
-            <p>
-              We are hiring now for <a href="/careers/3798310/technical-author-ubuntu-and-canonical-products-remote">Technical Authors</a> and individuals at various levels of experience and seniority. They will be placed in multiple different teams to work on software and products of all kinds.
-            </p>
-            <p>
-              <a href="/careers/3798310" class="p-button--positive">Join our team</a>
-            </p>
-          </div>
-        </div>
-        <hr class="p-rule" />
-        <div class="row p-block">
-          <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
-              id="being-a-technical-author"
-              style="scroll-margin-top: 3.5rem">Being a Canonical Technical Author</h2>
-          <div class="col-6 col-medium-4">
-            <p>A candidate for a Canonical Technical author role:</p>
-            <ul class="p-list--divided">
-              <li class="p-list__item has-bullet">
-                has and uses programming skills &mdash; they might not be an engineer, but programming is amongst the things they can do
-              </li>
-              <li class="p-list__item has-bullet">
-                creates documentation that's part of a product, whether it's a proprietary or open-source, professional or personal
-              </li>
-              <li class="p-list__item has-bullet">engages with the software and the development process as part of their work</li>
-              <li class="p-list__item has-bullet">thinks about and puzzles over the problems of documentation</li>
-            </ul>
-            <p>If that sounds like you &mdash; maybe you're ready to join our team.</p>
-          </div>
-        </div>
-        <hr class="p-rule" />
-        <div class="row p-block">
-          <h2 class="col-3 col-medium-2 p-heading--4">What is a Technical Author, exactly?</h2>
-          <div class="col-6 col-medium-4">
-            <p>
-              In some software organisations, the work of documentation specialists &ndash; is to produce documentation. They receive explanations and descriptions of software from their engineering colleagues, and turn those into polished output. They are expert technical <em>writers</em>.
-            </p>
-            <p>
-              Our documentation specialists have a different role. They are technical <em>authors</em>, members of our engineering teams. They are called Technical Authors because they have  technical authority: they know their products in depth, and are part of the software development process.
-            </p>
-            <p>
-              A Technical Author's work shapes the way our products are conceived and presented. Amongst other things, it's reflective, critical, active and creative. It's work that feeds back into the product itself, and helps define what it is, and always seeks new and better ways to add to its value.
-            </p>
-            <p>
-              Our Technical Authors come from many backgrounds, including academic research, software engineering and journalism. What they have in common is that they are expert, effective communicators. They share an intense sense of technical curiosity, and a strong feeling for the perspective of a product's users. Their strength of imagination and qualities of empathy are crucial to their work.
-            </p>
-            <p>
-              Documentation is something that everyone contributes to; Technical Authors encourage and lead documentation work, and help guarantee its quality.
-            </p>
-          </div>
-        </div>
-        <hr class="p-rule" />
-        <div class="row p-block">
-          <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
-              id="in-the-documentation-team">In the documentation team</h2>
-          <div class="col-2 col-medium-1">
-            <div class="p-image-wrapper">
-              <img src="https://assets.ubuntu.com/v1/f75f5612-tmihoc-photo.jpg" alt="" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="introduction"
+                style="scroll-margin-top: 3.5rem">Working in documentation at Canonical</h2>
+            <div class="col-6 col-medium-4">
+              <p>
+                We are hiring now for <a href="/careers/3798310/technical-author-ubuntu-and-canonical-products-remote">Technical Authors</a> and individuals at various levels of experience and seniority. They will be placed in multiple different teams to work on software and products of all kinds.
+              </p>
+              <p>
+                <a href="/careers/3798310" class="p-button--positive">Join our team</a>
+              </p>
             </div>
-            <p class="p-heading--5 u-no-margin--bottom u-sv-1">Teodora Mihoc</p>
-            <p class="p-muted-heading">Technical Author (Juju)</p>
-          </div>
-          <div class="col-4 col-medium-3">
-            <p class="p-media-object__content">Before joining Canonical, I spent 10 years of my life doing linguistics.</p>
-            <p class="p-media-object__content">
-              My favourite thing about that was semantics and pragmatics, and my favourite thing about that was building unified theories, in a spirit of amiable free inquiry.
-            </p>
-            <p class="p-media-object__content">
-              I get the same pleasure in creating new knowledge and systematically, collaboratively, pursuing order in my work as a technical author for <a href="https://juju.is/">Juju</a> at Canonical.
-            </p>
-            <p class="p-media-object__content">
-              The subject matter is, of course, very different. But in every other way the challenge is delightfully the same: to understand the puzzle; find the solution; and repeat - until it all makes sense in an ever bigger scheme of things.
-            </p>
-          </div>
-          <div class="col-6 col-start-large-4 col-medium-4 col-start-medium-3">
-            <hr class="p-rule" />
-          </div>
-          <div class="col-2 col-start-large-4 col-medium-1 col-start-medium-3">
-            <div class="p-image-wrapper">
-              <img src="https://assets.ubuntu.com/v1/7e32a5b7-Daniele-Procida.png"
-                   alt="" />
-            </div>
-            <p class="p-heading--5 u-no-margin--bottom u-sv-1">Daniele Procida</p>
-            <p class="p-muted-heading">Director of Engineering</p>
-          </div>
-          <div class="col-4 col-medium-3">
-            <p class="p-media-object__content">
-              I lead Documentation Practice throughout Canonical, from long-term strategy to guiding our activities, processes and objectives along the way.
-            </p>
-            <p class="p-media-object__content">
-              I get to work closely with a team of talented, thoughtful and disciplined authors, whose own leadership in documentation is helping transform the way the entire organisation thinks about process and the product.
-            </p>
-            <p class="p-media-object__content">
-              I've been a long-term participant in open-source software projects and communities, notably Python and Django, and in the growing pan-African open-source software movement.
-            </p>
-            <p class="p-media-object__content">
-              At Canonical, I have the privilege of working in an organisation that itself works right at the heart of open-source software, and is committed to attaining excellence in documentation.
-            </p>
           </div>
         </div>
         <hr class="p-rule" />
-        <div class="row p-block">
-          <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
-              id="how-we-hire"
-              style="scroll-margin-top: 3.5rem">How we hire</h2>
-          <div class="col-6 col-medium-4">
-            <p>
-              We have a rigorous hiring process for Technical Authors. Once your application is processed, you will be invited to complete a written interview, covering numerous aspects of your career, work in and thoughts on documentation and your education. Stages along the way include:
-            </p>
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="being-a-technical-author"
+                style="scroll-margin-top: 3.5rem">Being a Canonical Technical Author</h2>
+            <div class="col-6 col-medium-4">
+              <p>A candidate for a Canonical Technical author role:</p>
+              <ul class="p-list--divided">
+                <li class="p-list__item has-bullet">
+                  has and uses programming skills &mdash; they might not be an engineer, but programming is amongst the things they can do
+                </li>
+                <li class="p-list__item has-bullet">
+                  creates documentation that's part of a product, whether it's a proprietary or open-source, professional or personal
+                </li>
+                <li class="p-list__item has-bullet">engages with the software and the development process as part of their work</li>
+                <li class="p-list__item has-bullet">thinks about and puzzles over the problems of documentation</li>
+              </ul>
+              <p>If that sounds like you &mdash; maybe you're ready to join our team.</p>
+            </div>
           </div>
-          <div class="col-9 col-medium-6">
-            <hr class="p-rule" />
+        </div>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4">What is a Technical Author, exactly?</h2>
+            <div class="col-6 col-medium-4">
+              <p>
+                In some software organisations, the work of documentation specialists &ndash; is to produce documentation. They receive explanations and descriptions of software from their engineering colleagues, and turn those into polished output. They are expert technical <em>writers</em>.
+              </p>
+              <p>
+                Our documentation specialists have a different role. They are technical <em>authors</em>, members of our engineering teams. They are called Technical Authors because they have  technical authority: they know their products in depth, and are part of the software development process.
+              </p>
+              <p>
+                A Technical Author's work shapes the way our products are conceived and presented. Amongst other things, it's reflective, critical, active and creative. It's work that feeds back into the product itself, and helps define what it is, and always seeks new and better ways to add to its value.
+              </p>
+              <p>
+                Our Technical Authors come from many backgrounds, including academic research, software engineering and journalism. What they have in common is that they are expert, effective communicators. They share an intense sense of technical curiosity, and a strong feeling for the perspective of a product's users. Their strength of imagination and qualities of empathy are crucial to their work.
+              </p>
+              <p>
+                Documentation is something that everyone contributes to; Technical Authors encourage and lead documentation work, and help guarantee its quality.
+              </p>
+            </div>
           </div>
-          <h3 class="col-3 col-medium-2 p-heading--5">Written interview</h3>
-          <div class="col-6 col-medium-4">
-            <p>
-              The written interview is an important part of the process. It's reviewed - anonymously, in an effort to remove bias - by multiple members of the team.
-            </p>
-            <p>
-              This has several benefits. One is that in-person interviews are stressful experiences, while a written interview gives you all the time you need to gather your thoughts and put them together in a way that presents you at your best. It's a good opportunity to say things that might not otherwise come up later.
-            </p>
-            <p>
-              It's also excellent preparation for the interviews that will come. We want to see your best, and for you to be prepared for them. And we want them to be a good experience for you too.
-            </p>
-            <p>
-              Our written interviews are used by all the future in-person interviewers you'll meet. When you do meet them, they'll already have had a good introduction to you, so that you don't need to repeat the same stories and explanations to multiple people.
-            </p>
+        </div>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="in-the-documentation-team">In the documentation team</h2>
+            <div class="col-2 col-medium-1">
+              <div class="p-image-wrapper">
+                <img src="https://assets.ubuntu.com/v1/f75f5612-tmihoc-photo.jpg" alt="" />
+              </div>
+              <p class="p-heading--5 u-no-margin--bottom u-sv-1">Teodora Mihoc</p>
+              <p class="p-muted-heading">Technical Author (Juju)</p>
+            </div>
+            <div class="col-4 col-medium-3">
+              <p class="p-media-object__content">Before joining Canonical, I spent 10 years of my life doing linguistics.</p>
+              <p class="p-media-object__content">
+                My favourite thing about that was semantics and pragmatics, and my favourite thing about that was building unified theories, in a spirit of amiable free inquiry.
+              </p>
+              <p class="p-media-object__content">
+                I get the same pleasure in creating new knowledge and systematically, collaboratively, pursuing order in my work as a technical author for <a href="https://juju.is/">Juju</a> at Canonical.
+              </p>
+              <p class="p-media-object__content">
+                The subject matter is, of course, very different. But in every other way the challenge is delightfully the same: to understand the puzzle; find the solution; and repeat - until it all makes sense in an ever bigger scheme of things.
+              </p>
+            </div>
+            <div class="col-6 col-start-large-4 col-medium-4 col-start-medium-3">
+              <hr class="p-rule" />
+            </div>
+            <div class="col-2 col-start-large-4 col-medium-1 col-start-medium-3">
+              <div class="p-image-wrapper">
+                <img src="https://assets.ubuntu.com/v1/7e32a5b7-Daniele-Procida.png"
+                     alt="" />
+              </div>
+              <p class="p-heading--5 u-no-margin--bottom u-sv-1">Daniele Procida</p>
+              <p class="p-muted-heading">Director of Engineering</p>
+            </div>
+            <div class="col-4 col-medium-3">
+              <p class="p-media-object__content">
+                I lead Documentation Practice throughout Canonical, from long-term strategy to guiding our activities, processes and objectives along the way.
+              </p>
+              <p class="p-media-object__content">
+                I get to work closely with a team of talented, thoughtful and disciplined authors, whose own leadership in documentation is helping transform the way the entire organisation thinks about process and the product.
+              </p>
+              <p class="p-media-object__content">
+                I've been a long-term participant in open-source software projects and communities, notably Python and Django, and in the growing pan-African open-source software movement.
+              </p>
+              <p class="p-media-object__content">
+                At Canonical, I have the privilege of working in an organisation that itself works right at the heart of open-source software, and is committed to attaining excellence in documentation.
+              </p>
+            </div>
           </div>
-          <div class="col-9 col-medium-6">
-            <hr class="p-rule" />
-          </div>
-          <h3 class="col-3 col-medium-2 p-heading--5">Peer interviews</h3>
-          <div class="col-6 col-medium-4">
-            <p>Candidates who progress will face up to three interviews with Technical Author peers, covering:</p>
-            <ul class="p-list--divided">
-              <li class="p-list__item has-bullet">
-                <em>Skills and experience</em>: What have you done? What do you know? What can you do?
-              </li>
-              <li class="p-list__item has-bullet">
-                <em>Insight and understanding</em>: How do you think about documentation and its challenges? What ideas have you formed, about practice, process and product? How deep is your thinking?
-              </li>
-              <li class="p-list__item has-bullet">
-                <em>Culture and value</em>: What drives you and what values underpin your work? How do you collaborate? How will you fit in with our values, and how will you challenge us to do better?
-              </li>
-            </ul>
-          </div>
-          <div class="col-9 col-medium-6">
-            <hr class="p-rule" />
-          </div>
-          <h3 class="col-3 col-medium-2 p-heading--5">Talent interview</h3>
-          <div class="col-6 col-medium-4">
-            <p>
-              Next is an interview with someone from our Talent Acquisition team, that looks back at your career, discusses how you work and want to work, and considers questions like salary, availability to start and so on.
-            </p>
-          </div>
-          <div class="col-9 col-medium-6">
-            <hr class="p-rule" />
-          </div>
-          <h3 class="col-3 col-medium-2 p-heading--5">Technical exercise</h3>
-          <div class="col-6 col-medium-4">
-            <p>
-              Not strictly an interview, but an opportunity to demonstrate your ability to think through and solve documentation problems (and it's not a writing test; we already know you can write). We want to see how you approach issues such as meeting user needs and documentation structure, and your analytical and critical skills.
-            </p>
-          </div>
-          <div class="col-9 col-medium-6">
-            <hr class="p-rule" />
-          </div>
-          <h3 class="col-3 col-medium-2 p-heading--5">Documentation lead interview</h3>
-          <div class="col-6 col-medium-4">
-            <p>
-              An interview to confirm our assessments and work out the next steps, based on your interests, skills and experience. This will help us arrange interviews with appropriate hiring managers in different teams.
-            </p>
-          </div>
-          <div class="col-9 col-medium-6">
-            <hr class="p-rule" />
-          </div>
-          <h3 class="col-3 col-medium-2 p-heading--5">Hiring manager interviews</h3>
-          <div class="col-6 col-medium-4">
-            <p>
-              By this stage, we'd like to have you as a Technical Author at Canonical, and now it's a question of finding the right team or project for you, where both we and you feel that you'll be excited by the technology and in a strong position to make a valuable contribution.
-            </p>
+        </div>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <h2 class="col-3 col-medium-2 p-heading--4 question-heading"
+                id="how-we-hire"
+                style="scroll-margin-top: 3.5rem">How we hire</h2>
+            <div class="col-6 col-medium-4">
+              <p>
+                We have a rigorous hiring process for Technical Authors. Once your application is processed, you will be invited to complete a written interview, covering numerous aspects of your career, work in and thoughts on documentation and your education. Stages along the way include:
+              </p>
+            </div>
+            <div class="col-9 col-medium-6">
+              <hr class="p-rule" />
+            </div>
+            <h3 class="col-3 col-medium-2 p-heading--5">Written interview</h3>
+            <div class="col-6 col-medium-4">
+              <p>
+                The written interview is an important part of the process. It's reviewed - anonymously, in an effort to remove bias - by multiple members of the team.
+              </p>
+              <p>
+                This has several benefits. One is that in-person interviews are stressful experiences, while a written interview gives you all the time you need to gather your thoughts and put them together in a way that presents you at your best. It's a good opportunity to say things that might not otherwise come up later.
+              </p>
+              <p>
+                It's also excellent preparation for the interviews that will come. We want to see your best, and for you to be prepared for them. And we want them to be a good experience for you too.
+              </p>
+              <p>
+                Our written interviews are used by all the future in-person interviewers you'll meet. When you do meet them, they'll already have had a good introduction to you, so that you don't need to repeat the same stories and explanations to multiple people.
+              </p>
+            </div>
+            <div class="col-9 col-medium-6">
+              <hr class="p-rule" />
+            </div>
+            <h3 class="col-3 col-medium-2 p-heading--5">Peer interviews</h3>
+            <div class="col-6 col-medium-4">
+              <p>Candidates who progress will face up to three interviews with Technical Author peers, covering:</p>
+              <ul class="p-list--divided">
+                <li class="p-list__item has-bullet">
+                  <em>Skills and experience</em>: What have you done? What do you know? What can you do?
+                </li>
+                <li class="p-list__item has-bullet">
+                  <em>Insight and understanding</em>: How do you think about documentation and its challenges? What ideas have you formed, about practice, process and product? How deep is your thinking?
+                </li>
+                <li class="p-list__item has-bullet">
+                  <em>Culture and value</em>: What drives you and what values underpin your work? How do you collaborate? How will you fit in with our values, and how will you challenge us to do better?
+                </li>
+              </ul>
+            </div>
+            <div class="col-9 col-medium-6">
+              <hr class="p-rule" />
+            </div>
+            <h3 class="col-3 col-medium-2 p-heading--5">Talent interview</h3>
+            <div class="col-6 col-medium-4">
+              <p>
+                Next is an interview with someone from our Talent Acquisition team, that looks back at your career, discusses how you work and want to work, and considers questions like salary, availability to start and so on.
+              </p>
+            </div>
+            <div class="col-9 col-medium-6">
+              <hr class="p-rule" />
+            </div>
+            <h3 class="col-3 col-medium-2 p-heading--5">Technical exercise</h3>
+            <div class="col-6 col-medium-4">
+              <p>
+                Not strictly an interview, but an opportunity to demonstrate your ability to think through and solve documentation problems (and it's not a writing test; we already know you can write). We want to see how you approach issues such as meeting user needs and documentation structure, and your analytical and critical skills.
+              </p>
+            </div>
+            <div class="col-9 col-medium-6">
+              <hr class="p-rule" />
+            </div>
+            <h3 class="col-3 col-medium-2 p-heading--5">Documentation lead interview</h3>
+            <div class="col-6 col-medium-4">
+              <p>
+                An interview to confirm our assessments and work out the next steps, based on your interests, skills and experience. This will help us arrange interviews with appropriate hiring managers in different teams.
+              </p>
+            </div>
+            <div class="col-9 col-medium-6">
+              <hr class="p-rule" />
+            </div>
+            <h3 class="col-3 col-medium-2 p-heading--5">Hiring manager interviews</h3>
+            <div class="col-6 col-medium-4">
+              <p>
+                By this stage, we'd like to have you as a Technical Author at Canonical, and now it's a question of finding the right team or project for you, where both we and you feel that you'll be excited by the technology and in a strong position to make a valuable contribution.
+              </p>
+            </div>
           </div>
         </div>
         <p>That is indeed a lot of interviews. It's an in-depth process for an exacting role and we take it very seriously.</p>

--- a/templates/partial/_careers_navigation.html
+++ b/templates/partial/_careers_navigation.html
@@ -176,7 +176,7 @@
 					<h4 class="p-muted-heading muted-color">Working here</h4>
 				</div>
 				<hr class="p-rule--muted is-dark" />
-				<div class="p-block">
+				<div class="p-section--shallow">
 					<p><a class="p-link is-dark" href="/careers/company-culture">Company culture</a></p>
 					<p><a class="p-link is-dark" href="/careers/company-culture/remote-work">Remote work</a></p>
 					<p><a class="p-link is-dark" href="/careers/company-culture/progression">Progression</a></p>


### PR DESCRIPTION
_Note: There are 20+ files where this needs to be done, I'm splitting them up into separate prs so that it's easier to review_

## Done

- Replaced deprecated `p-block` class with it's current equivalent `p-section--shallow`
- Removed misused class combinations eg `p-section u-no-padding--top`
- Ran djlint where needed

## QA

- Check the following pages against prod and see that there are no visual changes: 
- [ ] https://canonical-com-1523.demos.haus/blog
- [ ] https://canonical-com-1523.demos.haus/blog/sifive-eswin-computing-and-canonical-announce-availability-of-ubuntu-on-the-hifive-premier-p550 (or any other blog)
- [ ] https://canonical-com-1523.demos.haus/careers
- [ ] https://canonical-com-1523.demos.haus/careers/company-culture/remote-work
- [ ] https://canonical-com-1523.demos.haus/careers/engineering (or any careers page)
- [ ] https://canonical-com-1523.demos.haus/documentation (all tabs)
- [ ] https://canonical-com-1523.demos.haus/contact-us

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14226
