### PR TITLE
upgrade flask-base to enable assets compression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask-base==2.0.0
+canonicalwebteam.flask-base==2.1.0
 canonicalwebteam.blog==6.4.4
 canonicalwebteam.http==1.0.4
 canonicalwebteam.image-template==1.3.1

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -75,7 +75,7 @@
 
           {% set current_path = url_for(request.endpoint, **request.view_args) %}
           {% if "/careers" in current_path %}
-            <script src="https://www.google.com/recaptcha/enterprise.js?render={{ recaptcha_site_key }}"></script>
+            <script src="https://www.google.com/recaptcha/enterprise.js?render={{ recaptcha_site_key }}" defer></script>
             <meta name="twitter:image"
                   content="https://assets.ubuntu.com/v1/c17ef7b4-careers-meta-image-resized.png" />
             <meta property="og:image"

--- a/templates/index.html
+++ b/templates/index.html
@@ -724,6 +724,7 @@ meta_copydoc %}
                                 width="520",
                                 height="948",
                                 hi_def=True,
+                                loading="lazy",
                                 attrs={"class": "p-logo-section__logo"}) | safe
                 }}
               </div>
@@ -826,6 +827,6 @@ meta_copydoc %}
     {% include "partners/partial/_homepage-form.html" %}
   {% endwith %}
 
-  <script src="{{ versioned_static('js/tabbed-content.js') }}"></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
 
 {% endblock %}

--- a/templates/navigation/partials/_preview-links.html
+++ b/templates/navigation/partials/_preview-links.html
@@ -8,7 +8,7 @@
         <a class="p-link--inverted p-navigation__preview-link"
            href="{{ link.url }}">
           <div class="p-navigation__preview-link--image">
-            <img src="{{ link.image_url }}" alt="" />
+            <img src="{{ link.image_url }}" alt="" loading="lazy" />
           </div>
           <p class="p-navigation__preview-link--description">{{ link.description }}</p>
         </a>


### PR DESCRIPTION
## Done

Improve performance of the website loading via:
- upgrading version of the canonicalwebteam.flask-base package to 2.1.0 to enable JS and CSS compression
- lazy loading images that are not immediately visible on the home page
- deferring JS that is not needed immediately

## QA

- Open the demo link below and check the size of the resources via Network tab of the dev console. Compare it to the size of the resources on production. Make sure it's smaller which means the website loads quicker.
- You can also use third-party tools like https://pagespeed.web.dev/ to compare the performance of the demo instance vs production. 
