### PR TITLE
fix: remove `p-block` throughout partners bubble

### DIFF
--- a/templates/partners/become-a-partner.html
+++ b/templates/partners/become-a-partner.html
@@ -49,7 +49,7 @@
   </div>
   <section class="p-section">
     <hr class="p-rule is-fixed-width" />
-    <div class="p-block">
+    <div class="p-section--shallow">
       <div class="row">
         <div class="col-medium-2 col-9  col-start-large-4">
           <h2>How we work with our partners</h2>
@@ -73,7 +73,7 @@
     </div>
     <div class="row">
       <div class="col-medium-2 col-3">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <p class="p-text--small-caps">About you</p>
         </div>
       </div>

--- a/templates/partners/channel-and-reseller.html
+++ b/templates/partners/channel-and-reseller.html
@@ -27,7 +27,7 @@
         </h1>
       </div>
       <div class="col">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <p>
             Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers. Additionally these partners can both resell services and value-added offerings around our technology enabling them to grow their business.
           </p>
@@ -46,9 +46,11 @@
   {% endwith %}
 
   <section class="p-section">
-    <div class="row p-block">
-      <hr class="p-rule" />
-      <h2>What does Canonical's channel partner programme offer?</h2>
+    <div class="p-section--shallow">
+      <div class="u-fixed-width">
+        <hr class="p-rule" />
+        <h2>What does Canonical's channel partner programme offer?</h2>
+      </div>
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4 col-medium-5 col-start-medium-2">

--- a/templates/partners/desktop.html
+++ b/templates/partners/desktop.html
@@ -40,9 +40,11 @@
   {% endwith %}
 
   <section class="p-section">
-    <div class="row p-block">
-      <hr class="p-rule" />
-      <h2>Why buy a certified Ubuntu desktop?</h2>
+    <div class="p-section--shallow">
+      <div class="u-fixed-width">
+        <hr class="p-rule" />
+        <h2>Why buy a certified Ubuntu desktop?</h2>
+      </div>
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4 col-medium-5 col-start-medium-2">

--- a/templates/partners/executive-summit.html
+++ b/templates/partners/executive-summit.html
@@ -16,7 +16,7 @@
   <section class="p-strip">
     <div class="row">
       <div class="col-6 col-medium-3">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <h1 class="p-heading--bold">
             Canonical
             <br class="u-hide--small" />
@@ -47,12 +47,12 @@
     <div class="row">
       <hr class="p-rule" />
       <div class="col-6 col-medium-3">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <h2>Explore the benefits of doing business with open source</h2>
         </div>
       </div>
       <div class="col-6 col-medium-3">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <p>
             More organizations are using open source solutions to benefit from better options and adaptability. This also comes with increased risk and complexity.
           </p>
@@ -82,7 +82,7 @@
         <hr class="p-rule u-hide--large" />
       </div>
       <div class="col-9 ">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <div class="row">
             <div class="col-3 col-medium-2 col-small-2">
               <h3 class="p-heading--2">Bangalore</h3>
@@ -115,7 +115,7 @@
         <hr class="p-rule u-hide--large" />
       </div>
       <div class="col-9">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <div class="row">
             <div class="col-3 col-medium-2 col-small-2">
               <h3 class="p-heading--2">
@@ -134,7 +134,7 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <hr class="p-rule" />
           <div class="row">
             <div class="col-3 col-medium-2 col-small-2">
@@ -152,7 +152,7 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <hr class="p-rule" />
           <div class="row">
             <div class="col-3 col-medium-2 col-small-2">
@@ -172,7 +172,7 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <hr class="p-rule" />
           <div class="row">
             <div class="col-3 col-medium-2 col-small-2">
@@ -195,7 +195,7 @@
   <section class="p-strip--white is-deep">
     <div class="row">
       <div class="col-9 col-medium-4 col-start-large-4 col-start-medium-3">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <h2>Become a Canonical partner</h2>
         </div>
         <div>

--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -18,33 +18,31 @@
   <section class="p-section">
     <div class="row">
       <div class="col-start-large-4 col-6">
-        <div class="row">
-          <div class="p-block">
-            <h1>Find a Canonical partner</h1>
-          </div>
-          <p>
-            Canonical's partner network spans the full range of our product suite, from Ubuntu to private cloud, open source applications and IoT solutions. We work with public clouds, silicon vendors, IHVs/OEMs, PC manufacturers, channel/resellers and global systems integrators to bring open source to enterprises and consumers.
-          </p>
-          <form class="p-search-box">
-            <label class="u-off-screen" for="search">Search</label>
-            <input class="p-search-box__input js-find-a-partner__search-input"
-                   name="search"
-                   id="search"
-                   placeholder="Search"
-                   required=""
-                   type="search" />
-            <button type="reset"
-                    class="p-search-box__reset u-no-margin--right"
-                    alt="reset">
-              <i class="p-icon--close"></i>
-            </button>
-            <button type="submit"
-                    class="p-search-box__button js-submit-button"
-                    alt="search">
-              <i class="p-icon--search"></i>
-            </button>
-          </form>
+        <div class="p-section--shallow">
+          <h1>Find a Canonical partner</h1>
         </div>
+        <p>
+          Canonical's partner network spans the full range of our product suite, from Ubuntu to private cloud, open source applications and IoT solutions. We work with public clouds, silicon vendors, IHVs/OEMs, PC manufacturers, channel/resellers and global systems integrators to bring open source to enterprises and consumers.
+        </p>
+        <form class="p-search-box">
+          <label class="u-off-screen" for="search">Search</label>
+          <input class="p-search-box__input js-find-a-partner__search-input"
+                  name="search"
+                  id="search"
+                  placeholder="Search"
+                  required=""
+                  type="search" />
+          <button type="reset"
+                  class="p-search-box__reset u-no-margin--right"
+                  alt="reset">
+            <i class="p-icon--close"></i>
+          </button>
+          <button type="submit"
+                  class="p-search-box__button js-submit-button"
+                  alt="search">
+            <i class="p-icon--search"></i>
+          </button>
+        </form>
       </div>
     </div>
     <!-- Start moble side nav -->
@@ -135,20 +133,28 @@
       <hr class="p-rule" />
       <div class="col-3">
         <div class="row u-hide--small" id="filters">
-          <div class="p-section col-3">
-            <h2 class="p-muted-heading">Filters</h2>
+          <div class="col-3">
+            <div class="p-section--shallow">
+              <h2 class="p-muted-heading">Filters</h2>
+            </div>
           </div>
-          <div class="col-medium-2 col-3 p-block">
-            <h3 class="p-heading--5">Programme</h3>
-            {% include '/partners/partial/_partner-filters/_programme-filters.html' %}
+          <div class="col-medium-2 col-3">
+            <div class="p-section--shallow">
+              <h3 class="p-heading--5">Programme</h3>
+              {% include '/partners/partial/_partner-filters/_programme-filters.html' %}
+            </div>
           </div>
-          <div class="col-medium-2 col-3 p-block">
-            <h3 class="p-heading--5">Technology</h3>
-            {% include '/partners/partial/_partner-filters/_technology-filters.html' %}
+          <div class="col-medium-2 col-3">
+            <div class="p-section--shallow">
+              <h3 class="p-heading--5">Technology</h3>
+              {% include '/partners/partial/_partner-filters/_technology-filters.html' %}
+            </div>
           </div>
-          <div class="col-medium-2 col-3 p-block">
-            <h3 class="p-heading--5">Services offered</h3>
-            {% include '/partners/partial/_partner-filters/_services-filters.html' %}
+          <div class="col-medium-2 col-3">
+            <div class="p-section--shallow">
+              <h3 class="p-heading--5">Services offered</h3>
+              {% include '/partners/partial/_partner-filters/_services-filters.html' %}
+            </div>
           </div>
         </div>
       </div>
@@ -169,32 +175,34 @@
           </div>
           {% if partners %}
             {% for partner in partners %}
-              <div class="p-block js-find-a-partner__partner"
+              <div class="js-find-a-partner__partner"
                    id="{{ partner['slug'] }}"
                    data-searchText="{{ partner['name'] }} {{ partner['short_description'] }} {% for tag in partner['tags'] %}{{ tag['fields']['tag'] }}{% endfor %}"
                    data-filter="{% for technology in partner['technology'] %}{{ technology['name']|slug }} {% endfor %}{% for programme in partner['programme'] %}{{ programme['name']|slug }} {% endfor %}{% for service_offered in partner['service_offered'] %}{{ service_offered['name']|slug }}{% endfor %}">
                 <hr class="p-rule" />
-                <div class="row">
-                  <div class="col-6 col-medium-4 col-small-3">
-                    <p class="p-heading--2">
-                      {% if partner['partner_website'] %}
-                        <a title="{{ partner['name'] }} website"
-                           href="{{ partner['partner_website'] }}">{{ partner['name'] }}</a>
-                      {% else %}
-                        <a href="/{{ partner['slug'] }}">{{ partner['name'] }}</a>
+                <div class="p-section--shallow">
+                  <div class="row">
+                    <div class="col-6 col-medium-4 col-small-3">
+                      <p class="p-heading--2">
+                        {% if partner['partner_website'] %}
+                          <a title="{{ partner['name'] }} website"
+                             href="{{ partner['partner_website'] }}">{{ partner['name'] }}</a>
+                        {% else %}
+                          <a href="/{{ partner['slug'] }}">{{ partner['name'] }}</a>
+                        {% endif %}
+                      </p>
+                      <p>{{ partner['short_description']|markup|safe }}</p>
+                    </div>
+                    <div class="col-2 col-start-large-8 col-medium-2 col-small-1">
+                      {% if partner['logo'] %}
+                        <div class="p-image-wrapper">
+                          <img src="{{ partner['logo'] }}"
+                               class="partners-logo"
+                               alt=""
+                               loading="lazy" />
+                        </div>
                       {% endif %}
-                    </p>
-                    <p>{{ partner['short_description']|markup|safe }}</p>
-                  </div>
-                  <div class="col-2 col-start-large-8 col-medium-2 col-small-1">
-                    {% if partner['logo'] %}
-                      <div class="p-image-wrapper">
-                        <img src="{{ partner['logo'] }}"
-                             class="partners-logo"
-                             alt=""
-                             loading="lazy" />
-                      </div>
-                    {% endif %}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/templates/partners/gsi.html
+++ b/templates/partners/gsi.html
@@ -23,7 +23,7 @@
         <h1>Global System Integrator Programme</h1>
       </div>
       <div class="col">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <p>
             Canonical works with Global System Integrators around the world to build solutions that help our joint customers be successful in their business.
           </p>
@@ -47,17 +47,19 @@
     <div class="row">
       <hr class="p-rule" />
     </div>
-    <div class="row--50-50 p-block">
-      <div class="col">
-        <h2>Building powerful customer solutions together</h2>
-      </div>
-      <div class="col">
-        <p>
-          Join our webinars created specifically for Global System Integrators who are overcoming difficult technological challenges to build solutions and platforms for their customers.
-        </p>
-        <p>
-          We will talk about scaleable, automated and repeatable deployments that will help your customers meet their digital transformation needs.
-        </p>
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <div class="col">
+          <h2>Building powerful customer solutions together</h2>
+        </div>
+        <div class="col">
+          <p>
+            Join our webinars created specifically for Global System Integrators who are overcoming difficult technological challenges to build solutions and platforms for their customers.
+          </p>
+          <p>
+            We will talk about scaleable, automated and repeatable deployments that will help your customers meet their digital transformation needs.
+          </p>
+        </div>
       </div>
     </div>
     <div class="row">

--- a/templates/partners/ihv-and-oem.html
+++ b/templates/partners/ihv-and-oem.html
@@ -27,7 +27,7 @@
         </h1>
       </div>
       <div class="col">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <p>Pioneering open source for the modern data centre.</p>
           <p>
             For nearly two decades, Canonical and our enterprise partners have provided market&dash;leading solutions for customers seeking alternatives to complex and costly proprietary operating environments.
@@ -46,9 +46,11 @@
   {% endwith %}
 
   <section class="p-section">
-    <div class="row p-block">
-      <hr class="p-rule" />
-      <h2>Benefits of the IHV and OEM Partner Programme</h2>
+    <div class="p-section--shallow">
+      <div class="u-fixed-width">
+        <hr class="p-rule" />
+        <h2>Benefits of the IHV and OEM Partner Programme</h2>
+      </div>
     </div>
     <div class="row--25-75">
       <div class="col">
@@ -148,14 +150,16 @@
         </h2>
       </div>
       <div class="col">
-        <div class="p-block p-image-wrapper is-partner">
-          {{ image(url="https://assets.ubuntu.com/v1/53f92323-Frame 3338.png",
-                    alt="Photo of laptop running Ubuntu",
-                    width="1082",
-                    height="725",
-                    hi_def=True,
-                    loading="lazy") | safe
-          }}
+        <div class="p-section--shallow">
+          <div class="p-image-wrapper is-partner">
+            {{ image(url="https://assets.ubuntu.com/v1/53f92323-Frame 3338.png",
+                      alt="Photo of laptop running Ubuntu",
+                      width="1082",
+                      height="725",
+                      hi_def=True,
+                      loading="lazy") | safe
+            }}
+          </div>
         </div>
         <p>Our users have a high level of expectation in their experience with Ubuntu.</p>
         <p>

--- a/templates/partners/iot-device.html
+++ b/templates/partners/iot-device.html
@@ -50,7 +50,7 @@
 
   <section class="p-section">
     <div class="u-fixed-width u-sv3">
-      <div class="p-block">
+      <div class="p-section--shallow">
         <hr class="p-rule" />
         <h2>Benefits of the IoT partner programme</h2>
       </div>

--- a/templates/partners/isv-partners.html
+++ b/templates/partners/isv-partners.html
@@ -27,7 +27,7 @@
         </h1>
       </div>
       <div class="col">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <p>
             From Ubuntu Server to containers, Canonical's portfolio is used by independent software vendors (ISVs) around the world to power SaaS, appliances and software solutions deployed within public clouds, data centres, edge infrastructure and workstations. Our ISV Embedding programme offers the optimal technical, commercial and legal framework to enjoy cost-effective support across the lifecycle of your product.
           </p>

--- a/templates/partners/public-cloud.html
+++ b/templates/partners/public-cloud.html
@@ -27,7 +27,7 @@
         </h1>
       </div>
       <div class="col">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <p>
             Ubuntu is enormously popular with providers delivering public cloud services today. Significant developer mindshare, a favourable licensing model and a policy of regular updates have made Ubuntu the number one platform for cloud guests, the world over.
           </p>

--- a/templates/partners/silicon/index.html
+++ b/templates/partners/silicon/index.html
@@ -28,7 +28,7 @@
         <h1>Silicon programme</h1>
       </div>
       <div class="col">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <p>Unlock new opportunities with optimised secure open source solutions.</p>
           <p>
             Canonical is a trusted partner for silicon vendors with open source solutions. Canonical infrastructure software solutions with custom silicon optimisations, security, maintenance, and support have helped silicon companies reduce cost, improve software performance, and create additional business opportunities across cloud and edge markets.
@@ -82,7 +82,7 @@
         </div>
       </div>
       <div class="col">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <p>
             Enhance the developer experience on your silicon by enabling one of the most popular operating systems for developers through enablement and certification programmes.
           </p>
@@ -126,7 +126,7 @@
                     loading="lazy") | safe
           }}
         </div>
-        <div class="p-block">
+        <div class="p-section--shallow">
           <p>
             Ubuntu on workstations, servers, IoT devices, edge devices allows for seamless developer experience thus reducing cost and friction for application development and maintenance.
           </p>


### PR DESCRIPTION
_Note: Continuation of https://github.com/canonical/canonical.com/pull/1523_


## Done
- Replaced deprecated `p-block` class with it's current equivalent `p-section--shallow`
- Removed misused class combinations

## QA

- Check the following pages against prod and see that they do not have any visual changes: 
- [x] https://canonical-com-1526.demos.haus/partners/become-a-partner
- [x] https://canonical-com-1526.demos.haus/partners/channel-and-reseller
- [x] https://canonical-com-1526.demos.haus/partners/desktop
- [x] https://canonical-com-1526.demos.haus/partners/executive-summit
- [x] https://canonical-com-1526.demos.haus/partners/find-a-partner
- [x] https://canonical-com-1526.demos.haus/partners/gsi
- [x] https://canonical-com-1526.demos.haus/partners/ihv-and-oem
- [x] https://canonical-com-1526.demos.haus/partners/isv-partners
- [x] https://canonical-com-1526.demos.haus/partners/public-cloud
- [x] https://canonical-com-1526.demos.haus/partners/silicon

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14226
