### PR TITLE
fix: /lxd/manage modal

### DIFF
--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -285,8 +285,8 @@ meta_copydoc %}
               management and application-deployment tool.
             </p>
             <p>The main integrations between Ansible and LXD are:</p>
+            <hr class="p-rule--muted u-no-margin--bottom" />
             <ul class="p-list--divided">
-              <hr class="p-rule--muted" />
               <li class="p-list__item has-bullet">
                 A <a href="https://docs.ansible.com/ansible/latest/collections/community/general/lxd_connection.html#ansible-collections-community-general-lxd-connection">connection
                 plugin</a> allowing Ansible to manage a LXD instance just as any other Linux system
@@ -414,9 +414,8 @@ meta_copydoc %}
   <script defer src="{{ versioned_static('js/modals.js') }}"></script>
 
   {% with %}
-    {% set formid = "4903" %}
-    {% set returnURL = "https://canonical.com/data/mongodb#success" %}
-    {% include "data/_form-data-mongodb.html" %}
+    {% set returnURL = "https://canonical.com/lxd/install#success" %}
+    {% include "lxd/_form-lxd-install.html" %}
   {% endwith %}
 
 {% endblock %}


### PR DESCRIPTION
## Done

- Fixed incorrect modal call
- Drive by: fixed misplaced hr showing up twice above list

## QA

- View the site locally in your web browser at: https://canonical-com-1527.demos.haus/lxd/manage
- Click the "Talk to our LXD experts" cta and see that the modal opens as expected
- Under the "Third-party integrations" see that there is not a duplicate hr above the Ansible list items


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
