### PR TITLE
Wd 8834 fix: full width tabbed list on medium screens + fixed side navigation

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -188,12 +188,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 // Makes side-navigation fit with the custom top-navigation of c.com
 .p-side-navigation {
   &--raw-html.is-sticky {
-    top: 4.5rem;
-    z-index: 5; // make sure it's higher than 2, that is used by some components (like the rules)
-  }
-
-  &__drawer {
-    top: 48px;
+    z-index: 102;
   }
 }
 

--- a/templates/documentation/_documentation-tab-navigation.html
+++ b/templates/documentation/_documentation-tab-navigation.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-9 col-medium-4 col-start-large-4 col-start-medium-3">
+  <div class="col-9 col-start-large-4">
     <nav class="p-tabs" data-js="tabs" aria-label="Documentation navigation tabs">
       <ul class="p-tabs__list" role="tablist">
         <li class="p-tabs__item" role="presentation">


### PR DESCRIPTION
## Done

- Made tabbed list full screen on medium size
- Made side navigation full width like on [u.com](https://ubuntu.com/download/alternative-downloads)

## QA

- Open this [demo](https://canonical-com-1529.demos.haus/documentation)
- Use medium size screen from developer tools
- Verify the tabbed list is full width
- Toggle side navigation by clicking on "Toggle side navigation" button.
- Verify the side navigation is full height

## Issue / Card

Fixes #[WD-8834](https://warthogs.atlassian.net/browse/WD-8834)


[WD-8834]: https://warthogs.atlassian.net/browse/WD-8834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ