### PR TITLE
fix: remove final `p-block` instances

### DIFF
--- a/templates/press-centre/card.html
+++ b/templates/press-centre/card.html
@@ -1,9 +1,11 @@
 <div class="p-section">
   <div class="row">
-    <hr class="p-rule">
+    <hr class="p-rule" />
     <div class="col-3 col-medium-2">
-      <p><a href="/blog/author/{{article.author.slug}}">{{ article.author.name }}</a>
-        <br>{{ article.date }}
+      <p>
+        <a href="/blog/author/{{ article.author.slug }}">{{ article.author.name }}</a>
+        <br />
+        {{ article.date }}
       </p>
     </div>
 
@@ -15,15 +17,15 @@
               <a href="/blog/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
             </h3>
           </div>
-          
+
           <span class="p-chip--information">
             <span class="p-chip__value">
-            {% if request.path == "topic/blog/cloud-and-server" %}
-                  Cloud and Server
+              {% if request.path == "topic/blog/cloud-and-server" %}
+                Cloud and Server
               {% elif request.path == "topic/blog/desktop" %}
-                  Desktop
+                Desktop
               {% elif request.path == "topic/blog/internet-of-things" %}
-                  Internet of Things
+                Internet of Things
               {% else %}
                 {% if article.group %}
                   {{ article.group.name }}
@@ -34,14 +36,10 @@
             </span>
           </span>
           <span class="p-chip--information">
-            <span class="p-chip__value">
-              {% include 'blog/singular-category.html' %}
-            </span>
+            <span class="p-chip__value">{% include 'blog/singular-category.html' %}</span>
           </span>
-      
-          <p class="u-hide--small">
-            {{ article.excerpt.raw.replace("[…]", "")|truncate(1000) }}...
-          </p>
+
+          <p class="u-hide--small">{{ article.excerpt.raw.replace('[…]', '') |truncate(1000) }}...</p>
         </div>
         <div class="col-3 col-start-large-7 u-hide--medium u-hide--small">
           {% if article.image and article.image.source_url %}

--- a/templates/press-centre/card.html
+++ b/templates/press-centre/card.html
@@ -10,7 +10,7 @@
     <div class="col-9 col-medium-4">
       <div class="row">
         <div class="col-6 col-medium-4">
-          <div class="p-block">
+          <div class="p-section--shallow">
             <h3 class="p-heading--2">
               <a href="/blog/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
             </h3>

--- a/templates/press-centre/index.html
+++ b/templates/press-centre/index.html
@@ -51,7 +51,7 @@
         <h2 class="p-muted-heading">Canonical <br class="u-hide--small">at a glance</h2>
       </div>
       <div class="col-9 col-medium-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <p class="p-heading--2">Publishing the #1 OS in the cloud. <br class="u-hide--medium u-hide--small">Trusted by industry leaders.</p>
         </div>
         <ul class="p-list--divided">

--- a/templates/projects/directory.html
+++ b/templates/projects/directory.html
@@ -20,7 +20,7 @@
   <section class="p-section">
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <h1>Open source projects directory</h1>
         </div>
         <p>

--- a/templates/projects/index.html
+++ b/templates/projects/index.html
@@ -13,12 +13,14 @@
 {% block content %}
 
   <section class="p-strip">
-    <div class="row p-block">
-      <div class="col-8 col-start-large-4">
-        <h1>Open source is what we do</h1>
-        <p class="p-heading--2">
-          We believe in the power of open source software. As well as driving our own projects, we contribute staff, code and funding to many more.
-        </p>
+    <div class="p-section--shallow">
+      <div class="row">
+        <div class="col-8 col-start-large-4">
+          <h1>Open source is what we do</h1>
+          <p class="p-heading--2">
+            We believe in the power of open source software. As well as driving our own projects, we contribute staff, code and funding to many more.
+          </p>
+        </div>
       </div>
     </div>
   </section>
@@ -55,7 +57,7 @@
     <div class="row">
       <div class="col-3 col-medium-3 p-section">
         <hr class="p-rule--highlight" />
-        <div class="p-block">
+        <div class="p-section--shallow">
           <h3 class="p-heading--2">
             <a href="https://ubuntu.com/openstack">OpenStack</a>
           </h3>
@@ -66,7 +68,7 @@
       </div>
       <div class="col-3 col-medium-3 p-section">
         <hr class="p-rule--highlight" />
-        <div class="p-block">
+        <div class="p-section--shallow">
           <h3 class="p-heading--2">
             <a href="https://jaas.ai">Juju</a>
           </h3>
@@ -77,7 +79,7 @@
       </div>
       <div class="col-3 col-medium-3 p-section">
         <hr class="p-rule--highlight" />
-        <div class="p-block">
+        <div class="p-section--shallow">
           <h3 class="p-heading--2">
             <a href="https://maas.io">MAAS</a>
           </h3>
@@ -88,7 +90,7 @@
       </div>
       <div class="col-3 col-medium-3 p-section">
         <hr class="p-rule--highlight" />
-        <div class="p-block">
+        <div class="p-section--shallow">
           <h3 class="p-heading--2">
             <a href="https://mir-server.io/">Mir</a>
           </h3>
@@ -99,7 +101,7 @@
       </div>
       <div class="col-3 col-medium-3 p-section">
         <hr class="p-rule--highlight" />
-        <div class="p-block">
+        <div class="p-section--shallow">
           <h3 class="p-heading--2">
             <a href="https://www.launchpad.net/">Launchpad</a>
           </h3>
@@ -110,7 +112,7 @@
       </div>
       <div class="col-3 col-medium-3 p-section">
         <hr class="p-rule--highlight" />
-        <div class="p-block">
+        <div class="p-section--shallow">
           <h3 class="p-heading--2">
             <a href="https://cloud-init.io/">Cloud-init</a>
           </h3>
@@ -121,7 +123,7 @@
       </div>
       <div class="col-3 col-medium-3 p-section">
         <hr class="p-rule--highlight" />
-        <div class="p-block">
+        <div class="p-section--shallow">
           <h3 class="p-heading--2">
             <a href="https://ubuntu.com/community/debian">Debian</a>
           </h3>
@@ -140,36 +142,42 @@
         <h2 class="p-muted-heading">Learn more</h2>
       </div>
       <div class="col-9">
-        <div class="row p-block">
-          <div class="col-6 col-medium-3">
-            <h3 class="p-heading--2">
-              <a href="/projects/directory">View Canonical project directory</a>
-            </h3>
-          </div>
-          <div class="col-3 col-medium-3">
-            <p>See an overview of open source projects set up by Canonical, with contact information for each project.</p>
-          </div>
-        </div>
-        <hr class="p-rule" />
-        <div class="row p-block">
-          <div class="col-6 col-medium-3">
-            <h3 class="p-heading--2">
-              <a href="https://www.ubuntu.com">Explore ubuntu.com</a>
-            </h3>
-          </div>
-          <div class="col-3 col-medium-3">
-            <p>On ubuntu.com, you&rsquo;ll find out more about the platform, our management services and our partner programs.</p>
+        <div class="p-section--shallow">
+          <div class="row">
+            <div class="col-6 col-medium-3">
+              <h3 class="p-heading--2">
+                <a href="/projects/directory">View Canonical project directory</a>
+              </h3>
+            </div>
+            <div class="col-3 col-medium-3">
+              <p>See an overview of open source projects set up by Canonical, with contact information for each project.</p>
+            </div>
           </div>
         </div>
         <hr class="p-rule" />
-        <div class="row p-block">
-          <div class="col-6 col-medium-3">
-            <h3 class="p-heading--2">
-              <a href="https://www.ubuntu.com/support">Contact us today</a>
-            </h3>
+        <div class="p-section--shallow">
+          <div class="row">
+            <div class="col-6 col-medium-3">
+              <h3 class="p-heading--2">
+                <a href="https://www.ubuntu.com">Explore ubuntu.com</a>
+              </h3>
+            </div>
+            <div class="col-3 col-medium-3">
+              <p>On ubuntu.com, you&rsquo;ll find out more about the platform, our management services and our partner programs.</p>
+            </div>
           </div>
-          <div class="col-3 col-medium-3">
-            <p>Interested in Ubuntu Pro? Talk to us today for more information.</p>
+        </div>
+        <hr class="p-rule" />
+        <div class="p-section--shallow">
+          <div class="row">
+            <div class="col-6 col-medium-3">
+              <h3 class="p-heading--2">
+                <a href="https://www.ubuntu.com/support">Contact us today</a>
+              </h3>
+            </div>
+            <div class="col-3 col-medium-3">
+              <p>Interested in Ubuntu Pro? Talk to us today for more information.</p>
+            </div>
           </div>
         </div>
       </div>

--- a/templates/shared/_promoted_roles.html
+++ b/templates/shared/_promoted_roles.html
@@ -1,46 +1,50 @@
 <section class="p-section">
   {% if featured_jobs %}
-  <div class="u-fixed-width">
-    <hr class="p-rule">
-  </div>
-  <div class="row--25-75">
-    <div class="col-3 col-medium-3">
-      <div class="p-section--shallow">
-        <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Featured Roles</h2>
-      </div>
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
     </div>
-    <div class="col-9 col-medium-3">
-      <div class="row">
-      {% for job in featured_jobs %}
-      {% if loop.index < 10 %}
-        <div class="col-3">
-          {% if loop.index < 4 %}
-            <hr class="p-rule u-hide--large {% if loop.index == 1 %}u-hide--medium{% endif %}">
-          {% else %}
-            <hr class="p-rule">
-          {% endif %}
-          <p><a class="p-featured__url p-card--content" href="/careers/{{job.id}}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Featured job', 'eventAction' : 'Click', 'eventLabel' : '{{ job.title }}', 'eventValue' : undefined });">{{ job.title }}</a></p>
+    <div class="row--25-75">
+      <div class="col-3 col-medium-3">
+        <div class="p-section--shallow">
+          <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Featured Roles</h2>
         </div>
-      {% endif %}
-      {% endfor %}
       </div>
-      <br />
-      <div class="row" style="text-align: right">
-        <div class="col">
-          <hr class="p-rule">
-          {% if formatted_slug %}
-            <p class="u-no-max-width">
-              <a href="/careers/all?filter={{formatted_slug}}">See all {{ department.name }} roles</a>
-            </p>
-          {% else %}
-          <p class="u-no-max-width">
-            <a href="/careers/all?filter={{department.slug.capitalize()}}">See all {{ department.name }} roles</a>
-          </p>
-          {% endif %}
+      <div class="col-9 col-medium-3">
+        <div class="row">
+          {% for job in featured_jobs %}
+            {% if loop.index < 10 %}
+              <div class="col-3">
+                {% if loop.index < 4 %}
+                  <hr class="p-rule u-hide--large {% if loop.index == 1 %}u-hide--medium{% endif %}" />
+                {% else %}
+                  <hr class="p-rule" />
+                {% endif %}
+                <p>
+                  <a class="p-featured__url p-card--content"
+                     href="/careers/{{ job.id }}"
+                     onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Featured job', 'eventAction' : 'Click', 'eventLabel' : '{{ job.title }}', 'eventValue' : undefined });">{{ job.title }}</a>
+                </p>
+              </div>
+            {% endif %}
+          {% endfor %}
         </div>
+        <br />
+        <div class="row" style="text-align: right">
+          <div class="col">
+            <hr class="p-rule" />
+            {% if formatted_slug %}
+              <p class="u-no-max-width">
+                <a href="/careers/all?filter={{ formatted_slug }}">See all {{ department.name }} roles</a>
+              </p>
+            {% else %}
+              <p class="u-no-max-width">
+                <a href="/careers/all?filter={{ department.slug.capitalize() }}">See all {{ department.name }} roles</a>
+              </p>
+            {% endif %}
+          </div>
 
+        </div>
       </div>
     </div>
-  </div>
   {% endif %}
 </section>

--- a/templates/shared/_promoted_roles.html
+++ b/templates/shared/_promoted_roles.html
@@ -3,13 +3,13 @@
     <div class="u-fixed-width">
       <hr class="p-rule" />
     </div>
-    <div class="row--25-75">
-      <div class="col-3 col-medium-3">
+    <div class="row--25-75-on-large row--50-50-on-medium">
+      <div class="col">
         <div class="p-section--shallow">
           <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Featured Roles</h2>
         </div>
       </div>
-      <div class="col-9 col-medium-3">
+      <div class="col">
         <div class="row">
           {% for job in featured_jobs %}
             {% if loop.index < 10 %}

--- a/templates/shared/_promoted_roles.html
+++ b/templates/shared/_promoted_roles.html
@@ -5,7 +5,7 @@
   </div>
   <div class="row--25-75">
     <div class="col-3 col-medium-3">
-      <div class="p-block">
+      <div class="p-section--shallow">
         <h2 class="p-text--x-small-capitalised u-align-text--x-small-to-default">Featured Roles</h2>
       </div>
     </div>


### PR DESCRIPTION
_Note: Continuation of https://github.com/canonical/canonical.com/pull/1523_

## Done

- Replaced deprecated `p-block` class with it's current equivalent `p-section--shallow`
- Removed misused class combinations

## QA

- Check the following pages against prod and see that there are no visual changes:
- [x] "Featured roles" section on https://canonical-com-1535.demos.haus/careers/finance (or any dept page)
- [x] https://canonical-com-1535.demos.haus/press-centre
- [x] https://canonical-com-1535.demos.haus/projects

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14226
