### PR TITLE
[WD-18726] Introduced an optional formId prop to form-template.html

### DIFF
--- a/templates/embedding/index.html
+++ b/templates/embedding/index.html
@@ -200,6 +200,8 @@
 
   <script defer src="{{ versioned_static('js/modals.js') }}"></script>
 
-  {% include "/shared/forms/form-template.html" %}
+  {% with formId=4482 %}
+    {% include "/shared/forms/form-template.html" %}
+  {% endwith %}
 
 {% endblock content %}

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -2,7 +2,7 @@
   <form {% if isModal %}class="js-modal-form"{% endif %}
         action="https://ubuntu.com/marketo/submit"
         method="post"
-        id="mktoForm_{{ formData.formId }}"
+        id="mktoForm_{{ form_id }}"
         onsubmit="getCustomFields(event)">
     {% for fieldset in fieldsets %}
 
@@ -169,7 +169,7 @@
                        aria-hidden="true"
                        aria-label="hidden field"
                        name="formid"
-                       value="{{ formData.formId }}" />
+                       value="{{ form_id }}" />
                 <input type="hidden"
                        aria-hidden="true"
                        aria-label="hidden field"

--- a/templates/shared/forms/form-template.html
+++ b/templates/shared/forms/form-template.html
@@ -1,3 +1,5 @@
+{% set form_id = formId or formData.formId %}
+
 {% if isModal %}
   <div class="p-modal" style="display: none;" id="{{ modalId }}">
     <div class="p-modal__dialog js-modal-content is-wide-modal"


### PR DESCRIPTION
## Done

- Pass an optional formId prop when including form-template.html. If it is passed, it will be used for the formId submitted to marketo, otherwise the one specified in form-data.json will be used.
- Added example (to be removed before merging) at embedding/index.html

## QA

- Navigate to [embedding#get-in-touch](https://canonical-com-1536.demos.haus/embedding#get-in-touch)
- Fill and submit the form
- Check the payload in network tab and see if it shows correct formId
- Make sure the form submission works.
- Also, navigate to any form that uses formId from form-data.json, for example, [/data/postgresql#get-in-touch](https://canonical-com-1536.demos.haus/data/postgresql#get-in-touch)
- Fill and submit the form
- Make sure the formId is correct in payload and verify the form submission works.

## Issue / Card

Fixes #[WD-18726](https://warthogs.atlassian.net/browse/WD-18726)


[WD-18726]: https://warthogs.atlassian.net/browse/WD-18726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ