### PR TITLE
[WD-18681] Removed toggle nav on documentation

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -190,7 +190,7 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 // Makes side-navigation fit with the custom top-navigation of c.com
 .p-side-navigation {
   &--raw-html.is-sticky {
-    z-index: 102;
+    z-index: 5; // make sure it's higher than 2, that is used by some components (like the rules)
   }
 }
 

--- a/templates/documentation/beyond-canonical.html
+++ b/templates/documentation/beyond-canonical.html
@@ -19,16 +19,10 @@
     <div class="row" id="documentation">
       <aside class="col-3">
         <div class="p-side-navigation--raw-html is-sticky" id="drawer">
-          <button class="p-side-navigation__toggle js-drawer-toggle"
-                  aria-controls="drawer">Toggle side navigation</button>
           <div class="p-side-navigation__overlay js-drawer-toggle"
                aria-controls="drawer"></div>
           <nav class="p-side-navigation__drawer"
                aria-label="documentation side navigation">
-            <div class="p-side-navigation__drawer-header">
-              <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle"
-                      aria-controls="drawer">Toggle table of contents</button>
-            </div>
             <ul>
               <li class="p-side-navigation__item">
                 <a class="highlight-link" href="#encounters-and-dialogue">Encounters and dialogue</a>

--- a/templates/documentation/index.html
+++ b/templates/documentation/index.html
@@ -19,16 +19,10 @@
     <div class="row" id="documentation">
       <aside class="col-3">
         <div class="p-side-navigation--raw-html is-sticky" id="drawer">
-          <button class="p-side-navigation__toggle js-drawer-toggle"
-                  aria-controls="drawer">Toggle side navigation</button>
           <div class="p-side-navigation__overlay js-drawer-toggle"
                aria-controls="drawer"></div>
           <nav class="p-side-navigation__drawer"
                aria-label="documentation side navigation">
-            <div class="p-side-navigation__drawer-header">
-              <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle"
-                      aria-controls="drawer">Toggle table of contents</button>
-            </div>
             <ul>
               <li class="p-side-navigation__item">
                 <a class="highlight-link" href="#documentation-as-practice">Documentation as practice</a>
@@ -198,8 +192,8 @@
             </div>
           </div>
         </div>
-    </main>
-  </div>
-</section>
+      </main>
+    </div>
+  </section>
 
 {% endblock documentation_content %}

--- a/templates/documentation/open-documentation-academy.html
+++ b/templates/documentation/open-documentation-academy.html
@@ -19,16 +19,10 @@
     <div class="row" id="documentation">
       <aside class="col-3">
         <div class="p-side-navigation--raw-html is-sticky" id="drawer">
-          <button class="p-side-navigation__toggle js-drawer-toggle"
-                  aria-controls="drawer">Toggle side navigation</button>
           <div class="p-side-navigation__overlay js-drawer-toggle"
                aria-controls="drawer"></div>
           <nav class="p-side-navigation__drawer"
                aria-label="documentation side navigation">
-            <div class="p-side-navigation__drawer-header">
-              <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle"
-                      aria-controls="drawer">Toggle table of contents</button>
-            </div>
             <ul>
               <li class="p-side-navigation__item">
                 <a class="highlight-link" href="#get-out-of-it">What you'll get out of it</a>

--- a/templates/documentation/work-and-careers.html
+++ b/templates/documentation/work-and-careers.html
@@ -19,16 +19,10 @@
     <div class="row" id="documentation">
       <aside class="col-3">
         <div class="p-side-navigation--raw-html is-sticky" id="drawer">
-          <button class="p-side-navigation__toggle js-drawer-toggle"
-                  aria-controls="drawer">Toggle side navigation</button>
           <div class="p-side-navigation__overlay js-drawer-toggle"
                aria-controls="drawer"></div>
           <nav class="p-side-navigation__drawer"
                aria-label="documentation side navigation">
-            <div class="p-side-navigation__drawer-header">
-              <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle"
-                      aria-controls="drawer">Toggle table of contents</button>
-            </div>
             <ul>
               <li class="p-side-navigation__item">
                 <a class="highlight-link" href="#being-a-technical-author">Being a technical author</a>


### PR DESCRIPTION
## Done

- Removed toggle nav
- Fixed side nav going over the top nav

## QA

- Open this [demo](https://canonical-com-1537.demos.haus/documentation) in your browser
- Scroll up and down to make sure side nav is not going over the top nav
- Change screen size to mobile/tablet from dev tools
- Make sure there is no button for toggling side navigation
- Do the above for all of the 4 different tabs on the page

## Issue / Card

Fixes #[WD-18681](https://warthogs.atlassian.net/browse/WD-18681)


[WD-18681]: https://warthogs.atlassian.net/browse/WD-18681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ