### PR TITLE
feat: Add 'selfReportedAttribution'  field to 3 high traffic forms for testing

### DIFF
--- a/templates/partners/partial/_homepage-form.html
+++ b/templates/partners/partial/_homepage-form.html
@@ -444,9 +444,9 @@
               <input required id="jobTitle" name="title" maxlength="255" type="text" />
             </li>
             <li class="p-list__item">
-              <label for="selfReportedAttribution”">How did you hear about us?</label>
-              <input id="selfReportedAttribution”"
-                     name="selfReportedAttribution”"
+              <label for="selfReportedAttribution">How did you hear about us?</label>
+              <input id="selfReportedAttribution"
+                     name="selfReportedAttribution"
                      maxlength="255"
                      type="text" />
             </li>

--- a/templates/partners/partial/_homepage-form.html
+++ b/templates/partners/partial/_homepage-form.html
@@ -443,6 +443,13 @@
               <label for="jobTitle">Job title:</label>
               <input required id="jobTitle" name="title" maxlength="255" type="text" />
             </li>
+            <li class="p-list__item">
+              <label for="selfReportedAttribution”">How did you hear about us?</label>
+              <input id="selfReportedAttribution”"
+                     name="selfReportedAttribution”"
+                     maxlength="255"
+                     type="text" />
+            </li>
           </ul>
           <legend class="u-off-screen">Privacy policy</legend>
           <ul class="p-list">

--- a/templates/solutions/infrastructure/_form_infrastructure.html
+++ b/templates/solutions/infrastructure/_form_infrastructure.html
@@ -55,6 +55,13 @@
                             rows="4"
                             maxlength="2000"></textarea>
                 </li>
+                <li class="p-list__item">
+                  <label for="selfReportedAttribution">How did you hear about us?</label>
+                  <input id="selfReportedAttribution"
+                         name="selfReportedAttribution"
+                         maxlength="255"
+                         type="text" />
+                </li>
                 <div>
                   <label class="p-checkbox">
                     <input class="p-checkbox__input"

--- a/templates/solutions/open-source-security/_form-open-source-security.html
+++ b/templates/solutions/open-source-security/_form-open-source-security.html
@@ -2,83 +2,171 @@
   <div class="p-modal__dialog js-modal-content is-paper" role="dialog">
     <div class="js-pagination js-pagination--1">
       <div class="js-formfield">
-      <div class="row--50-50 p-strip is-shallow">
-        <div class="col">
-          <h2 class="p-heading--1">Contact Canonical</h2>
-          <p>Contact Canonical to learn about our secure open source solutions, and they fit your use case.</p>
-        </div>
-        <div class="col">
-          <button class="p-modal__close p-modal-close-button " aria-controls="secure-open-source-modal" aria-label="Close active modal" style="margin-top: 0;">Close</button>
-          <form action="https://ubuntu.com/marketo/submit" method="post" class="modal-form">
-            <div class="p-section--shallow">
-              <label for="firstName" class="is-required">First name:</label>
-              <input required id="firstName" name="firstName" maxlength="255" type="text"/>
-            </div>
-            <div class="p-section--shallow">
-              <label for="lastName" class="is-required">Last name:</label>
-              <input required id="lastName" name="lastName" maxlength="255" type="text"/>
-            </div>
-            <div class="p-section--shallow">
-              <label for="email" class="is-required">Email:</label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
-            </div>
-            <div class="p-section--shallow">
-              {% with required="false", remove_list=True %}
-                {% include "shared/forms/_country.html" %}
-              {% endwith %}
-            </div>
-            <div class="p-section--shallow">
-              <label for="phone">Phone number:</label>
-              <input id="phone" name="phone" maxlength="255" type="tel" pattern="[0-9\s]+" />
-            </div>
-            <div class="p-section--shallow">
-              <label for="company">Company:</label>
-              <input id="company" name="company" maxlength="255" type="text"/>
-            </div>
-            <div class="p-section--shallow">
-              <label for="title">Job title:</label>
-              <input id="title" name="title" maxlength="255" type="text" />
-            </div>
-            <div class="p-section--shallow">
-              <label for="Comments_from_lead__c">What would you like to talk with us about?</label>
-              <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" maxlength="2000"></textarea>
-            </div>
+        <div class="row--50-50 p-strip is-shallow">
+          <div class="col">
+            <h2 class="p-heading--1">Contact Canonical</h2>
+            <p>Contact Canonical to learn about our secure open source solutions, and they fit your use case.</p>
+          </div>
+          <div class="col">
+            <button class="p-modal__close p-modal-close-button "
+                    aria-controls="secure-open-source-modal"
+                    aria-label="Close active modal"
+                    style="margin-top: 0">Close</button>
+            <form action="https://ubuntu.com/marketo/submit"
+                  method="post"
+                  class="modal-form">
+              <div class="p-section--shallow">
+                <label for="firstName" class="is-required">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
+              </div>
+              <div class="p-section--shallow">
+                <label for="lastName" class="is-required">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
+              </div>
+              <div class="p-section--shallow">
+                <label for="email" class="is-required">Email:</label>
+                <input required
+                       id="email"
+                       name="email"
+                       maxlength="255"
+                       type="email"
+                       pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+              </div>
+              <div class="p-section--shallow">
+                {% with required="false", remove_list=True %}
+                  {% include "shared/forms/_country.html" %}
+                {% endwith %}
+              </div>
+              <div class="p-section--shallow">
+                <label for="phone">Phone number:</label>
+                <input id="phone" name="phone" maxlength="255" type="tel" pattern="[0-9\s]+" />
+              </div>
+              <div class="p-section--shallow">
+                <label for="company">Company:</label>
+                <input id="company" name="company" maxlength="255" type="text" />
+              </div>
+              <div class="p-section--shallow">
+                <label for="title">Job title:</label>
+                <input id="title" name="title" maxlength="255" type="text" />
+              </div>
+              <div class="p-section--shallow">
+                <label for="Comments_from_lead__c">What would you like to talk with us about?</label>
+                <textarea id="Comments_from_lead__c"
+                          name="Comments_from_lead__c"
+                          rows="4"
+                          maxlength="2000"></textarea>
+              </div>
+              <div class="p-section--shallow">
+                <label for="selfReportedAttribution">How did you hear about us?</label>
+                <input id="selfReportedAttribution"
+                       name="selfReportedAttribution"
+                       maxlength="255"
+                       type="text" />
+              </div>
               <div class="p-section--shallow">
                 <label class="p-checkbox">
-                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                  <input class="p-checkbox__input"
+                         value="yes"
+                         aria-labelledby="canonicalUpdatesOptIn"
+                         name="canonicalUpdatesOptIn"
+                         type="checkbox" />
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
               </div>
-            <div class="p-section--shallow">By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/data-privacy">Canonical's Privacy Policy</a>.</div>
-            {# These are honey pot fields to catch bots #}
-            <div class="u-off-screen">
-              <label class="website" for="website">Website:</label>
-              <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
-            </div>
-            <div class="u-off-screen">
-              <label class="name" for="name">Name:</label>
-              <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
-            </div>
-            {# End of honey pots #}
+              <div class="p-section--shallow">
+                By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/data-privacy">Canonical's Privacy Policy</a>.
+              </div>
+              {# These are honey pot fields to catch bots #}
+              <div class="u-off-screen">
+                <label class="website" for="website">Website:</label>
+                <input name="website"
+                       type="text"
+                       class="website"
+                       autocomplete="off"
+                       value=""
+                       id="website"
+                       tabindex="-1" />
+              </div>
+              <div class="u-off-screen">
+                <label class="name" for="name">Name:</label>
+                <input name="name"
+                       type="text"
+                       class="name"
+                       autocomplete="off"
+                       value=""
+                       id="name"
+                       tabindex="-1" />
+              </div>
+              {# End of honey pots #}
 
-            <div class="u-hide">
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="5871" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="acquisition_url" id="acquisition_url" value="{{ request.url }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
-            </div>
+              <div class="u-hide">
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="returnURL"
+                       value="{{ returnURL }}" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="formid"
+                       value="5871" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="Consent_to_Processing__c"
+                       value="yes" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="acquisition_url"
+                       id="acquisition_url"
+                       value="{{ request.url }}" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="utm_campaign"
+                       id="utm_campaign"
+                       value="" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="utm_medium"
+                       id="utm_medium"
+                       value="" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="utm_source"
+                       id="utm_source"
+                       value="" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="utm_content"
+                       id="utm_content"
+                       value="" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       name="utm_term"
+                       id="utm_term"
+                       value="" />
+                <input type="hidden"
+                       aria-hidden="true"
+                       aria-label="hidden field"
+                       id="preferredLanguage"
+                       name="preferredLanguage"
+                       maxlength="255"
+                       value="" />
+              </div>
 
-            <div class="pagination">
-              <hr class="p-rule--muted" />
-              <button type="submit" class="pagination__link--next p-button--positive js-submit-button" aria-label="Submit">Submit form</button>
-            </div>
-          </form>
+              <div class="pagination">
+                <hr class="p-rule--muted" />
+                <button type="submit"
+                        class="pagination__link--next p-button--positive js-submit-button"
+                        aria-label="Submit">Submit form</button>
+              </div>
+            </form>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Adds the field 'selfReportedAttribution' to three high traffic fields, [as per request](https://warthogs.atlassian.net/browse/WD-18038):
https://canonical-com-1538.demos.haus/#get-in-touch
https://canonical-com-1538.demos.haus/solutions/infrastructure#get-in-touch
https://canonical-com-1538.demos.haus/solutions/open-source-security#get-in-touch (also formated, hence big diff)

## QA

- Check out out each of the above demo links
- Check the form has a optional text input labelled 'How did you hear about us?'
- Fill in the form and ensure you see 'selfReportedAttribution' in the payload
- Check the form is received in Marketo

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-18038
