### PR TITLE
feat: Add /observability to the meganav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -519,6 +519,8 @@ solutions:
           url: /solutions/open-source-security
         - title: IoT and devices
           url: /solutions/iot-and-devices
+        - title: Observability
+          url: /observability
 
     - title: Industries
       links:


### PR DESCRIPTION
## Done

- Adds /observability to the meganav, see [copydoc](https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?tab=t.0#heading=h.57yzphrdgf4q)

## QA

- Open [the demo](https://canonical-com-1540.demos.haus/)
- Open the navigation dropdown 'Solutions'
- You will see 'Observability' at the bottom of the 'Categories' list
- Click the link and see you are taken to https://canonical-com-1540.demos.haus/observability

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-18252