### PR TITLE
fix(navigation): Remove 'Streaming' link from /data [WD-19130]

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -53,8 +53,6 @@ data:
       path: /data/valkey
     - title: Docs
       path: /data/docs
-    - title: Streaming
-      path: /data/streaming
 
 kafka:
   title: Kafka


### PR DESCRIPTION
## Done

- Removed the Streaming Tab from secondary-navigation.yaml.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Verify that the Streaming tab is no longer present in the secondary navigation menu of Canonical.com/data

## Issue / Card

Jira Issue: https://warthogs.atlassian.net/browse/WD-19130
Copydoc: https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?tab=t.0#heading=h.ynmgujjj40mc%20-%20it%20was%20not%20added%20to%20the%20copydoc%20and%20so%20should%20not%20be%20added%20to%20the%20navigation

## Screenshots

![image](https://github.com/user-attachments/assets/fef3fb9e-56a7-420b-9c02-df9c61b94837)