### PR TITLE
feat: Add discourse url metatag for case studies

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -11,6 +11,9 @@
         {% block meta_copydoc %}https://drive.google.com/drive/folders/0B8feV0jqaac3TmExU3NDcHhFTGc{% endblock %}" />
         <meta name="author" content="Canonical Ltd" />
         <link rel="canonical" href="{% block canonical_url %}{{ request.url }}{% endblock %}" />
+        
+        <meta name="discourse-url" content="
+        {% block meta_discourse_url %}https://discourse.ubuntu.com{% endblock %}" />
 
           <meta name="theme-color" content="#262626" />
           <meta name="twitter:account_id" content="169015850" />

--- a/templates/case-study/episensor.html
+++ b/templates/case-study/episensor.html
@@ -16,10 +16,8 @@
 {% endblock %}
 
 {% block meta_company_name %}EpiSensor{% endblock %}
-
-{% block meta_copydoc %}
-  https://docs.google.com/document/d/1NxBHg59oiH-ry7bgMZX-xDxvWbC9IyqHYMei-bQciU4/edit?tab=t.0
-{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1NxBHg59oiH-ry7bgMZX-xDxvWbC9IyqHYMei-bQciU4/edit?tab=t.0{% endblock %}
+{% block meta_discourse_url %}https://discourse.ubuntu.com/t/case-study-episensor-accelerates-the-sustainable-energy-transition-with-ubuntu-core/54981/2{% endblock s%}
 
 {% block inner_content %}
   {%- call(slot) vf_hero(

--- a/templates/case-study/episensor.html
+++ b/templates/case-study/episensor.html
@@ -17,7 +17,7 @@
 
 {% block meta_company_name %}EpiSensor{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1NxBHg59oiH-ry7bgMZX-xDxvWbC9IyqHYMei-bQciU4/edit?tab=t.0{% endblock %}
-{% block meta_discourse_url %}https://discourse.ubuntu.com/t/case-study-episensor-accelerates-the-sustainable-energy-transition-with-ubuntu-core/54981/2{% endblock s%}
+{% block meta_discourse_url %}https://discourse.ubuntu.com/t/case-study-episensor-accelerates-the-sustainable-energy-transition-with-ubuntu-core/54981/2{% endblock %}
 
 {% block inner_content %}
   {%- call(slot) vf_hero(

--- a/templates/case-study/esa.html
+++ b/templates/case-study/esa.html
@@ -12,7 +12,7 @@
 {% block meta_description %}Thanks to Canonical, the ESA has unlocked cost savings, easier operations, and more confidence in providing infrastructure in their roadmap for doubling their number of space missions by 2030.{% endblock %}
 {% block meta_company_name %}European Space Agency{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1jc5DY4-9pDYQC04Egdt0If4_jrYn1mIBDwhJfILO46w/edit{% endblock %}
-{% block discourse_url %}https://discourse.ubuntu.com/t/case-study-grundium-ubuntu-pro-for-devices/53393/2{% endblock %}
+{% block meta_discourse_url %}https://discourse.ubuntu.com/t/case-study-esa-boosts-mission-capacity-with-canonical-infrastructure/53387/4{% endblock %}
 
 {% block inner_content %}
   <!-- Hero section -->

--- a/templates/case-study/grundium-ubuntu-pro-for-devices.html
+++ b/templates/case-study/grundium-ubuntu-pro-for-devices.html
@@ -13,7 +13,7 @@
 {% block meta_description %}As a medical device manufacturer, Grundium must meet stringent security requirements. Ubuntu Pro for Devices allows them to secure their digital microscopes.{% endblock %}
 {% block meta_company_name %}Grundium{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1wM1vo24SFowPaAnxWV9wfU-w6PVDq7RczM_5ZOb8OZM/edit{% endblock %}
-{% block discourse_url %}https://discourse.ubuntu.com/t/case-study-grundium-ubuntu-pro-for-devices/53393/2{% endblock %}
+{% block meta_discourse_url %}https://discourse.ubuntu.com/t/case-study-grundium-ubuntu-pro-for-devices/53393/2{% endblock %}
 
 {% block inner_content %}
   {%- call(slot) vf_hero(

--- a/templates/case-study/lucid-aws-fedramp-compliance-case-study.html
+++ b/templates/case-study/lucid-aws-fedramp-compliance-case-study.html
@@ -13,7 +13,7 @@
 {% block meta_description %}Learn how Ubuntu Pro allowed Lucid to meet FedRAMP compliance and provide its visualization &amp; work management tools to US Federal agencies.{% endblock %}
 {% block meta_company_name %}Lucid{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/11NbG_hLg0zZdMAzkOLXaS4ItOUfsRF31VAA1-093m_g{% endblock %}
-{% block discourse_url %}https://discourse.ubuntu.com/t/case-study-lucid-aws-fedramp-compliance/53391{% endblock %}
+{% block meta_discourse_url %}https://discourse.ubuntu.com/t/case-study-lucid-aws-fedramp-compliance/53391{% endblock %}
 
 {% block inner_content %}
   <!-- Hero section -->

--- a/templates/case-study/sbi-bits.html
+++ b/templates/case-study/sbi-bits.html
@@ -13,7 +13,7 @@
 {% block meta_description %}SBI BITS migrates to a new OpenStack environment while maintaining business continuity with the help of Canonical’s support services{% endblock %}
 {% block meta_company_name %}SBI BITS{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1tzLuweh3wM6P38O7U3HFEjb7jnXd1_IWSvM-uUkeiQo/edit?tab=t.0{% endblock %}
-{% block discourse_url %}https://discourse.ubuntu.com/t/case-study-sbi-bits/53390{% endblock %}
+{% block meta_discourse_url %}https://discourse.ubuntu.com/t/case-study-sbi-bits/53390{% endblock %}
 
 {% block inner_content %}
   {%- call(slot) vf_hero(

--- a/templates/case-study/ubuntu-pro-support-for-games-developer.html
+++ b/templates/case-study/ubuntu-pro-support-for-games-developer.html
@@ -12,7 +12,7 @@
 {% block meta_description %}Securing open source dependencies with Ubuntu Pro &mdash; legacy PHP support saves a game developer time and effort, while they plan a migration path.{% endblock %}
 {% block meta_company_name %}Ubuntu Pro for Games Developer{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1qQeL08ZQ2agpNKQunfbYkemqSAF9waQ9J5fqCpH3gtA/edit?tab=t.0{% endblock %}
-{% block discourse_url %}https://discourse.ubuntu.com/t/case-study-ubuntu-pro-support-for-games-developer/53389{% endblock %}
+{% block meta_discourse_url %}https://discourse.ubuntu.com/t/case-study-ubuntu-pro-support-for-games-developer/53389{% endblock %}
 
 {% block inner_content %}
     {%- call(slot) vf_hero(


### PR DESCRIPTION
## Done

- Add `discourse-tag` meta tag for case studies
- Allow devs to add `meta_discourse_url` to static case studies and link them to the discourse post 

## QA

- Go to any static case study page, accessible through /case-study
- Example: /case-study/sbi-bits
- Inspect page and search for `discourse-url`, see that it links the discourse page correctly

## Issue / Card

Fixes [WD-19234](https://warthogs.atlassian.net/browse/WD-19234)

## Screenshots

[if relevant, include a screenshot]


[WD-19234]: https://warthogs.atlassian.net/browse/WD-19234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ