### PR TITLE
WD-19131 Updated link in Meganav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -537,7 +537,7 @@ solutions:
 
   preview_secondary_links:
     title: Case studies
-    title_url: https://ubuntu.com/engage/
+    title_url: https://canonical.com/case-study
     links:
       - description: Sicredi transforms its infrastructure strategy with open source.
         url: https://ubuntu.com/engage/sicredi-openstack-case-study

--- a/templates/navigation/partials/_preview-links.html
+++ b/templates/navigation/partials/_preview-links.html
@@ -1,6 +1,8 @@
 <div class="p-navigation__preview-links">
-  {% if preview_secondary_links.title %}
-    <h2 class="p-navigation--list-heading p-text--small-caps">{{ preview_secondary_links.title }}</h2>
+  {% if preview_secondary_links.title and preview_secondary_links.title_url %}
+    <h2 class="p-navigation--list-heading p-text--small-caps">
+      <a href="{{ section.preview_secondary_links.title_url }}">{{ section.preview_secondary_links.title }}&nbsp;&rsaquo;</a>
+    </h2>
   {% endif %}
   <div class="row u-no-padding">
     {% for link in preview_secondary_links.links %}


### PR DESCRIPTION
## Done

- Added clickable link to `preview_secondary_links` 
- Updated link in meganav
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [Copydoc](https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?tab=t.0#heading=h.66b5xdgm390p)
- [Demo](https://canonical-com-1556.demos.haus/)  See if the case-study link is clickable in solutions meganav.

## Issue / Card

Fixes #[WD-19131](https://warthogs.atlassian.net/browse/WD-19131)



[WD-19131]: https://warthogs.atlassian.net/browse/WD-19131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ