### PR TITLE
feat: Set names and email as active fields on contact forms 

### DIFF
--- a/templates/data/postgresql/form-data.json
+++ b/templates/data/postgresql/form-data.json
@@ -35,18 +35,6 @@
           "fields": [
             {
               "type": "text",
-              "id": "firstName",
-              "label": "First name",
-              "isRequired": true
-            },
-            {
-              "type": "text",
-              "id": "lastName",
-              "label": "Last name",
-              "isRequired": true
-            },
-            {
-              "type": "text",
               "id": "company",
               "label": "Company name",
               "isRequired": true
@@ -55,12 +43,6 @@
               "type": "text",
               "id": "title",
               "label": "Job title",
-              "isRequired": true
-            },
-            {
-              "type": "email",
-              "id": "email",
-              "label": "Work email",
               "isRequired": true
             },
             {

--- a/templates/data/streaming/form-data.json
+++ b/templates/data/streaming/form-data.json
@@ -30,18 +30,6 @@
           "fields": [
             {
               "type": "text",
-              "id": "firstName",
-              "label": "First name",
-              "isRequired": true
-            },
-            {
-              "type": "text",
-              "id": "lastName",
-              "label": "Last name",
-              "isRequired": true
-            },
-            {
-              "type": "text",
               "id": "company",
               "label": "Company name",
               "isRequired": true
@@ -50,12 +38,6 @@
               "type": "text",
               "id": "title",
               "label": "Job title",
-              "isRequired": true
-            },
-            {
-              "type": "email",
-              "id": "email",
-              "label": "Work email",
               "isRequired": true
             },
             {

--- a/templates/embedding/form-data.json
+++ b/templates/embedding/form-data.json
@@ -42,24 +42,6 @@
           "noCommentsFromLead": true,
           "fields": [
             {
-              "type": "text",
-              "id": "firstName",
-              "label": "First name",
-              "isRequired": true
-            },
-            {
-              "type": "text",
-              "id": "lastName",
-              "label": "Last name",
-              "isRequired": true
-            },
-            {
-              "type": "email",
-              "id": "email",
-              "label": "Email address",
-              "isRequired": true
-            },
-            {
               "type": "tel",
               "id": "phone",
               "label": "Mobile/cell phone number"

--- a/templates/partners/silicon/intel/form-data.json
+++ b/templates/partners/silicon/intel/form-data.json
@@ -147,18 +147,6 @@
           "fields": [
             {
               "type": "text",
-              "id": "firstName",
-              "label": "First name",
-              "isRequired": true
-            },
-            {
-              "type": "text",
-              "id": "lastName",
-              "label": "Last name",
-              "isRequired": true
-            },
-            {
-              "type": "text",
               "id": "company",
               "label": "Company name",
               "isRequired": true
@@ -167,12 +155,6 @@
               "type": "text",
               "id": "title",
               "label": "Job title",
-              "isRequired": true
-            },
-            {
-              "type": "email",
-              "id": "email",
-              "label": "Work email",
               "isRequired": true
             },
             {

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -31,7 +31,7 @@
             </div>
             <div class="col">
               <ul class="p-list">
-                {% if fieldset_id == "about-you"%}
+                {% if fieldset_id == "about-you" %}
                   <label class="is-required"
                           for="firstName">First name:</label>
                   <input required

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -31,6 +31,31 @@
             </div>
             <div class="col">
               <ul class="p-list">
+                {% if fieldset_id == "about-you"%}
+                  <label class="is-required"
+                          for="firstName">First name:</label>
+                  <input required
+                          id="firstName"
+                          name="firstName"
+                          maxlength="255"
+                          type="text" />                              
+                  <label class="is-required"
+                          for="lastName">Last name:</label>
+                  <input required
+                          id="lastName"
+                          name="lastName"
+                          maxlength="255"
+                          type="text" />
+                  <label class="is-required"
+                            for="email">Email:</label>
+                  <input required
+                          id="email"
+                          name="email"
+                          maxlength="255"
+                          type="email"
+                          pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
+                {% endif %}
+
                 {% for field in fieldset.fields %}
 
                   {% if field.id %}

--- a/templates/solutions/open-source-security/cyber-resilience-act/form-data.json
+++ b/templates/solutions/open-source-security/cyber-resilience-act/form-data.json
@@ -13,27 +13,9 @@
       "fieldsets": [
         {
           "title": "Fill in this form and a member of our team will be in touch shortly.",
-          "id": "contact-form",
+          "id": "about-you",
           "noCommentsFromLead": true,
           "fields": [
-            {
-              "type": "text",
-              "label": "First name",
-              "id": "firstName",
-              "isRequired": true
-            },
-            {
-              "type": "text",
-              "label": "Last name",
-              "id": "lastName",
-              "isRequired": true
-            },
-            {
-              "type": "email",
-              "id": "email",
-              "label": "Email address",
-              "isRequired": true
-            },
             {
               "type": "tel",
               "id": "phone",

--- a/templates/solutions/telco/form-data.json
+++ b/templates/solutions/telco/form-data.json
@@ -22,24 +22,6 @@
           "noCommentsFromLead": true,
           "fields": [
             {
-              "type": "text",
-              "id": "firstName",
-              "label": "First name",
-              "isRequired": true
-            },
-            {
-              "type": "text",
-              "id": "lastName",
-              "label": "Last name",
-              "isRequired": true
-            },
-            {
-              "type": "email",
-              "id": "email",
-              "label": "Email",
-              "isRequired": true
-            },
-            {
               "type": "country",
               "id": "country",
               "label": "Country"


### PR DESCRIPTION
## Done

- Set first name, last name and email as active by default on contact forms
- Remove entries for these active fields on affected `forms-data.json` 
- Compiled affected form IDs

## QA

- Go to affected forms
- Check that first name, last name and email are showing on the modal
- Submit form and see that it goes through Marketo as expected

## Issue / Card

Fixes [WD-17910](https://warthogs.atlassian.net/browse/WD-17910)

## Screenshots

[if relevant, include a screenshot]


[WD-17910]: https://warthogs.atlassian.net/browse/WD-17910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ