### PR TITLE
[WD-19429] migrate /edge-computing page from u.com to c.com

### DIFF
--- a/static/js/modals.js
+++ b/static/js/modals.js
@@ -217,25 +217,6 @@ function validateCheckbox(event, fieldsetId) {
   }
 }
 
-function getRadioItemValue(fieldset) {
-  const selectedRadio = fieldset.querySelector(
-    "input[name='how-many-machines-do-you-have']:checked"
-  );
-  return selectedRadio ? selectedRadio.value : "";
-}
-
-function getCheckboxItemsAsCSV(fieldset) {
-  if (fieldset) {
-    const checkboxes = Array.from(
-      fieldset.querySelectorAll("input[class='p-checkbox__input']")
-    );
-    return checkboxes
-      .filter((item) => item.checked)
-      .map((item) => item.value)
-      .join(", ");
-  }
-}
-
 function getCustomFields(event) {
   var message = "";
   var formFields = document.querySelectorAll(".js-formfield");

--- a/static/js/modals.js
+++ b/static/js/modals.js
@@ -274,10 +274,7 @@ function getCustomFields(event) {
         case "checkbox":
           if (input.checked) {
             if (fieldsetForm) {
-              var labelId = input.getAttribute("aria-labelledby");
-              var span = document.getElementById(labelId);
-              var labelText = span ? span.innerText : "";
-              message += input.value + "-" + labelText + comma + " ";
+              message += input.value + comma + " ";
             } else {
               // Forms that have column separation
               var subSectionText = "";

--- a/templates/edge-computing/base_edge-computing.html
+++ b/templates/edge-computing/base_edge-computing.html
@@ -1,0 +1,7 @@
+{% extends "base_index.html" %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1GnYX749CUopI-IY9Egf4Vr5nCQNCpf2kL0UydU_Ln2I/edit#{% endblock meta_copydoc %}
+
+{% block outer_content %}
+    {% block content %}{% endblock %}
+{% endblock %}

--- a/templates/edge-computing/index.html
+++ b/templates/edge-computing/index.html
@@ -1,0 +1,479 @@
+{% extends "edge-computing/base_edge-computing.html" %}
+
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Micro cloud | Edge computing solution{% endblock %}
+
+{% block meta_description %}
+  Micro clouds are an edge computing solution for on-demand scalable clusters at the edge. From MAAS, LXD, MicroK8s and Kubernetes at the edge, micro clouds offer automated and repeatable deployments from popular open source components. Edge micro clouds are the working default with hardware vendors and the seamless integration with public cloud providers.
+{% endblock meta_description %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1pWMeqRw3io8DlHhNDq4tZ5EKDvLJbVS4vA1kQthzLMc/edit?tab=t.0
+{% endblock meta_copydoc %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block content %}
+
+  {% call(slot) vf_hero(
+    title_text='Micro clouds',
+    subtitle_text='Edge computing solution',
+    layout='50/50-full-width-image'
+    ) -%}
+    {%- if slot == 'description' -%}
+      <p>
+        Serving compute near the consumers, reusing cloud APIs. Compose unique edge solutions using the best open source components, anywhere at scale.
+      </p>
+    {%- endif -%}
+    {%- if slot == 'cta' -%}
+      <a href="https://ubuntu.com/engage/guide-to-micro-clouds"
+         class="p-button--positive">Get the whitepaper</a>
+    {%- endif -%}
+    {%- if slot == 'image' -%}
+      <div class="p-image-container--cinematic is-cover">
+        {{ image(url="https://assets.ubuntu.com/v1/3909b910-hero.png",
+                alt="",
+                width="2464",
+                height="1027",
+                hi_def=True,
+                loading="auto",
+                attrs={"class": "p-image-container__image"}) | safe
+        }}
+      </div>
+    {% endif -%}
+  {% endcall -%}
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Industries live at the edge</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <div class="p-image-container--16-9 is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/3084203a-webinar.png",
+                        alt="",
+                        width="1824",
+                        height="1014",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-image-container__image"}) | safe
+            }}
+          </div>
+        </div>
+        <h3 class="p-heading--5">What are edge computing use cases?</h3>
+        <p>
+          Real-life applications are localized &mdash; in a factory, a shop, a theatre, a stadium, on the subway, even in motion. Edge computing has the potential to transform almost any industry, serving workloads where and when needed. Micro clouds offer a modular and scalable solution to match the constraints of the edge in almost any scenario &mdash; from cloud edge to IoT gateways.
+        </p>
+        <div class="p-cta-block">
+          <a href="https://ubuntu.com/engage/introduction-to-micro-clouds">Watch this webinar to learn more&nbsp;&rsaquo;</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    {%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=true) -%}
+      {%- if slot == 'title' -%}
+        <h2>Learn more</h2>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_1' -%}
+        <h3 class="p-heading--5">Whitepaper</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_1' -%}
+        <div class="p-section--shallow">
+          <a href="https://ubuntu.com/engage/guide-to-micro-clouds">CTOs’ Guide to Micro Clouds</a>
+          <p>
+            This whitepaper discusses the concept of micro clouds, a new class of compute for the edge and decentralized environments. It’s ideal to gain an understanding of edge computing constraints, values, graphics and use cases.
+          </p>
+          <hr class="p-rule--muted" />
+          <a href="https://ubuntu.com/engage/edge-infrastructure">Edge infrastructure implementation the open source way</a>
+          <p>
+            Implementing an edge strategy entails a number of challenges. Explore how you can design edge infrastructure, from Multi-access Edge Computing (MEC) through to private mobile networks and IoT gateways, the open source way.
+          </p>
+        </div>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_2' -%}
+        <h3 class="p-heading--5">Webinar</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_2' -%}
+        <a href="https://ubuntu.com/engage/introduction-to-micro-clouds">Introduction to Micro Clouds</a>
+        <p>
+          A micro cloud is a new class of infrastructure for on-demand computing at the edge. Learn what micro clouds are and why they should be a part of your edge strategy.
+        </p>
+      {%- endif -%}
+    {%- endcall -%}
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>
+          Localized cloud APIs
+          <br />
+          with micro clouds
+        </h2>
+      </div>
+      <div class="col">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">Reusing proven clouds primitive</li>
+          <li class="p-list__item is-ticked">Modular micro clouds, API integration with existing solutions</li>
+          <li class="p-list__item is-ticked">Fully automated, centrally managed, with low to no onsite operations</li>
+        </ul>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        <div class="p-equal-height-row">
+          <div class="col-3 col-medium-2 p-equal-height-row__col">
+            <div class="p-image-container p-equal-height-row__item u-hide--small">
+              {{ image(url="https://assets.ubuntu.com/v1/9c1a227f-Industry 4.0_ inside the factory.png",
+                            alt="",
+                            width="852",
+                            height="1278",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-image-container__image"}) | safe
+              }}
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">Industry 4.0: inside the factory</h3>
+            <ul class="p-equal-height-row__item p-list--divided">
+              <li class="p-list__item has-bullet">Scalable and low-latency HA cluster for critical industrial applications</li>
+              <li class="p-list__item has-bullet">Local data processing for more governance and less network costs</li>
+              <li class="p-list__item has-bullet">Compute power at the factory core for Al and digital twins applications</li>
+            </ul>
+            <div class="p-cta-block p-equal-height-row__item">
+              <a href="https://ubuntu.com/internet-of-things/gateways">Connect IIoT devices to micro clouds&nbsp;&rsaquo;</a>
+            </div>
+          </div>
+          <div class="col-3 col-medium-2 p-equal-height-row__col">
+            <div class="p-image-container p-equal-height-row__item u-hide--small">
+              {{ image(url="https://assets.ubuntu.com/v1/f5e5bf7b-Telco edge_ 5G & edge computing.png",
+                            alt="",
+                            width="852",
+                            height="1278",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-image-container__image"}) | safe
+              }}
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">Telco edge: 5G & edge computing</h3>
+            <ul class="p-equal-height-row__item p-list--divided">
+              <li class="p-list__item has-bullet">Lightweight to run on small servers constrained by real estate</li>
+              <li class="p-list__item has-bullet">API-driven for providing on-demand compute and services</li>
+              <li class="p-list__item has-bullet">Distributed workloads, serving compute near the consumer</li>
+            </ul>
+            <div class="p-cta-block p-equal-height-row__item">
+              <a href="https://ubuntu.com/telco">Read more on Telco@Edge&nbsp;&rsaquo;</a>
+            </div>
+          </div>
+          <div class="col-3 col-medium-2 p-equal-height-row__col">
+            <div class="p-image-container p-equal-height-row__item u-hide--small">
+              {{ image(url="https://assets.ubuntu.com/v1/64c70419-Smart%20cities,%20utilities,%20and%20power%20grids.png",
+                            alt="",
+                            width="852",
+                            height="1278",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-image-container__image"}) | safe
+              }}
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">Smart cities, utilities, and power grids</h3>
+            <ul class="p-equal-height-row__item p-list--divided">
+              <li class="p-list__item has-bullet">Real time data analysis for automated resource allocation</li>
+              <li class="p-list__item has-bullet">Fully automated and resilient for remote site locations</li>
+              <li class="p-list__item has-bullet">Decentralized data driven predictive maintenance</li>
+            </ul>
+            <div class="p-cta-block p-equal-height-row__item">
+              <a href="https://ubuntu.com/internet-of-things/smart-city">Read more on Smart Cities&nbsp;&rsaquo;</a>
+            </div>
+          </div>
+        </div>
+        <div class="p-section--shallow u-hide--medium u-hide--small"></div>
+        <div class="p-equal-height-row">
+          <div class="col-3 col-medium-2 p-equal-height-row__col u-hide--medium u-hide--small"></div>
+          <div class="col-3 col-medium-2 p-equal-height-row__col">
+            <div class="p-image-container p-equal-height-row__item u-hide--small">
+              {{ image(url="https://assets.ubuntu.com/v1/1713e2f9-The future of remote-work with edge computing.png",
+                            alt="",
+                            width="852",
+                            height="1278",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-image-container__image"}) | safe
+              }}
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">The future of remote-work with edge computing</h3>
+            <ul class="p-equal-height-row__item p-list--divided">
+              <li class="p-list__item has-bullet">Low-touch, self-healing, few to no human interactions</li>
+              <li class="p-list__item has-bullet">Central remote management for corporate policies</li>
+              <li class="p-list__item has-bullet">On-demand K8s clusters, virtual machines, and containers</li>
+            </ul>
+            <div class="p-cta-block p-equal-height-row__item">
+              <a href="https://ubuntu.com/desktop/organisations">Read about Ubuntu in organizations&nbsp;&rsaquo;</a>
+            </div>
+          </div>
+          <div class="col-3 col-medium-2 p-equal-height-row__col">
+            <div class="p-image-container p-equal-height-row__item u-hide--small">
+              {{ image(url="https://assets.ubuntu.com/v1/010c6eac-Micro cloud for end-consumer applications in retail.png",
+                            alt="",
+                            width="852",
+                            height="1278",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-image-container__image"}) | safe
+              }}
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">Micro cloud for end-consumer applications in retail</h3>
+            <ul class="p-equal-height-row__item p-list--divided">
+              <li class="p-list__item has-bullet">Reliable, resilient to cloud outages to prevent downtimes</li>
+              <li class="p-list__item has-bullet">Predictions and insights with data analytics and inferences at the edge</li>
+              <li class="p-list__item has-bullet">Running on low cost small devices</li>
+            </ul>
+            <div class="p-cta-block p-equal-height-row__item">
+              <a href="https://ubuntu.com/financial-services">Explore our FinTech solutions&nbsp;&rsaquo;</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>
+          Let’s discuss
+          <br />
+          your edge application
+        </h2>
+      </div>
+      <div class="col">
+        <p>
+          The Canonical team can deploy the first site with you to enable your edge strategy and upskill your teams. We provide long-term security maintenance and technical support for all the open source components you need to build your micro cloud.
+        </p>
+        <hr class="p-rule--muted" />
+        <a href="/contact-us" class="p-button" aria-controls="homepage-modal">Get in touch</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+          <h2>
+            Integrate with
+            <br />
+            the best hardware vendors
+          </h2>
+        </div>
+        <div class="col">
+          <p>Ubuntu works with a number of hardware vendors specialized in edge computing server equipment.</p>
+          <div class="p-cta-block">
+            <a href="/contact-us" aria-controls="homepage-modal">Contact us to discuss working with your preferred vendors&nbsp;&rsaquo;</a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="u-fixed-width">
+      <div class="p-logo-section">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/94085dbf-arm-logo.png",
+                        alt="ARM",
+                        width="76",
+                        height="156",
+                        hi_def=True,
+                        loading="lazy") | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/d4663b3e-nvidia-logo.png",
+                        alt="NVidia",
+                        width="155",
+                        height="156",
+                        hi_def=True,
+                        loading="lazy") | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/677e5ba9-intel-new-logo.png",
+                        alt="Intel",
+                        width="81",
+                        height="156",
+                        hi_def=True,
+                        loading="lazy") | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/a684b3b2-Hewlett-Packard-logo.png",
+                        alt="Hewlett Packard",
+                        width="141",
+                        height="156",
+                        hi_def=True,
+                        loading="lazy") | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/8d0e5ce4-Dell-logo.png",
+                        alt="Dell",
+                        width="156",
+                        height="156",
+                        hi_def=True,
+                        loading="lazy") | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/b466c5c3-hp-logo.png",
+                        alt="HP",
+                        width="66",
+                        height="156",
+                        hi_def=True,
+                        loading="lazy") | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/99418046-lenovo-logo.png",
+                        alt="Lenovo",
+                        width="101",
+                        height="156",
+                        hi_def=True,
+                        loading="lazy") | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/d4dc5e10-cisco-logo.png",
+                        alt="Cisco",
+                        width="94",
+                        height="156",
+                        hi_def=True,
+                        loading="lazy") | safe
+            }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    {%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=false) -%}
+      {%- if slot == 'title' -%}
+        <h2>Micro clouds under the microscope</h2>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_1' -%}
+        <h3 class="p-heading--5">What are micro clouds?</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_1' -%}
+        <div class="p-section--shallow">
+          <div class="p-image-container--3-2 is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/d694b804-edge-computing-updated.png",
+                        alt="Edge computing micro cloud architecture",
+                        width="1800",
+                        height="1201",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-image-container__image"}) | safe
+            }}
+          </div>
+        </div>
+        <p>
+          Edge computing isn’t a solution: it’s a term for describing geographically-distributed computing. Micro clouds are a solution for edge computing.
+        </p>
+        <p>
+          A micro cloud is a new class of infrastructure for on-demand computing at the edge. Micro clouds are small footprint clusters of compute nodes with local storage and secure networking, optimized for repeatable, reliable remote deployments.
+        </p>
+        <p>
+          Standard and open APIs provide the same functionality you would expect from larger clouds, and an abstraction layer separates the hardware from the software.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_2' -%}
+        <h3 class="p-heading--5">Advantages of micro clouds for edge computing</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_2' -%}
+        <p>
+          Micro cloud enables you to compose customized edge computing solutions from the best open source components, anywhere and at scale.
+        </p>
+        <ul class="p-list--divided">
+          <li class="p-list__item has-bullet">Flexibility and scalability</li>
+          <li class="p-list__item has-bullet">Full-stack automation</li>
+          <li class="p-list__item has-bullet">Open and standard APIs</li>
+          <li class="p-list__item has-bullet">Abstraction layer</li>
+        </ul>
+        <p>
+          The edge of the network is the center of everyday businesses and applications. Micro clouds empower ecosystems rather than single-vendor solutions, bringing apps closer to the consumers.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_3' -%}
+        <h3 class="p-heading--5">What is the size of a micro cloud?</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_3' -%}
+        <p>
+          Micro clouds go from tiny <a href="https://ubuntu.com/kubernetes">Kubernetes</a> clusters in an outdoor box to small private edge clouds localized nearest to the consumers of an application. They can extend in site size, scale number of sites, and run with no on-site maintenance.
+        </p>
+      {%- endif -%}
+
+    {%- endcall -%}
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Connect with our experts today</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <div class="p-image-containner--3-2">
+            {{ image(url="https://assets.ubuntu.com/v1/316be044-connect.png",
+                        alt="",
+                        width="1800",
+                        height="1201",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-image-container__image"}) | safe
+            }}
+          </div>
+        </div>
+        <p>
+          Trade the exponential scalability of public and private clouds for security, privacy, governance, and low-latency of decentralized edge computing environments.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="is-fixed-width p-rule" />
+
+  <section class="p-strip is-deep">
+    <div class="u-fixed-width">
+      <a href="/contact-us"
+         class="p-heading--2"
+         aria-controls="homepage-modal">Get in touch&nbsp;&rsaquo;</a>
+    </div>
+  </section>
+
+  {% with %}
+    {% set formid = "4271" %}
+    {% set returnURL = "https://canonical.com/edge-computing#success" %}
+    {% include "partners/partial/_homepage-form.html" %}
+  {% endwith %}
+
+{% endblock content %}

--- a/templates/partners/partial/_homepage-form.html
+++ b/templates/partners/partial/_homepage-form.html
@@ -27,100 +27,103 @@
         </div>
       </div>
       <hr class="p-rule--muted" />
-      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right js-formfield js-toggle-checkbox-visibility"
-           id="ubuntu-versions">
-        <div class="col">
-          <legend class="u-off-screen">If you use Ubuntu, which version or versions are you using?</legend>
-          <h4 class="js-formfield-title">If you use Ubuntu, which version(s) are you using?</h4>
-        </div>
-        <div class="col">
-          <div class="row u-no-padding">
-            <div class="col-4 u-sv3">
-              <strong>LTS within standard support</strong>
-              <label class="p-checkbox">
-                <input type="checkbox"
-                       aria-labelledby="24-04"
-                       class="p-checkbox__input js-checkbox-visibility"
-                       value="24.04 LTS" />
-                <span class="p-checkbox__label" id="22-04">24.04 LTS</span>
-              </label>
-              <label class="p-checkbox">
-                <input type="checkbox"
-                       aria-labelledby="22-04"
-                       class="p-checkbox__input js-checkbox-visibility"
-                       value="22.04 LTS" />
-                <span class="p-checkbox__label" id="22-04">22.04 LTS</span>
-              </label>
-              <label class="p-checkbox">
-                <input type="checkbox"
-                       aria-labelledby="20-04"
-                       class="p-checkbox__input js-checkbox-visibility"
-                       value="20.04 LTS" />
-                <span class="p-checkbox__label" id="20-04">20.04 LTS</span>
-              </label>
-            </div>
-            <div class="col-4 u-sv3">
-              <strong>LTS out of standard support</strong>
-              <label class="p-checkbox">
-                <input type="checkbox"
-                       aria-labelledby="18-04"
-                       class="p-checkbox__input js-checkbox-visibility"
-                       value="18.04 LTS" />
-                <span class="p-checkbox__label" id="18-04">18.04 LTS</span>
-              </label>
-              <label class="p-checkbox">
-                <input type="checkbox"
-                       aria-labelledby="16-04"
-                       class="p-checkbox__input js-checkbox-visibility"
-                       value="16.04 LTS" />
-                <span class="p-checkbox__label" id="16-04">16.04 LTS</span>
-              </label>
-              <label class="p-checkbox">
-                <input type="checkbox"
-                       aria-labelledby="14-04"
-                       class="p-checkbox__input js-checkbox-visibility"
-                       value="14.04 LTS" />
-                <span class="p-checkbox__label" id="14-04">14.04 LTS</span>
-              </label>
-            </div>
-            <div class="col-4 u-sv3">
-              <strong>Outdated or non-LTS releases</strong>
-              <label class="p-checkbox">
-                <input type="checkbox"
-                       aria-labelledby="22-10"
-                       class="p-checkbox__input js-checkbox-visibility"
-                       value="22.10 (interim release)" />
-                <span class="p-checkbox__label" id="22-10">non-LTS release</span>
-              </label>
-              <label class="p-checkbox">
-                <input type="checkbox"
-                       aria-labelledby="12-04"
-                       class="p-checkbox__input js-checkbox-visibility"
-                       value="12.04 LTS" />
-                <span class="p-checkbox__label" id="12-04">12.04 LTS</span>
-              </label>
-            </div>
-            <div class="col-4 u-sv3">
-              <strong>Other</strong>
-              <label class="p-checkbox">
-                <input type="checkbox"
-                       aria-labelledby="dont-use-ubuntu-today"
-                       class="p-checkbox__input js-checkbox-visibility__other"
-                       value="I don't use Ubuntu today" />
-                <span class="p-checkbox__label" id="dont-use-ubuntu-today">I don't use
-                Ubuntu today</span>
-              </label>
-              <label class="p-checkbox">
-                <input type="checkbox"
-                       aria-labelledby="i-dont-know"
-                       class="p-checkbox__input js-checkbox-visibility__other"
-                       value="I don't know" />
-                <span class="p-checkbox__label" id="i-dont-know">I don't know</span>
-              </label>
+      <fieldset class="p-fieldset-section js-formfield js-toggle-checkbox-visibility"
+                aria-labelledby="ubuntu-versions-legend">
+        <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right"
+             id="ubuntu-versions">
+          <div class="col">
+            <legend class="u-off-screen">If you use Ubuntu, which version or versions are you using?</legend>
+            <h4 class="js-formfield-title">If you use Ubuntu, which version(s) are you using?</h4>
+          </div>
+          <div class="col">
+            <div class="row u-no-padding">
+              <div class="col-4 u-sv3">
+                <strong>LTS within standard support</strong>
+                <label class="p-checkbox">
+                  <input type="checkbox"
+                         aria-labelledby="24-04"
+                         class="p-checkbox__input js-checkbox-visibility"
+                         value="24.04 LTS" />
+                  <span class="p-checkbox__label" id="22-04">24.04 LTS</span>
+                </label>
+                <label class="p-checkbox">
+                  <input type="checkbox"
+                         aria-labelledby="22-04"
+                         class="p-checkbox__input js-checkbox-visibility"
+                         value="22.04 LTS" />
+                  <span class="p-checkbox__label" id="22-04">22.04 LTS</span>
+                </label>
+                <label class="p-checkbox">
+                  <input type="checkbox"
+                         aria-labelledby="20-04"
+                         class="p-checkbox__input js-checkbox-visibility"
+                         value="20.04 LTS" />
+                  <span class="p-checkbox__label" id="20-04">20.04 LTS</span>
+                </label>
+              </div>
+              <div class="col-4 u-sv3">
+                <strong>LTS out of standard support</strong>
+                <label class="p-checkbox">
+                  <input type="checkbox"
+                         aria-labelledby="18-04"
+                         class="p-checkbox__input js-checkbox-visibility"
+                         value="18.04 LTS" />
+                  <span class="p-checkbox__label" id="18-04">18.04 LTS</span>
+                </label>
+                <label class="p-checkbox">
+                  <input type="checkbox"
+                         aria-labelledby="16-04"
+                         class="p-checkbox__input js-checkbox-visibility"
+                         value="16.04 LTS" />
+                  <span class="p-checkbox__label" id="16-04">16.04 LTS</span>
+                </label>
+                <label class="p-checkbox">
+                  <input type="checkbox"
+                         aria-labelledby="14-04"
+                         class="p-checkbox__input js-checkbox-visibility"
+                         value="14.04 LTS" />
+                  <span class="p-checkbox__label" id="14-04">14.04 LTS</span>
+                </label>
+              </div>
+              <div class="col-4 u-sv3">
+                <strong>Outdated or non-LTS releases</strong>
+                <label class="p-checkbox">
+                  <input type="checkbox"
+                         aria-labelledby="22-10"
+                         class="p-checkbox__input js-checkbox-visibility"
+                         value="22.10 (interim release)" />
+                  <span class="p-checkbox__label" id="22-10">non-LTS release</span>
+                </label>
+                <label class="p-checkbox">
+                  <input type="checkbox"
+                         aria-labelledby="12-04"
+                         class="p-checkbox__input js-checkbox-visibility"
+                         value="12.04 LTS" />
+                  <span class="p-checkbox__label" id="12-04">12.04 LTS</span>
+                </label>
+              </div>
+              <div class="col-4 u-sv3">
+                <strong>Other</strong>
+                <label class="p-checkbox">
+                  <input type="checkbox"
+                         aria-labelledby="dont-use-ubuntu-today"
+                         class="p-checkbox__input js-checkbox-visibility__other"
+                         value="I don't use Ubuntu today" />
+                  <span class="p-checkbox__label" id="dont-use-ubuntu-today">I don't use
+                  Ubuntu today</span>
+                </label>
+                <label class="p-checkbox">
+                  <input type="checkbox"
+                         aria-labelledby="i-dont-know"
+                         class="p-checkbox__input js-checkbox-visibility__other"
+                         value="I don't know" />
+                  <span class="p-checkbox__label" id="i-dont-know">I don't know</span>
+                </label>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </fieldset>
       <hr class="p-rule--muted" />
       <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right js-formfield"
            id="kind-of-device">

--- a/templates/partners/partial/_homepage-form.html
+++ b/templates/partners/partial/_homepage-form.html
@@ -17,21 +17,21 @@
           onsubmit="getCustomFields(event)">
       <p>Fill in this form and we'll be in touch within one working day.</p>
       <hr class="p-rule--muted" />
-      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right">
+      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right js-formfield">
         <div class="col">
           <legend class="u-off-screen">Tell us about your project and team</legend>
-          <h4>Tell us about your project</h4>
+          <h4 class="js-formfield-title">Tell us about your project</h4>
         </div>
         <div class="col">
           <textarea id="about-your-project" rows="3"></textarea>
         </div>
       </div>
       <hr class="p-rule--muted" />
-      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right"
+      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right js-formfield js-toggle-checkbox-visibility"
            id="ubuntu-versions">
         <div class="col">
           <legend class="u-off-screen">If you use Ubuntu, which version or versions are you using?</legend>
-          <h4>If you use Ubuntu, which version(s) are you using?</h4>
+          <h4 class="js-formfield-title">If you use Ubuntu, which version(s) are you using?</h4>
         </div>
         <div class="col">
           <div class="row u-no-padding">
@@ -40,21 +40,21 @@
               <label class="p-checkbox">
                 <input type="checkbox"
                        aria-labelledby="24-04"
-                       class="p-checkbox__input"
+                       class="p-checkbox__input js-checkbox-visibility"
                        value="24.04 LTS" />
                 <span class="p-checkbox__label" id="22-04">24.04 LTS</span>
               </label>
               <label class="p-checkbox">
                 <input type="checkbox"
                        aria-labelledby="22-04"
-                       class="p-checkbox__input"
+                       class="p-checkbox__input js-checkbox-visibility"
                        value="22.04 LTS" />
                 <span class="p-checkbox__label" id="22-04">22.04 LTS</span>
               </label>
               <label class="p-checkbox">
                 <input type="checkbox"
                        aria-labelledby="20-04"
-                       class="p-checkbox__input"
+                       class="p-checkbox__input js-checkbox-visibility"
                        value="20.04 LTS" />
                 <span class="p-checkbox__label" id="20-04">20.04 LTS</span>
               </label>
@@ -64,21 +64,21 @@
               <label class="p-checkbox">
                 <input type="checkbox"
                        aria-labelledby="18-04"
-                       class="p-checkbox__input"
+                       class="p-checkbox__input js-checkbox-visibility"
                        value="18.04 LTS" />
                 <span class="p-checkbox__label" id="18-04">18.04 LTS</span>
               </label>
               <label class="p-checkbox">
                 <input type="checkbox"
                        aria-labelledby="16-04"
-                       class="p-checkbox__input"
+                       class="p-checkbox__input js-checkbox-visibility"
                        value="16.04 LTS" />
                 <span class="p-checkbox__label" id="16-04">16.04 LTS</span>
               </label>
               <label class="p-checkbox">
                 <input type="checkbox"
                        aria-labelledby="14-04"
-                       class="p-checkbox__input"
+                       class="p-checkbox__input js-checkbox-visibility"
                        value="14.04 LTS" />
                 <span class="p-checkbox__label" id="14-04">14.04 LTS</span>
               </label>
@@ -88,14 +88,14 @@
               <label class="p-checkbox">
                 <input type="checkbox"
                        aria-labelledby="22-10"
-                       class="p-checkbox__input"
+                       class="p-checkbox__input js-checkbox-visibility"
                        value="22.10 (interim release)" />
                 <span class="p-checkbox__label" id="22-10">non-LTS release</span>
               </label>
               <label class="p-checkbox">
                 <input type="checkbox"
                        aria-labelledby="12-04"
-                       class="p-checkbox__input"
+                       class="p-checkbox__input js-checkbox-visibility"
                        value="12.04 LTS" />
                 <span class="p-checkbox__label" id="12-04">12.04 LTS</span>
               </label>
@@ -105,7 +105,7 @@
               <label class="p-checkbox">
                 <input type="checkbox"
                        aria-labelledby="dont-use-ubuntu-today"
-                       class="p-checkbox__input"
+                       class="p-checkbox__input js-checkbox-visibility__other"
                        value="I don't use Ubuntu today" />
                 <span class="p-checkbox__label" id="dont-use-ubuntu-today">I don't use
                 Ubuntu today</span>
@@ -113,7 +113,7 @@
               <label class="p-checkbox">
                 <input type="checkbox"
                        aria-labelledby="i-dont-know"
-                       class="p-checkbox__input"
+                       class="p-checkbox__input js-checkbox-visibility__other"
                        value="I don't know" />
                 <span class="p-checkbox__label" id="i-dont-know">I don't know</span>
               </label>
@@ -122,11 +122,11 @@
         </div>
       </div>
       <hr class="p-rule--muted" />
-      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right"
+      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right js-formfield"
            id="kind-of-device">
         <div class="col">
           <legend class="u-off-screen">What kind of device are you using?*</legend>
-          <h4>What kind of device are you using?*</h4>
+          <h4 class="js-formfield-title">What kind of device are you using?*</h4>
         </div>
         <div class="col">
           <div class="row u-no-padding">
@@ -177,11 +177,11 @@
         </div>
       </div>
       <hr class="p-rule--muted" />
-      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right"
+      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right js-formfield"
            id="how-many-machines">
         <div class="col">
           <legend class="u-off-screen">How many devices?*</legend>
-          <h4>How many devices?*</h4>
+          <h4 class="js-formfield-title">How many devices?*</h4>
         </div>
         <div class="col">
           <div class="row u-no-padding">
@@ -237,11 +237,11 @@
         </div>
       </div>
       <hr class="p-rule--muted" />
-      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right"
+      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right js-formfield"
            id="how-do-you-consume-open-source">
         <div class="col">
           <legend class="u-off-screen">How do you consume open source?</legend>
-          <h4>How do you consume open source?</h4>
+          <h4 class="js-formfield-title">How do you consume open source?</h4>
         </div>
         <div class="col">
           <div class="row u-no-padding">
@@ -279,11 +279,11 @@
         </div>
       </div>
       <hr class="p-rule--muted" />
-      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right"
+      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right js-formfield"
            id="hardening-requirements">
         <div class="col">
           <legend class="u-off-screen">Do you have specific compliance or hardening requirements?</legend>
-          <h4>Do you have specific compliance or hardening requirements?</h4>
+          <h4 class="js-formfield-title">Do you have specific compliance or hardening requirements?</h4>
         </div>
         <div class="col">
           <div class="row u-no-padding">
@@ -349,13 +349,13 @@
         </div>
       </div>
       <hr class="p-rule--muted" />
-      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right"
+      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right js-formfield"
            id="responsible-for-tracking">
         <div class="col">
           <legend class="u-off-screen">
             Who is responsible for tracking, testing and applying CVE patches in a timely manner?
           </legend>
-          <h4>Who is responsible for tracking, testing and applying CVE patches in a timely manner?</h4>
+          <h4 class="js-formfield-title">Who is responsible for tracking, testing and applying CVE patches in a timely manner?</h4>
         </div>
         <div class="col">
           <div class="row u-no-padding">
@@ -393,10 +393,10 @@
         </div>
       </div>
       <hr class="p-rule--muted" />
-      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right">
+      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right js-formfield">
         <div class="col">
           <legend class="u-off-screen">What advice are you looking for?</legend>
-          <h4>What advice are you looking for?</h4>
+          <h4 class="js-formfield-title">What advice are you looking for?</h4>
         </div>
         <div class="col">
           <textarea id="advice"
@@ -443,8 +443,8 @@
               <label for="jobTitle">Job title:</label>
               <input required id="jobTitle" name="title" maxlength="255" type="text" />
             </li>
-            <li class="p-list__item">
-              <label for="selfReportedAttribution">How did you hear about us?</label>
+            <li class="p-list__item js-formfield">
+              <label for="selfReportedAttribution" class="js-formfield-title">How did you hear about us?</label>
               <input id="selfReportedAttribution"
                      name="selfReportedAttribution"
                      maxlength="255"

--- a/templates/partners/partial/_homepage-form.html
+++ b/templates/partners/partial/_homepage-form.html
@@ -177,7 +177,7 @@
         </div>
       </div>
       <hr class="p-rule--muted" />
-      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right js-formfield"
+      <div class="row--50-50 p-section--shallow u-no-padding--left u-no-padding--right js-formfield js-remove-radio-names"
            id="how-many-machines">
         <div class="col">
           <legend class="u-off-screen">How many devices?*</legend>
@@ -355,7 +355,9 @@
           <legend class="u-off-screen">
             Who is responsible for tracking, testing and applying CVE patches in a timely manner?
           </legend>
-          <h4 class="js-formfield-title">Who is responsible for tracking, testing and applying CVE patches in a timely manner?</h4>
+          <h4 class="js-formfield-title">
+            Who is responsible for tracking, testing and applying CVE patches in a timely manner?
+          </h4>
         </div>
         <div class="col">
           <div class="row u-no-padding">


### PR DESCRIPTION
## Done

- Basically copy pasted an existing page at ubuntu.com/edge-computing to a new page at canonical.com. 
- There is another PR [here](https://github.com/canonical/ubuntu.com/pull/14758) that removes the page from ubuntu.com and redirects it to this new webpage.
- Used the same type of modal form as on ubuntu.com/edge-computing. It has already been created on canonical.com before, so just reused that with a different form ID.
- Created a new copy document in canonica.com's GDrive folder (by copying the old one) and referenced that in the new page.

## QA

- Open the demo at https://canonical-com-1564.demos.haus/edge-computing
- Observe the page and check that it looks identical to the one at https://ubuntu.com/edge-computing
- Click on "Get in touch" links/buttons and verify that the form works and submits to Marketo

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-19429
