### PR TITLE
fix: Modal invoke bug

### DIFF
--- a/templates/macros/_macros-cta.jinja
+++ b/templates/macros/_macros-cta.jinja
@@ -11,7 +11,7 @@
         <div class="col-start-large-4 col-9">
           <p class="p-heading--2">
             <a href="{{ link }}"
-             aria-controls="case-study-contact-modal">
+            {% if has_modal %}aria-controls="case-study-contact-modal"{% endif %}>
               {{ title }}&nbsp;&rsaquo;
             </a>
           </p>


### PR DESCRIPTION
## Done

- Fix bug for cta macro to only invoke modal when `has_modal` is set to True

## QA

- Go to https://canonical-com-1567.demos.haus/case-study/grundium-ubuntu-pro-for-devices
- Scroll down to CTA section
- Click on the link and see that it links to a page rather than invoking a modal

## Issue / Card

Fixes [WD-19467](https://warthogs.atlassian.net/browse/WD-19467)

## Screenshots

[if relevant, include a screenshot]


[WD-19467]: https://warthogs.atlassian.net/browse/WD-19467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ