### PR TITLE
chore: Update Dell logo on the Microcloud page

### DIFF
--- a/templates/microcloud/index.html
+++ b/templates/microcloud/index.html
@@ -443,10 +443,10 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/fa3697a9-dell-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/231d8b6f-Dell_logo.png",
                         alt="Dell",
-                        width="172",
-                        height="312",
+                        width="276",
+                        height="385",
                         hi_def=True,
                         loading="lazy",
                         attrs={"class": "p-logo-section__logo"}) | safe


### PR DESCRIPTION
## Done

Updated the Dell logo on the Microcloud page

## QA

- Go to https://canonical-com-1574.demos.haus/microcloud
- Check that the Dell logo has changed (compare to [production](https://canonical.com/microcloud))

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-19550
