### PR TITLE
Update the latest release of Multipass to 1.15.1

### DIFF
--- a/static/files/latest-multipass-releases.json
+++ b/static/files/latest-multipass-releases.json
@@ -1,11 +1,11 @@
 {
-  "version": "1.15.0",
-  "title": "Multipass 1.15.0 release",
-  "description": "Clone, bridging on QEMU/Linux, Updated GUI, MSI installer.",
+  "version": "1.15.1",
+  "title": "Multipass 1.15.1 release",
+  "description": "Bug fixes for mounts, the GUI, and more.",
   "download_url": "https://canonical.com/multipass/install",
-  "release_url": "https://github.com/canonical/multipass/releases/tag/v1.15.0",
+  "release_url": "https://github.com/canonical/multipass/releases/tag/v1.15.1",
   "installer_urls": {
-    "windows": "https://github.com/canonical/multipass/releases/download/v1.15.0/multipass-1.15.0+win-win64.msi",
-    "macos": "https://github.com/canonical/multipass/releases/download/v1.15.0/multipass-1.15.0+mac-Darwin.pkg"
+    "windows": "https://github.com/canonical/multipass/releases/download/v1.15.1/multipass-1.15.1+win-win64.msi",
+    "macos": "https://github.com/canonical/multipass/releases/download/v1.15.1/multipass-1.15.1+mac-Darwin.pkg"
   }
 }


### PR DESCRIPTION
## Done

- Update the latest release of Multipass to 1.15.1.
- Update urls and description accordingly.
