### PR TITLE
[WD-17926] copy update for opensearch

### DIFF
--- a/templates/data/opensearch/what-is-opensearch.html
+++ b/templates/data/opensearch/what-is-opensearch.html
@@ -275,7 +275,7 @@
               </p>
               <div class="p-image-wrapper">
                 <div class="p-image-container u-hide--small">
-                  {{ image(url="https://assets.ubuntu.com/v1/41ec4805-OpenSearch Cluster.png",
+                  {{ image(url="https://assets.ubuntu.com/v1/817b2f30-OpenSearch%20Cluster%201%20-%20v2@2x.png",
                                     alt="",
                                     width="3545",
                                     height="1196",
@@ -553,13 +553,13 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-3 col-medium-3">
-            <h3 class="p-heading--5">OpenSearch Rock container image</h3>
+            <h3 class="p-heading--5">OpenSearch OCI-compliant container image</h3>
           </div>
           <div class="col-6 col-medium-3">
             <p class="p-heading--5">Included in Ubuntu Pro + Support</p>
             <p>
-              Also included in Ubuntu Pro + Support, you get support for Canonical’s container image
-              OpenSearch, based on Ubuntu LTS. So solid and secure, we call it a Rock.
+              Also included in Ubuntu Pro + Support, you get support for Canonical’s OCI-compliant 
+              container image for OpenSearch, based on Ubuntu LTS.
             </p>
             <hr class="p-rule--muted" />
             <div class="p-section--shallow">


### PR DESCRIPTION
## Done

- opensearch diagram
- replaced 'Rock' references to `OCI-compliant` containers.

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://localhost:8002/data/opensearch/what-is-opensearch
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

