### PR TITLE
feat: Implement sitemaps tree parser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ google-auth-oauthlib==0.5.1
 pytz==2024.1
 djlint==1.34.1
 responses==0.25.3
+-e ../parser

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -28,6 +28,7 @@ from canonicalwebteam.discourse import (
     EngagePages,
 )
 from canonicalwebteam.search import build_search_view
+from canonicalwebteam.parser import scan_directory
 from requests.exceptions import HTTPError
 from slugify import slugify
 
@@ -1389,3 +1390,18 @@ case_studies = EngagePages(
 app.add_url_rule(
     case_study_path, view_func=build_case_study_index(case_studies)
 )
+
+
+def get_sitemaps_tree():
+    try:
+        tree = scan_directory("/home/ubuntu/canonical-com/templates")
+    except Exception as e:
+        raise Exception(f"Error scanning directory: {e}")
+    return tree
+
+
+get_sitemaps_tree()
+
+
+# TODO: Endpoint for testing and QA purposes only
+app.add_url_rule("/sitemaps_parser", view_func=get_sitemaps_tree)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1394,7 +1394,7 @@ app.add_url_rule(
 
 def get_sitemaps_tree():
     try:
-        tree = scan_directory("/home/ubuntu/canonical-com/templates")
+        tree = scan_directory(os.getcwd() + "/templates")
     except Exception as e:
         raise Exception(f"Error scanning directory: {e}")
     return tree


### PR DESCRIPTION
## Done
- Implemented parser that reads the tree structure of canonical.com and returns the title, name, description and link of every website
- Added `/sitemaps_parser` endpoint for QA purposes
- Parser repo [here](https://github.com/canonical/canonicalwebteam.parser/)
- Fly-by: Add missing `index.html` on `/templates/data/docs` that was throwing an error.

## QA

- Check out of this branch
- Clone the parser repo https://github.com/canonical/canonicalwebteam.parser/
- Make sure that the parser repo is in the same working directory as canonical.com repo
- Run the project locally using `dotrun -m "<path-to-parser>/canonicalwebteam.parser":../parser`
- Once canonical.com is spun up locally, visit http://0.0.0.0:8002/sitemaps_parser
- See that the tree parser of all canonical.com websites are present in JSON format
- Visit http://0.0.0.0:8002/templates/data/docs
- See that it loads the documentation page as expected

## Issue / Card

Fixes [WD-19198](https://warthogs.atlassian.net/browse/WD-19198)

## Screenshots

[if relevant, include a screenshot]


[WD-19198]: https://warthogs.atlassian.net/browse/WD-19198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ