### PR TITLE
feat: Update requirements to use sitemaps-parser package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ canonicalwebteam.image-template==1.5.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.discourse==5.7.4
 canonicalwebteam.search==2.1.1
+canonicalwebteam.sitemaps-parser===1.0.1
 bleach==5.0.1
 markdown==3.5.2
 python-slugify==8.0.1
@@ -17,4 +18,3 @@ google-auth-oauthlib==0.5.1
 pytz==2024.1
 djlint==1.34.1
 responses==0.25.3
--e ../parser

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -28,7 +28,7 @@ from canonicalwebteam.discourse import (
     EngagePages,
 )
 from canonicalwebteam.search import build_search_view
-from canonicalwebteam.parser import scan_directory
+from canonicalwebteam.sitemaps_parser import scan_directory
 from requests.exceptions import HTTPError
 from slugify import slugify
 


### PR DESCRIPTION
## Done

- Published sitemaps-repo on test PyPi - [package here](https://test.pypi.org/project/canonicalwebteam.sitemaps-parser/1.0.0/)
- Update `requirements.txt` to use the package
- Note: The package is currently on test pypi. It will be migrated outside of test before this feature branch is merged

## QA

- Check that demo loads
- Go to /sitemaps_parser
- See that it shows JSON field of directory tree

## Issue / Card

Fixes [WD-19979](https://warthogs.atlassian.net/browse/WD-19979)


Fixes #

## Screenshots

[if relevant, include a screenshot]


[WD-19979]: https://warthogs.atlassian.net/browse/WD-19979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ