### PR TITLE
fix: Hot fix for careers 500ing due to missing department field

### DIFF
--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -355,7 +355,8 @@ class Harvest:
         departments = json.loads(response.text)["custom_field_options"]
 
         # Temporary fix until we move to new department list
-        departments.append({"id": 82559, "name": "Alliances"})
+        if not any(item['name'].lower() == 'alliances' for item in departments):
+            departments.append({"id": 82559, "name": "Alliances"})
 
         return sorted(
             [Department(department["name"]) for department in departments],

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -355,7 +355,9 @@ class Harvest:
         departments = json.loads(response.text)["custom_field_options"]
 
         # Temporary fix until we move to new department list
-        if not any(item['name'].lower() == 'alliances' for item in departments):
+        if not any(
+            item["name"].lower() == "alliances" for item in departments
+        ):
             departments.append({"id": 82559, "name": "Alliances"})
 
         return sorted(

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -354,6 +354,9 @@ class Harvest:
         response.raise_for_status()
         departments = json.loads(response.text)["custom_field_options"]
 
+        # Temporary fix until we move to new department list
+        departments.append({"id": 82559, "name": "Alliances"})
+
         return sorted(
             [Department(department["name"]) for department in departments],
             key=lambda dept: dept.name,


### PR DESCRIPTION
## Done

- Manually add 'alliances' as a department to the greenhouse dict

## QA

- open https://canonical-com-1595.demos.haus/careers
- check it loads
- check all the careers pages load

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
