### PR TITLE
chore: Bump vanilla version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   },
   "dependencies": {
     "@canonical/cookie-policy": "^3.6.4",
+    "@canonical/discourse-rad-parser": "1.0.2",
     "@canonical/global-nav": "3.6.4",
     "@canonical/latest-news": "1.5.0",
-    "@canonical/discourse-rad-parser": "1.0.2",
     "@testing-library/cypress": "9.0.0",
     "autoprefixer": "10.4.17",
     "concurrently": "7.6.0",
@@ -35,7 +35,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sass": "1.79.0",
-    "vanilla-framework": "4.21.0"
+    "vanilla-framework": "4.21.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4977,10 +4977,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@4.21.0:
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.21.0.tgz#745e6d4cff71b9d2a976540fc8041478d43127ae"
-  integrity sha512-/qQu0J5L17Oumpd9AD+kqEYgkBm/JjOJNO3ArObnw9Hx9Dk1Vt3dIasYEo9IR6QFAMU64daOXqbFB+Dz8fZmxw==
+vanilla-framework@4.21.1:
+  version "4.21.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.21.1.tgz#6a011d49cc028784d091d8745882a9343e9845ab"
+  integrity sha512-kf1l41iv9H4xhJrrpJC3TOF4SBiXJvtZsUFP20g8GVv6d4wgV4vAClD4zCF6sUEnGhxZ13kO/P9nK++DvWzdvQ==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

- Bumped vanilla version to 4.21.1

## QA

- View the site locally in your web browser at: https://canonical-com-1598.demos.haus/
- This version shouldn't introduce any breaking changes, but click through a couple pages to double check nothing looks broken

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-19622
