### PR TITLE
Add CTA section to bottom of page

### DIFF
--- a/templates/solutions/open-source-security/cyber-resilience-act/index.html
+++ b/templates/solutions/open-source-security/cyber-resilience-act/index.html
@@ -390,13 +390,13 @@
 
     <hr class="p-rule is-fixed-width" />
 
-    <div class="u-fixed-width p-strip">
-      <section class="p-strip">
+    <section class="p-strip is-deep">
+      <div class="u-fixed-width">
         <h2>
           <a href="/contact-us#get-in-touch">Need help with your CRA roadmap? Contact our experts &nbsp;&rsaquo;</a>
         </h2>
-      </section>
-    </div>
+      </div>
+    </section>
 
     <hr class="p-rule is-fixed-width" />
 
@@ -610,15 +610,15 @@
 
     <hr class="p-rule is-fixed-width" />
 
-    <div class="u-fixed-width p-strip">
-      <section class="p-strip">
+    <section class="p-strip is-deep">
+      <div class="u-fixed-width">
         <h2>
           Get help preparing your devices and PDEs for CRA compliance
           <br />
           <a href="/contact-us#get-in-touch">Contact us &nbsp;&rsaquo;</a>
         </h2>
-      </section>
-    </div>
+      </div>
+    </section>
 
   {% endblock %}
 {% endblock %}

--- a/templates/solutions/open-source-security/cyber-resilience-act/index.html
+++ b/templates/solutions/open-source-security/cyber-resilience-act/index.html
@@ -59,7 +59,7 @@
                       frameborder="0"></iframe>
             </p>
             <p class="p-section--shallow u-no-padding--bottom">
-              The CRA is a European Union legislation that aims to make Products with Digital Elements (PDEs) safer by requiring developers, manufacturers, distributors and retailers to follow mandatory cybersecurity, documentation, and vulnerability reporting requirements. The CRA extends this protection throughout the product life cycle.
+              The CRA is a European Union legislation that aims to make Products with Digital Elements (PDEs) safer by requiring developers, manufacturers, distributors, and retailers to follow mandatory cybersecurity, documentation, and vulnerability reporting requirements. The CRA extends this protection throughout the product life cycle.
             </p>
             <hr class="p-rule--muted" />
             <a href="https://ubuntu.com/blog/a-cisos-comprehensive-breakdown-of-the-cyber-resilience-act">
@@ -605,6 +605,18 @@
 
           </div>
         </div>
+      </section>
+    </div>
+
+    <hr class="p-rule is-fixed-width" />
+
+    <div class="u-fixed-width p-strip">
+      <section class="p-strip">
+        <h2>
+          Get help preparing your devices and PDEs for CRA compliance
+          <br />
+          <a aria-controls="cra-contact-modal">Contact us &nbsp;&rsaquo;</a>
+        </h2>
       </section>
     </div>
 

--- a/templates/solutions/open-source-security/cyber-resilience-act/index.html
+++ b/templates/solutions/open-source-security/cyber-resilience-act/index.html
@@ -33,7 +33,7 @@
             </p>
           </div>
           <div class="p-cta-block">
-            <a href="/contact-us" aria-controls="cra-contact-modal" class="p-button--positive">Contact our team</a>
+            <a href="/contact-us#get-in-touch" aria-controls="cra-contact-modal" class="p-button--positive">Contact our team</a>
           </div>
         </div>
       </div>
@@ -614,7 +614,8 @@
       <div class="u-fixed-width">
         <h2>
           Get help preparing your devices and PDEs for CRA compliance
-          <br />
+        </h2>
+        <h2>
           <a href="/contact-us#get-in-touch">Contact us &nbsp;&rsaquo;</a>
         </h2>
       </div>

--- a/templates/solutions/open-source-security/cyber-resilience-act/index.html
+++ b/templates/solutions/open-source-security/cyber-resilience-act/index.html
@@ -615,9 +615,9 @@
         <h2>
           Get help preparing your devices and PDEs for CRA compliance
         </h2>
-        <h2>
+        <p class="p-heading--2">
           <a href="/contact-us#get-in-touch">Contact us &nbsp;&rsaquo;</a>
-        </h2>
+        </p>
       </div>
     </section>
 

--- a/templates/solutions/open-source-security/cyber-resilience-act/index.html
+++ b/templates/solutions/open-source-security/cyber-resilience-act/index.html
@@ -393,7 +393,7 @@
     <div class="u-fixed-width p-strip">
       <section class="p-strip">
         <h2>
-          <a aria-controls="cra-contact-modal">Need help with your CRA roadmap? Contact our experts &nbsp;&rsaquo;</a>
+          <a href="/contact-us#get-in-touch">Need help with your CRA roadmap? Contact our experts &nbsp;&rsaquo;</a>
         </h2>
       </section>
     </div>
@@ -615,14 +615,10 @@
         <h2>
           Get help preparing your devices and PDEs for CRA compliance
           <br />
-          <a aria-controls="cra-contact-modal">Contact us &nbsp;&rsaquo;</a>
+          <a href="/contact-us#get-in-touch">Contact us &nbsp;&rsaquo;</a>
         </h2>
       </section>
     </div>
-
-    <!-- Form builder -->
-    <script defer src="{{ versioned_static('js/modals.js') }}"></script>
-    {% include "/shared/forms/form-template.html" %}
 
   {% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Done

Added CTA section to bottom of the page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- visit [/solutions/open-source-security/cyber-resilience-act](https://canonical-com-1599.demos.haus/solutions/open-source-security/cyber-resilience-act)
- Compare with copy doc at https://docs.google.com/document/d/13VaiP6GGkGB4mE01bIqJ3cg8MfQXulNs9m3cmYb20HQ/edit?tab=t.0

## Issue / Card

Fixes [#WD-19768](https://warthogs.atlassian.net/browse/WD-19768)

## Screenshots

[if relevant, include a screenshot]
