### PR TITLE
update broken charmhub.io link

### DIFF
--- a/templates/data/postgresql/index.html
+++ b/templates/data/postgresql/index.html
@@ -209,7 +209,7 @@
           </ul>
           <hr class="p-rule--muted" />
           <p>
-            <a href="https://charmhub.io/postgresql/docs/t-overview">Get started with Charmed PostgreSQL&nbsp;&rsaquo;</a>
+            <a href="https://charmhub.io/postgresql/docs/t-set-up">Get started with Charmed PostgreSQL&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Done

Updates broken link to `postgresql` docs

## QA

- Go to https://canonical-com-1602.demos.haus/data/postgresql
- Check "Get started with Charmed Postgresql" link goes to the docs on charmhub.io

## Issue / Card

https://chat.canonical.com/canonical/pl/gxopsm88e7ra3mxa48pqn8ke3y
