### PR TITLE
[WD-20171] fix: Global nav and tabbed content glitches

### DIFF
--- a/static/js/navigation/main.js
+++ b/static/js/navigation/main.js
@@ -180,6 +180,7 @@ navigation.querySelectorAll(".js-navigation-tab").forEach((tab) => {
 // Is attached via HTML onclick attribute.
 function toggleSection(e) {
   e.preventDefault();
+  e.stopPropagation();
   const targetId = e.target.getAttribute("aria-controls");
   const el = document.querySelector(`.js-dropdown-window #${targetId}`);
   const currTabWindow = e.target.closest(".js-dropdown-window");

--- a/templates/index.html
+++ b/templates/index.html
@@ -263,7 +263,7 @@ meta_copydoc %}
     </section>
     <section class="p-section">
       <div class="p-tabs is-home row">
-        <div class="p-tabs__list js-tabbed-content col-start-medium-3 col-medium-4 col-start-large-4 col-9 u-no-margin--bottom "
+        <div class="p-tabs__list col-start-medium-3 col-medium-4 col-start-large-4 col-9 u-no-margin--bottom "
              role="tablist"
              aria-label="Trusted in every industry">
           <div class="p-tabs__item">
@@ -355,7 +355,8 @@ meta_copydoc %}
            role="tabpanel"
            id="Education-tab"
            aria-labelledby="Education"
-           aria-hidden="false">
+           aria-hidden="false"
+           hidden="hidden">
         <div class="p-section">
           <div class="row">
             <div class="col-2 col-medium-2 col-small-2">
@@ -394,7 +395,8 @@ meta_copydoc %}
            role="tabpanel"
            id="IoT-tab"
            aria-labelledby="IoT"
-           aria-hidden="false">
+           aria-hidden="false"
+           hidden="hidden">
         <div class="p-section--shallow">
           <div class="row">
             <div class="col-2 col-medium-2 col-small-2">
@@ -437,7 +439,8 @@ meta_copydoc %}
            role="tabpanel"
            id="Automotive-tab"
            aria-labelledby="Automotive"
-           aria-hidden="false">
+           aria-hidden="false"
+           hidden="hidden">
         <div class="p-section--shallow">
           <div class="row">
             <div class="col-2 col-medium-2 col-small-2">
@@ -480,7 +483,8 @@ meta_copydoc %}
            role="tabpanel"
            id="SaaS-tab"
            aria-labelledby="SaaS"
-           aria-hidden="false">
+           aria-hidden="false"
+           hidden="hidden">
         <div class="p-section">
           <div class="row">
             <div class="col-2 col-medium-2 col-small-2">
@@ -522,7 +526,8 @@ meta_copydoc %}
            role="tabpanel"
            id="Finance-tab"
            aria-labelledby="Finance"
-           aria-hidden="false">
+           aria-hidden="false"
+           hidden="hidden">
         <div class="p-section">
           <div class="row">
             <div class="col-2 col-medium-2 col-small-2">

--- a/templates/navigation/partials/_dropdown-desktop.html
+++ b/templates/navigation/partials/_dropdown-desktop.html
@@ -11,7 +11,6 @@
                {% if loop.index != 1 %}hidden="true"{% endif %}
                id="{{ id }}-{{ nav_section.title | slug }}-tab-content"
                tabindex="-1"
-               role="tabpanel"
                aria-labelledby="{{ id }}-{{ nav_section.title | slug }}-tab">
             <div class="row u-no-padding">
               <div class="col-{% if nav_section.secondary_links %}6{% else %}9{% endif %}">

--- a/templates/navigation/partials/_tab-panel.html
+++ b/templates/navigation/partials/_tab-panel.html
@@ -2,7 +2,6 @@
   <div class="p-side-navigation is-dark">
     <div class="p-side-navigation__drawer">
       <ul class="p-side-navigation__list js-tabs u-no-margin--bottom"
-          role="tablist"
           aria-label="Categories">
         {% for nav_section in side_nav_sections %}
           <li class="p-side-navigation__item"


### PR DESCRIPTION
## Done

- Fixed: prevent page from scrolling to top when changing global nav sections
- Fixed: global nav categories detail section disappearing when selecting any tab on the home page
- Fixed: tabs selection glitches when clicked too many times

## QA

- View the site in your web browser at: https://canonical-com-1603.demos.haus/
- Verify all three issues documented [here](https://warthogs.atlassian.net/browse/WD-20171) have been fixed.

## Issue / Card

Fixes #[WD-20171](https://warthogs.atlassian.net/browse/WD-20171)


[WD-20171]: https://warthogs.atlassian.net/browse/WD-20171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ