### PR TITLE
chore: Remove compromised tj-actions from PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,34 +72,6 @@ jobs:
       - name: Lint python
         run: yarn lint-python
 
-  lint-jinja:
-    runs-on: ubuntu-22.04
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install node dependencies
-        run: yarn install --immutable
-
-      - name: Install python dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          sudo pip3 install djlint
-
-      - name: Get changed HTML files in the templates folder
-        id: changed-files
-        uses: tj-actions/changed-files@v43
-        with:
-          files: templates/**
-
-      - name: Lint jinja
-        if: steps.changed-files.outputs.any_changed == 'true'
-        env:
-          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-        run: |
-          echo "The following files have changed: $CHANGED_FILES"
-          djlint $CHANGED_FILES --lint
-
   test-python:
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
## Done

- Remove tj-action and lint-jinja from PR workflow due to compromise in tj-actions/changed-files
- Note: re-enable lint-jinja action once another fix to replace tj-action is up

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
