### PR TITLE
Changed url to new summit page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -663,7 +663,7 @@ company:
         - title: Open source commitment
           url: /projects
         - title: Ubuntu Summit
-          url: https://summit.ubuntu.com/
+          url: https://ubuntu.com/summit
 
     - title: Latest updates
       links:


### PR DESCRIPTION
## Done

- Changed url for ubuntu.com/summit page.
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Linked to https://github.com/canonical/ubuntu.com/pull/14872/
## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
