### PR TITLE
unflip single-select options in job application

### DIFF
--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -103,7 +103,7 @@
             {% elif question.type == "single_select" or question.type == "boolean" %}
             <select name="{{ question.name }}" id="{{ question.name }}" {% if question.description %}aria-describedby="{{ question.name }}_help"{% endif %} {% if question.required %}required{% endif %}>
               <option value="" disabled="disabled" selected="">Select an option</option>
-              {% for answer_option in question.get("values",[])|reverse %}
+              {% for answer_option in question.get("values",[]) %}
               <option value="{{ answer_option.value }}">{{ answer_option.label }}</option>
               {% endfor %}
             </select>


### PR DESCRIPTION
## Done

- unfliped single-select options in job application

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/5191982/application
- Check countries ordering
