### PR TITLE
chore(copy): update meganav copy

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -172,7 +172,7 @@ products:
             description: Open source storage
             url: https://ubuntu.com/ceph
           - title: Anbox Cloud
-            description: Virtualised Android on demand
+            description: Virtualized Android on demand
             url: https://anbox-cloud.io/
           - title: Juju
             description: Orchestrator engine for operators
@@ -240,7 +240,7 @@ products:
       secondary_links:
         title: Quick links
         links:
-          - title: What is virtualisation?
+          - title: What is virtualization?
             url: https://snapcraft.io/blog/what-is-virtualisation-the-basics
           - title: Multipass documentation
             url: /multipass/docs
@@ -305,7 +305,7 @@ products:
       primary_links:
         links:
           - title: Kubernetes
-            description: Containerised workloads
+            description: Containerized workloads
             url: https://ubuntu.com/kubernetes
           - title: MicroK8s
             description: Simplest way to get Kubernetes
@@ -465,7 +465,7 @@ products:
       primary_links:
         links:
           - title: Snaps
-            description: Containerised applications for Linux
+            description: Containerized applications for Linux
             url: https://snapcraft.io/about
           - title: Snapcraft
             description: Build and publish your snaps
@@ -521,6 +521,8 @@ solutions:
           url: /solutions/iot-and-devices
         - title: Observability
           url: /observability
+        - title: Cloud-native app development
+          url: /solutions/cloud-native-development
 
     - title: Industries
       links:
@@ -553,7 +555,7 @@ partners:
   cta: Explore our partners
   cta_link: /partners
   primary_links:
-    title: Partner programmes
+    title: Partner programs
     links:
       - title: Desktop
         description: Desktop, laptops and workstations
@@ -574,7 +576,7 @@ partners:
         description: Global Systems Integrators
         url: /partners/gsi
       - title: Public cloud
-        description: Ubuntu optimised for the cloud
+        description: Ubuntu optimized for the cloud
         url: /partners/public-cloud
       - title: Silicon
         description: CPUs, boards and SoCs


### PR DESCRIPTION
## Done

- Update meganav spelling.
- Add link to 'Cloud-native app development'

https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?tab=t.0

## QA

- Open the meganav and check that the spelling matches the changes in the copy doc.
- Under 'Solutions' check that there is a 'Cloud-native app development' link.

## Issue / Card

https://warthogs.atlassian.net/browse/WD-20479
https://warthogs.atlassian.net/browse/WD-20023

