### PR TITLE
Update hiring process information

### DIFF
--- a/templates/careers/application/index.html
+++ b/templates/careers/application/index.html
@@ -198,7 +198,7 @@
         <h2 class="p-text--x-small-capitalised">Your application process</h2>
         {% if "stage_progress" in application and application["stage_progress"]["early_stage"] %}
           <p>
-            <a href="#ceo-video">Listen to how we hire at Canonical</a>
+            <a target="_blank" href="/careers/hiring-process">Read about our hiring process</a>
           </p>
         {% endif %}
       </div>

--- a/templates/careers/hiring-process/index.html
+++ b/templates/careers/hiring-process/index.html
@@ -225,62 +225,6 @@
           <div class="col-6 col-medium-4 p-section--shallow">
             <blockquote class="u-no-margin u-no-padding" style="border: none;">
               <p>
-                <i>“I was impressed by the recruitment process. It required a lot of involvement from my side but also from Canonical's side. I wanted to work for a company who takes great care when selecting its employees. I was able to talk to many Canonical employees and this convinced me this is a great place to work.”</i>
-              </p>
-            </blockquote>
-            <span class="u-off-screen">Joined December 2023</span>
-          </div>
-          <div class="col-3 col-medium-2">
-            <p class="u-text--muted" aria-hidden="true">Joined December 2023</p>
-          </div>
-        </div>
-        <hr class="p-rule--muted" />
-        <div class="row p-section--shallow">
-          <div class="col-6 col-medium-4 p-section--shallow">
-            <blockquote class="u-no-margin u-no-padding" style="border: none;">
-              <p>
-                <i>“I really liked having access to the platform where I could check the entire selection process and upcoming interviews, as well as download the reports about my tests”</i>
-              </p>
-            </blockquote>
-            <span class="u-off-screen">Joined March 2024</span>
-          </div>
-          <div class="col-3 col-medium-2">
-            <p class="u-text--muted" aria-hidden="true">Joined March 2024</p>
-          </div>
-        </div>
-        <hr class="p-rule--muted" />
-        <div class="row p-section--shallow">
-          <div class="col-6 col-medium-4 p-section--shallow">
-            <blockquote class="u-no-margin u-no-padding" style="border: none;">
-              <p>
-                <i>“I met a lot of interesting people during the recruitment interviews and I can say that they were a reassurance that Canonical was a great place for me.”</i>
-              </p>
-            </blockquote>
-            <span class="u-off-screen">Joined January 2024</span>
-          </div>
-          <div class="col-3 col-medium-2">
-            <p class="u-text--muted" aria-hidden="true">Joined January 2024</p>
-          </div>
-        </div>
-        <hr class="p-rule--muted" />
-        <div class="row p-section--shallow">
-          <div class="col-6 col-medium-4 p-section--shallow">
-            <blockquote class="u-no-margin u-no-padding" style="border: none;">
-              <p>
-                <i>“I felt very lucky meeting with people from different continents as I met with people from the US and from EMEA.”</i>
-              </p>
-            </blockquote>
-            <span class="u-off-screen">Joined April 2024</span>
-          </div>
-          <div class="col-3 col-medium-2">
-            <p class="u-text--muted" aria-hidden="true">Joined April 2024</p>
-          </div>
-        </div>
-        <hr class="p-rule--muted" />
-        <div class="row p-section--shallow">
-          <div class="col-6 col-medium-4 p-section--shallow">
-            <blockquote class="u-no-margin u-no-padding" style="border: none;">
-              <p>
                 <i>“Ubuntu had its own reputation &ndash; but the ideology behind the hiring process made it standout!”</i>
               </p>
             </blockquote>
@@ -288,6 +232,62 @@
           </div>
           <div class="col-3 col-medium-2">
             <p class="u-text--muted" aria-hidden="true">Joined July 2024</p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-6 col-medium-4 p-section--shallow">
+            <blockquote class="u-no-margin u-no-padding" style="border: none;">
+              <p>
+                <i>“The most respectful and transparent recruitment process I've ever gone through.”</i>
+              </p>
+            </blockquote>
+            <span class="u-off-screen">Joined October 2024</span>
+          </div>
+          <div class="col-3 col-medium-2">
+            <p class="u-text--muted" aria-hidden="true">Joined October 2024</p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-6 col-medium-4 p-section--shallow">
+            <blockquote class="u-no-margin u-no-padding" style="border: none;">
+              <p>
+                <i>“Greenhouse has been such a great hub during pre-onboarding. It answered 95% of my questions. For the remaining 5% where I had regional specific questions I was assigned a peer buddy from my geographical area which was super helpful.”</i>
+              </p>
+            </blockquote>
+            <span class="u-off-screen">Joined January 2025</span>
+          </div>
+          <div class="col-3 col-medium-2">
+            <p class="u-text--muted" aria-hidden="true">Joined January 2025</p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-6 col-medium-4 p-section--shallow">
+            <blockquote class="u-no-margin u-no-padding" style="border: none;">
+              <p>
+                <i>“Very friendly and supportive team members conducted the interviews and each interview process was professional.”</i>
+              </p>
+            </blockquote>
+            <span class="u-off-screen">Joined January 2025</span>
+          </div>
+          <div class="col-3 col-medium-2">
+            <p class="u-text--muted" aria-hidden="true">Joined January 2025</p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-6 col-medium-4 p-section--shallow">
+            <blockquote class="u-no-margin u-no-padding" style="border: none;">
+              <p>
+                <i>“All the interviewers were professional and genuinely interested in what I had to say.”</i>
+              </p>
+            </blockquote>
+            <span class="u-off-screen">Joined March 2025</span>
+          </div>
+          <div class="col-3 col-medium-2">
+            <p class="u-text--muted" aria-hidden="true">Joined March 2025</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Update hiring process quotes
- Add link to hiring process page on candidate dash

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Navigate to [the hiring process page](http://localhost:8002/careers/hiring-process) and ensure that the quotes at the bottom match Hanna's changes in [the copy doc](https://docs.google.com/document/d/1j-G0LCapJ1zRnNgQeoC0_rh15N6ICdpDy7M1tubQuoo/edit?tab=t.0).
- Navigate to this candidate dashboard and ensure that the "Listen to how we hire at Canonical" link has been replaced with a "Read about our hiring process" link, which links to the aforementioned `/careers/hiring-process` page, opening in a new tab.

## Issue / Card

[TSP-775](https://warthogs.atlassian.net/browse/TSP-775)
[TSP-776](https://warthogs.atlassian.net/browse/TSP-776)


[TSP-775]: https://warthogs.atlassian.net/browse/TSP-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TSP-776]: https://warthogs.atlassian.net/browse/TSP-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ