### PR TITLE
feat: Add 'tag' filter to /case-study search

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.blog==6.4.4
 canonicalwebteam.http==1.0.4
 canonicalwebteam.image-template==1.5.0
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.discourse==5.7.4
+canonicalwebteam.discourse==6.1.1
 canonicalwebteam.search==2.1.1
 canonicalwebteam.form-generator==1.0.0
 bleach==5.0.1

--- a/templates/case-study/index.html
+++ b/templates/case-study/index.html
@@ -1,127 +1,177 @@
 {% set hide_wrapper = True %}
+
 {% extends "case-study/base_case-study.html" %}
 
 {% block title %}Case Studies{% endblock %}
+
 {% block meta_description %}Ubuntu Case Studies{% endblock %}
 
 <!-- Set resource_types and tags somewhere -->
+
 {% block inner_content %}
-<section class="p-strip--suru-blog-header is-dark">
-  <div class="row">
-    <div class="col-6">
-      <h1>Case Studies</h1>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-shallow">
-  <form action="/">
-  <div class="row">
-    <div class="col-3">
-      <div class="p-form__group">
-        <label for="language-selector">Select language:</label>
-        <select name="language-selector" id="language-selector" class="u-no-margin--bottom">
-          <option value="all">All languages</option>
-          <option value="zh-TW">Chinese (Traditional)</option>
-          <option value="de">Deutsch</option>
-          <option value="en">English</option>
-          <option value="es">Espa&ntilde;ol</option>
-          <option value="fr">Fran&ccedil;ais</option>
-          <option value="it">Italiano</option>
-          <option value="kr">Korean</option>
-          <option value="pt">Portugu&ecirc;s</option>
-          <option value="ru">Русс&#1082;&#1080;&#1081;</option>
-        </select>
+  <section class="p-strip--suru-blog-header is-dark">
+    <div class="row">
+      <div class="col-6">
+        <h1>Case Studies</h1>
       </div>
     </div>
-    <div class="col-9 u-align--right" style="display: flex; align-items: flex-end; justify-content: flex-end;">
-      <div class="u-hide u-show--small u-show--medium" >
-        <br /><br />
-      </div>
-      <button id="clear-filters" class="u-no-margin--bottom" onclick="clearFilters()" type="reset" disabled>Clear filter</button>
-    </div>
-  </div>
-  </form>
-</section>
-
-<section class="p-strip is-shallow" id="posts-list">
-  <div id="loading-message" class="u-fixed-width u-vertically-center u-align--center u-hide">
-    <i class="p-icon--spinner u-animation--spin"></i>
-  </div>
-  <div class="row u-equal-height" id="posts-content">
-    {% if metadata %}
-      {% for case_study in metadata %}
-        {% with title=case_study.topic_name, title_link=case_study.path, description=case_study.subtitle, tags=case_study.tags %}
-          {% include "case-study/_case-study-card.html" %}
-        {% endwith %}
-      {% endfor %}
-    {% else %}
-    <p>
-      No case studies found for the selected filter.
-    </p>
-    {% endif %}
-  </div>
-</section>
-
-{% if total_pages > 1 %}
-  <section class="p-strip is-shallow">
-    {% with %}
-      {% set total_pages = total_pages %}
-      {% set current_page = current_page %}
-      {% include "shared/_pagination.html" %}
-    {% endwith %}
   </section>
-{% endif %}
 
-<script>
-  function clearFilters() {
-    const clearFiltersButton = document.getElementById("clear-filters");
-    window.location.assign("/case-study");
-  }
-  (function() {
-    const languageSelector = document.getElementById("language-selector");
-    const clearFiltersButton = document.getElementById("clear-filters");
-    const urlObj = new URL(window.location);
+  <section class="p-strip is-shallow">
+    <form action="/" class="js-case-study-form">
+      <div class="row">
+        <div class="col-3">
+          <div class="p-form__group">
+            <label for="language-selector">Select language:</label>
+            <select name="language-selector"
+                    class="js-language-selector u-no-margin--bottom">
+              <option value="all">All languages</option>
+              <option value="zh-TW">Chinese (Traditional)</option>
+              <option value="de">Deutsch</option>
+              <option value="en">English</option>
+              <option value="es">Espa&ntilde;ol</option>
+              <option value="fr">Fran&ccedil;ais</option>
+              <option value="it">Italiano</option>
+              <option value="kr">Korean</option>
+              <option value="pt">Portugu&ecirc;s</option>
+              <option value="ru">Русс&#1082;&#1080;&#1081;</option>
+              <option value="tr">T&uuml;rk&ccedil;e</option>
+            </select>
+          </div>
+        </div>
+        {% if tags %}
+          <div class="col-3">
+            <div class="p-form__group">
+              <label for="tag-selector">Select tag:</label>
+              <select name="tag-selector" class="js-tag-selector u-no-margin--bottom">
+                <option value="all">All tags</option>
+                {% for tag in tags %}
+                  <option {% if tag == "" %}disabled{% endif %} value="{{ tag }}">
+                    {% if tag == "" %}
+                      -
+                    {% else %}
+                      {{ tag }}
+                    {% endif %}
+                  </option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+        {% endif %}
+        <div class="col-3 col-start-large-10"
+             style="display: flex;
+                    align-items: flex-end;
+                    justify-content: flex-end">
+          <div class="u-hide u-show--small">
+            <br />
+            <br />
+          </div>
+          <button class="js-apply-filters p-button--positive u-no-margin--bottom">Apply filters</button>
+          <button class="js-clear-filters u-no-margin--bottom"
+                  onclick="clearFilters()"
+                  type="reset"
+                  disabled>Clear filters</button>
+        </div>
+      </div>
+    </form>
+  </section>
 
-    const loadingMessage = document.getElementById("loading-message");
-    const postsContent = document.getElementById("posts-content");
-  
-    if (urlObj.search !== "") {
-      clearFiltersButton.removeAttribute("disabled");
+  <section class="p-strip is-shallow" id="posts-list">
+    <div class="row u-equal-height" id="posts-content">
+      {% if metadata %}
+        {% for case_study in metadata %}
+          {% with title=case_study.topic_name, title_link=case_study.path, description=case_study.subtitle, tags=case_study.tags %}
+            {% include "case-study/_case-study-card.html" %}
+          {% endwith %}
+        {% endfor %}
+      {% else %}
+        <p>No case studies found for the selected filter.</p>
+      {% endif %}
+    </div>
+  </section>
+
+  {% if total_pages > 1 %}
+    <section class="p-strip is-shallow">
+      {% with %}
+        {% set total_pages = total_pages %}
+        {% set current_page = current_page %}
+        {% include "shared/_pagination.html" %}
+      {% endwith %}
+    </section>
+  {% endif %}
+
+  <script>
+    function clearFilters(e) {
+      addLoadingSpinner(e.currentTarget);
+      window.location.assign("/case-study");
     }
 
-    function handleFilter(key, el, url) {
-      if (!el) {
-        return;
-      }
-  
-      if (url.searchParams.has(key)) {
-        el.value = url.searchParams.get(key);
-      }
-  
-      el.addEventListener("change", function(e) {
-        const value = e.target.value;
-        const selectFields = document.querySelectorAll("select:checked")
-  
-        // Reset filters, data explorer query can't search multiple fields
-        // at the same time
-        url.search = "";
-  
-        if (value !== "all") {
-          url.searchParams.append(key, value);
-        }
+    function addLoadingSpinner(button) {
+      const spinnerIcon = document.createElement("i");
+      const buttonIsDark = button.classList.contains("p-button--positive");
+      spinnerIcon.className = "p-icon--spinner u-animation--spin" + (buttonIsDark ? " is-light" : "");
 
-        // Show loading message
-        loadingMessage.classList.remove("u-hide");
-        postsContent.classList.add("u-hide");
-
-        window.location = url;
+      // retain button dimensions
+      const {
+        width,
+        height
+      } = button.getBoundingClientRect();
+      Object.assign(button.style, {
+        width: `${width}px`,
+        height: `${height}px`
       });
-    }
-  
-    handleFilter("language", languageSelector, urlObj);
-  })()
-  </script>
-  
-{% endblock %}
 
+      button.disabled = true;
+      button.innerText = "";
+      button.appendChild(spinnerIcon);
+    }
+
+    (function() {
+      const caseStudyForm = document.querySelector(".js-case-study-form");
+      const languageSelector = document.querySelector(".js-language-selector");
+      const tagSelector = document.querySelector(".js-tag-selector");
+
+      const applyFiltersButton = document.querySelector(".js-apply-filters");
+      const clearFiltersButton = document.querySelector(".js-clear-filters");
+      const urlObj = new URL(window.location);
+
+      if (urlObj.search !== "") {
+        clearFiltersButton.removeAttribute("disabled");
+      }
+
+      function setFiltersDropdown(key, selector) {
+        if (!selector) {
+          return;
+        }
+        if (urlObj.searchParams.has(key)) {
+          selector.value = urlObj.searchParams.get(key);
+        }
+      }
+
+      setFiltersDropdown("language", languageSelector);
+      setFiltersDropdown("tag", tagSelector);
+
+      function setFilters(key, selector) {
+        if (selector.value != "all") {
+          urlObj.searchParams.set(key, selector.value);
+        } else {
+          urlObj.searchParams.delete(key);
+        }
+      }
+
+      function applyFilters() {
+        event.preventDefault();
+
+        addLoadingSpinner(applyFiltersButton);
+
+        setFilters("language", languageSelector);
+        setFilters("tag", tagSelector);
+
+        urlObj.searchParams.delete("page");
+        window.location = urlObj.href;
+      }
+      clearFiltersButton.addEventListener("click", clearFilters);
+      caseStudyForm.addEventListener("submit", applyFilters);
+    })()
+  </script>
+{% endblock %}

--- a/templates/case-study/index.html
+++ b/templates/case-study/index.html
@@ -62,7 +62,7 @@
              style="display: flex;
                     align-items: flex-end;
                     justify-content: flex-end">
-          <div class="u-hide u-show--small">
+          <div class="u-hide--large">
             <br />
             <br />
           </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1263,11 +1263,11 @@ def build_case_study_index(engage_docs):
         page = flask.request.args.get("page", default=1, type=int)
         preview = flask.request.args.get("preview")
         language = flask.request.args.get("language", default=None, type=str)
-        # tag = flask.request.args.get("tag", default=None, type=str)
-        limit = 20  # adjust as needed
+        tag = flask.request.args.get("tag", default=None, type=str)
+        limit = 21
         offset = (page - 1) * limit
 
-        if language:
+        if tag or language:
             (
                 metadata,
                 count,
@@ -1276,6 +1276,7 @@ def build_case_study_index(engage_docs):
             ) = engage_docs.get_index(
                 limit,
                 offset,
+                tag_value=tag,
                 key="type",
                 value="case study",
                 second_key="language",
@@ -1297,6 +1298,10 @@ def build_case_study_index(engage_docs):
             if path.startswith("/engage"):
                 case_study["path"] = "https://ubuntu.com" + path
 
+        tags = engage_docs.get_engage_pages_tags()
+        # strip whitespace & remove dupes
+        processed_tags = {tag.strip() for tag in tags if tag.strip()}
+
         return flask.render_template(
             "case-study/index.html",
             forum_url=engage_docs.api.base_url,
@@ -1307,6 +1312,7 @@ def build_case_study_index(engage_docs):
             posts_per_page=limit,
             total_pages=total_pages,
             current_page=page,
+            tags=processed_tags,
         )
 
     return case_study_index


### PR DESCRIPTION
## Done

- Adds 'tag' filter to /case-study search
- Adds loading state to the search/clear button
- Add card limit to 21 (a multiple of 3, so there isn't an empty space at the bottom of the page)
- Bump discourse version

## QA

- Go to https://canonical-com-1618.demos.haus/case-study
- Use the 'language' and 'tags' drop down to test the search filter
- See the filter button is disabled when clicked and displays a spinner
- Try the clear filter button, except the same loading behavior as the search filter

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-19545