### PR TITLE
fix: Update link to privacy policy on /embedding/faqs

### DIFF
--- a/templates/embedding/faqs.html
+++ b/templates/embedding/faqs.html
@@ -32,7 +32,7 @@
         <div class="p-section--shallow u-hide--small u-hide--medium"></div>
         <div class="p-section--shallow">
           <p>
-            As per the <a href="/legal/intellectual-property-policy">IPRights Policy</a>, Canonical owns and manages certain intellectual property rights in Ubuntu and other associated intellectual property (Canonical IP) and licenses the use of these rights to enterprises, individuals and members of the Ubuntu community in accordance with the IPRights Policy.
+            As per the <a href="https://ubuntu.com/legal/intellectual-property-policy">IPRights Policy</a>, Canonical owns and manages certain intellectual property rights in Ubuntu and other associated intellectual property (Canonical IP) and licenses the use of these rights to enterprises, individuals and members of the Ubuntu community in accordance with the IPRights Policy.
           </p>
           <p>
             Our policy exists to ensure that when you receive something that claims to be Ubuntu, you can trust that it will work to the same standard, regardless of where you got it from. And people everywhere tell us they appreciate that - when they get Ubuntu on a cloud or as a VM, it works, and they can trust it.


### PR DESCRIPTION
## Done

- updates link from https://canonical.com/embedding/faqs to https://ubuntu.com/legal/intellectual-property-policy

## QA

- Go to https://canonical-com-1619.demos.haus/embedding/faqs 
- Click the link for 'IPRights Policy'
- See it takes you to https://ubuntu.com/legal/intellectual-property-policy


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-20787
