### PR TITLE
[WD-21247] Title fix for /data/streaming

### DIFF
--- a/templates/data/streaming/index.html
+++ b/templates/data/streaming/index.html
@@ -21,7 +21,7 @@
 {% block content %}
 
     {% call(slot) vf_hero(
-        title_text='What is Data streaming?',
+        title_text='What is data streaming?',
         layout='50/50-full-width-image'
         ) -%}
         {%- if slot == 'description' -%}


### PR DESCRIPTION
## Done

- Adjust title casing for /data/streaming 
- Spacing was automatically reformatted for proper indentation

[Demo](https://canonical-com-1630.demos.haus/data/streaming)

## QA
Check out this feature branch
Run the site using the command ./run serve or dotrun
View the site locally in your web browser at: http://0.0.0.0:8001/
Be sure to test on mobile, tablet and desktop screen sizes
[List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #[WD-21247]


[WD-21247]: https://warthogs.atlassian.net/browse/WD-21247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ