### PR TITLE
Update lxd installation page to recent ubuntu version and new image server

### DIFF
--- a/templates/lxd/install.html
+++ b/templates/lxd/install.html
@@ -102,9 +102,9 @@
               <p>Command:</p>
               <pre>lxc launch {{"<image_server>:<image_name> <instance_name>"}}</pre>
               <p>Example:</p>
-              <pre>lxc launch ubuntu:22.04 ubuntu-container</pre>
+              <pre>lxc launch ubuntu:24.04 ubuntu-container</pre>
               <p>
-                Check the <a href="https://images.linuxcontainers.org/">community image server</a> for other Linux distributions.
+                Check the <a href="https://images.lxd.canonical.com/">image server</a> for other Linux distributions.
               </p>
             </div>
             <div tabindex="0"
@@ -115,7 +115,7 @@
               <p>Command:</p>
               <pre>lxc launch {{"<image_server>:<image_name> <instance_name>"}} --vm</pre>
               <p>Example:</p>
-              <pre>lxc launch ubuntu:22.04 ubuntu-container --vm</pre>
+              <pre>lxc launch ubuntu:24.04 ubuntu-container --vm</pre>
               <p>
                 Check the <a href="https://images.linuxcontainers.org/">community image server</a> for other Linux distributions.
               </p>


### PR DESCRIPTION
## Done

- Update lxd installation page to recent ubuntu version and
- Link to new image server

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- check https://canonical-com-1633.demos.haus/lxd/install
