### PR TITLE
fix: Don't purge intl-tel-input styles

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -12,6 +12,11 @@ let config = {
         "webapp/js/**/*.py",
       ],
       defaultExtractor: (content) => content.match(/[\w-/:]+(?<!:)/g) || [],
+      safelist: {
+        greedy: [
+            /^iti/
+        ],
+      }
     }),
   ],
 };


### PR DESCRIPTION
## Done

- Add classes starting with 'iti' to safelist of purgecss

## QA

- Open [demo](https://canonical-com-1647.demos.haus/)
- Check some forms that the country dropdown for mobile works
ex. https://canonical-com-1647.demos.haus/data

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-21490

## Screenshots

[if relevant, include a screenshot]
