### PR TITLE
Fix: handling of external CSS during purging

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -8,15 +8,38 @@ let config = {
       content: [
         "templates/**/*.html",
         "templates/**/*.jinja",
-        "static/js/**/*.js",
-        "webapp/js/**/*.py",
+        "static/**/*.js",
+        "static/**/*.tsx",
+        "webapp/**/*.py",
+        "templates/**/*.md",
+        "templates/**/*.py",
+        "templates/**/*.xml",
+        "static/*.js",
+        "static/*.jsx",
+        "static/*.md",
+        "static/*.tsx",
+        "static/*.xml",
       ],
       defaultExtractor: (content) => content.match(/[\w-/:]+(?<!:)/g) || [],
       safelist: {
-        greedy: [
-            /^iti/
+        standard: [
+          /^cookie-policy/,
+          /^form/,
+          /^p-/, // Preserve form related classes
+          /^u-/, // Utility classes
+          /^js-/, // JavaScript-related classes
         ],
-      }
+        greedy: [
+          /^iti/,
+          /^mktoForm/, // Marketo forms
+          /^cc-/, // Cookie consent related
+          /^optanon/, // Cookie consent related
+          /^has-/, // State-related classes
+        ],
+        deep: [/form-.+/],
+        keyframes: true,
+        variables: true,
+      },
     }),
   ],
 };


### PR DESCRIPTION
## Done

Fixed some styling issues caused by PurgeCSS integration.
Purge CSS removed some unused styles and it does this by checking the file glob patterns added to the config
but some styles are added externally such as the `cookies policy`, `tel` and `forms` and becuase they are not used in the files, it strips them out causing missing styles in production.

This PR adds more file patterns and whitelists those external classes

## QA

Head over to https://canonical-com-1648.demos.haus/
Check that styles work for 
- the cookie policy banner
- forms on pages such as 
- - https://canonical-com-1648.demos.haus/embedding#get-in-touch
- - https://canonical.com/solutions/telco#get-in-touch

## Issue / Card
https://warthogs.atlassian.net/browse/WD-21491

Fixes #



## Screenshots

