### PR TITLE
[WD-21440] - add a link to free trial

### DIFF
--- a/templates/case-study/ubuntu-pro-support-for-games-developer.html
+++ b/templates/case-study/ubuntu-pro-support-for-games-developer.html
@@ -170,6 +170,9 @@
         is_shallow=True
         )
         -%}
+        {%- if slot == 'cta' -%}
+            <a href="https://ubuntu.com/pro/free-trial" class="p-button--positive">Access a free trial</a>
+        {%- endif -%}
     {%- endcall -%}
 
 {% endblock %}


### PR DESCRIPTION
## Done

- Added a button linked to free trial

## QA

- View the site in your web browser at: https://canonical-com-1653.demos.haus/case-study/ubuntu-pro-support-for-games-developer
- Scroll to bottom and verify the presence of a green button named "Access a free trial"
- Click on the  button and verify it redirects to the correct destination.

## Issue / Card

Fixes #[WD-21440](https://warthogs.atlassian.net/browse/WD-21440)


[WD-21440]: https://warthogs.atlassian.net/browse/WD-21440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ