### PR TITLE
chore: Bump directory-parser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.discourse==6.1.1
 canonicalwebteam.search==2.1.1
 canonicalwebteam.form-generator==1.0.0
-git+https://github.com/canonical/canonicalwebteam.directory-parser.git@fix-homepage#egg=canonicalwebteam.directory-parser
+canonicalwebteam.directory-parser==1.2.10
 bleach==5.0.1
 markdown==3.5.2
 python-slugify==8.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ canonicalwebteam.blog==6.4.4
 canonicalwebteam.http==1.0.4
 canonicalwebteam.image-template==1.5.0
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.directory-parser==1.2.9
 canonicalwebteam.discourse==6.1.1
 canonicalwebteam.search==2.1.1
 canonicalwebteam.form-generator==1.0.0
+git+https://github.com/canonical/canonicalwebteam.directory-parser.git@fix-homepage#egg=canonicalwebteam.directory-parser
 bleach==5.0.1
 markdown==3.5.2
 python-slugify==8.0.1

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -73,10 +73,8 @@ class TestSitemap(unittest.TestCase):
         parser_response = self.client.get("/sitemap_parser")
         assert parser_response.status_code == 200
 
-        parser_data = parser_response.get_json()["children"]
-        parser_urls = {}
-        for site in parser_data:
-            parser_urls = extract_urls(site, parser_urls)
+        parser_data = parser_response.get_json()
+        parser_urls = extract_urls(parser_data)
 
         assert len(parser_urls) > 0, "No URLs found in sitemap_parser"
         assert len(parser_urls) == len(


### PR DESCRIPTION
## Done

- PR to QA missing homepage on sitemap template
- Bump directory-parser
- Fly-by: Update `test_sitemap.py` to include index pages

## QA

- See that [test-python](https://github.com/canonical/canonical.com/actions/runs/14590131688/job/40923282481?pr=1654) action passes
- See that index page is present on https://canonical-com-1654.demos.haus/sitemap_tree.xml

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
