### PR TITLE
fix: success tick image quality

### DIFF
--- a/templates/careers/thank-you.html
+++ b/templates/careers/thank-you.html
@@ -16,16 +16,9 @@
       <p><a href="https://ubuntu.com/blog" class="p-button--positive">Visit our blog</a></p>
     </div>
     <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/d1155ae3-tick-midaubergine.svg",
-          alt="",
-          height="200",
-          width="200",
-          loading="auto",
-          hi_def=True
-        ) | safe
-      }}
+      <img src="https://assets.ubuntu.com/v1/d1155ae3-tick-midaubergine.svg"
+            alt=""
+            width="200px" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Replaced the image component with the default img tag to prevent cloudinary optimization.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes #1671 

## Screenshots

### Before
<img width="1168" alt="Image" src="https://github.com/user-attachments/assets/00daa7f5-cb6f-452d-8e61-55e8bba1c68f" />

### After
![image](https://github.com/user-attachments/assets/d7964eed-8f1f-45dd-9d36-9f99b3eb648a)
