### PR TITLE
chore: Add Ubuntu Pro links to navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -300,6 +300,10 @@ products:
             url: https://ubuntu.com/security/cves
           - title: Ubuntu Security Notices (USN)
             url: https://ubuntu.com/security/notices
+          - title: Ubuntu Pro free trial
+            url: https://ubuntu.com/pro/free-trial
+          - title: Get Ubuntu Pro now
+            url: https://ubuntu.com/pro/subscribe
 
     - title: Kubernetes
       primary_links:


### PR DESCRIPTION
## Done

Added links to Ubuntu Pro free trial and Ubuntu Pro as requested in [the copy doc](https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Click the "Products" dropdown in the top navigation and go to the "Security and support" section
- Check that the "Quick links" column has an "[Ubuntu Pro free trial](https://ubuntu.com/pro/free-trial)" link
- Check that the "Quick links" column has an "[Get Ubuntu Pro now](https://ubuntu.com/pro/subscribe) link

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-21776