### PR TITLE
[WD-21454] feat: add aria-expanded label on the contact modal trigger button at canonical.com form generator

### DIFF
--- a/static/js/modals.js
+++ b/static/js/modals.js
@@ -3,6 +3,7 @@
   var lastFocus = null;
   var ignoreFocusChanges = false;
   var focusAfterClose = null;
+  var modalTrigger = null;
 
   const triggeringHash = "#get-in-touch";
 
@@ -132,17 +133,30 @@
     modals.forEach(function (modal) {
       toggleModal(modal, false, false);
     });
+    if (modalTrigger) {
+      modalTrigger.setAttribute("aria-expanded", false);
+    }
   }
 
   // Add click handler for clicks on elements with aria-controls
   document.addEventListener("click", function (e) {
     const isModalTrigger = e.target.closest(".js-invoke-modal");
     const isCloseButton = e.target.closest(".p-modal-close-button");
+    if (isModalTrigger) modalTrigger = isModalTrigger;
     if (isModalTrigger || isCloseButton) {
       e.preventDefault();
 
       const targetControls = e.target.getAttribute("aria-controls");
-      toggleModal(document.getElementById(targetControls), e.target, isModalTrigger ? true : false);
+      const toggleValue = isModalTrigger ? true : false;
+      toggleModal(
+        document.getElementById(targetControls),
+        e.target,
+        toggleValue
+      );
+
+      if (modalTrigger) {
+        modalTrigger.setAttribute("aria-expanded", toggleValue);
+      }
     }
     return false;
   });

--- a/static/js/modals.js
+++ b/static/js/modals.js
@@ -147,7 +147,7 @@
       e.preventDefault();
 
       const targetControls = e.target.getAttribute("aria-controls");
-      const toggleValue = isModalTrigger ? true : false;
+      const toggleValue = Boolean(isModalTrigger)
       toggleModal(
         document.getElementById(targetControls),
         e.target,


### PR DESCRIPTION
## Done

- Dynamically add `aria-expanded` attribute on contact buttons.

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002
- Alternatively, visit the demo [here](https://canonical-com-1679.demos.haus/)
- Click on the Contact us / get in touch buttons and verify the `aria-expanded` attribute is toggled as expected.

## Issue / Card

Fixes #[WD-21454](https://warthogs.atlassian.net/browse/WD-21454)


[WD-21454]: https://warthogs.atlassian.net/browse/WD-21454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ