### PR TITLE
Add workflow for checking broken links

### DIFF
--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -1,0 +1,54 @@
+name: Links on canonical.com live
+
+on:
+  schedule:
+    - cron: "20 7 * * *"
+
+jobs:
+  check-links:
+    if: github.repository == 'canonical/canonical.com'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install linkchecker
+        run: sudo pip install LinkChecker
+
+      - name: Write linkchecker config file
+        run: |
+          mkdir -p ~/.linkchecker
+          cat > ~/.linkchecker/linkcheckerrc <<EOF
+          [checking]
+          maxrequestspersecond=5
+          recursionlevel=2
+          timeout=1000
+          sslverify=0
+
+          [filtering]
+          checkextern=1
+          ignore=
+            https://res.cloudinary.com
+            q_auto
+            fl_sanitize
+            c_fill
+            e_sharpen
+            w_[0-9]*
+            h_[0-9]*
+            https://canonical.com/blog
+            https://ubuntu.com/blog
+            https://canonical.com/static/css/*
+            https://www.xilinx.com/applications/*
+            https://player.vimeo.com/video/*
+
+          [output]
+          status=0
+          warnings=0
+          ignoreerrors=
+            ^http?s://.* ^.*(471|500|503|504|400)
+          EOF
+
+      - name: Run linkchecker for 404 errors only
+        run: linkchecker --no-warning https://canonical.com
+
+      - name: Send message on failure
+        if: failure()
+        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" ${{ secrets.BOT_URL }}?room=web--design


### PR DESCRIPTION
## Done

Add `live-links.yaml` file that adds a daily workflow that checks for broken links in the repository and reports it to MM's Web channel (similar to how it works on ubuntu.com)
