### PR TITLE
copy-update: update canonical.com navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -526,7 +526,7 @@ solutions:
           url: /solutions/iot-and-devices
         - title: Observability
           url: /observability
-        - title: Cloud-native app development
+        - title: Cloud-native apps
           url: /solutions/cloud-native-development
 
     - title: Industries
@@ -671,6 +671,8 @@ company:
           url: /projects
         - title: Ubuntu Summit
           url: https://ubuntu.com/summit
+        - title: Company Trust Center
+          url: https://trust.canonical.com/
 
     - title: Latest updates
       links:


### PR DESCRIPTION
## Done

- Add a link for the Canonical trust center
- Shorten a link under solutions from “Cloud-native app development” to “Cloud-native apps”

## QA
[Demo](https://canonical-com-1682.demos.haus/)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Click on the `Company` dropdown and check that there is `Company Trust Center` after `Ubuntu Summit`
- Also, Click on `Solutions` and check that `Cloud-native app development` is shortened to `Cloud-native apps`

## Issue / Card https://warthogs.atlassian.net/browse/WD-21713
[Copy docs](https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?tab=t.0)

Fixes #

## Screenshots

[if relevant, include a screenshot]
