### PR TITLE
[WD-22013]: replace BT Group signpost logo with higher quality asset on `/solutions`

### DIFF
--- a/templates/solutions/index.html
+++ b/templates/solutions/index.html
@@ -367,7 +367,7 @@
                 <div class="row">
                   <div class="col-3">
                     <div class="p-image-wrapper u-sv2">
-                      {{ image(url="https://assets.ubuntu.com/v1/8b23b84c-btgroup-logo.png",
+                      {{ image(url="https://assets.ubuntu.com/v1/48e0ffc6-btgroup-logo.png",
                                             alt="BT group",
                                             width="88",
                                             height="29",


### PR DESCRIPTION
## Done

Following up on #1690 now we have an updated asset from @eliman11 :)

Replaces the BT Group signpost logo on /solutions with a higher quality version.

## QA

- Go to solutions page demo
- Verify the BT Group signpost logo has been changed to the new asset from the [copydoc](https://docs.google.com/document/d/1vdnlbFSCidiNBXZ1zVKHWNIv1kl6C0vMmQAMYfz3yhU/edit?tab=t.0)

## Issue / Card

Fixes [WD-22013](https://warthogs.atlassian.net/browse/WD-22013)

## Screenshots

Before
<img width="432" alt="Screenshot 2025-05-08 at 13 06 09" src="https://github.com/user-attachments/assets/4d5c18cb-6861-4e5a-9e4b-287ab3dc3f9b" />

After
<img width="432" alt="Screenshot 2025-05-08 at 13 06 05" src="https://github.com/user-attachments/assets/e1fdcce3-1678-44c7-b429-a55864693ca5" />



[WD-22013]: https://warthogs.atlassian.net/browse/WD-22013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ