### PR TITLE
fix: Broken new links

### DIFF
--- a/templates/consulting/index.html
+++ b/templates/consulting/index.html
@@ -485,7 +485,7 @@
             </div>
             <div class="col">
               <p>
-                Are you ready to make <a href="https://ubuntu.com/desktop/organisations">Ubuntu a first-class citizen</a> in your organization? We are here to help you make that a reality. From deployment automation, authentication and security hardening and compliance, our services team can help you make your Ubuntu estate enterprise-ready.
+                Are you ready to make <a href="https://ubuntu.com/desktop/organizations">Ubuntu a first-class citizen</a> in your organization? We are here to help you make that a reality. From deployment automation, authentication and security hardening and compliance, our services team can help you make your Ubuntu estate enterprise-ready.
               </p>
             </div>
           </div>

--- a/templates/edge-computing/index.html
+++ b/templates/edge-computing/index.html
@@ -220,7 +220,7 @@
               <li class="p-list__item has-bullet">On-demand K8s clusters, virtual machines, and containers</li>
             </ul>
             <div class="p-cta-block p-equal-height-row__item">
-              <a href="https://ubuntu.com/desktop/organisations">Read about Ubuntu in organizations&nbsp;&rsaquo;</a>
+              <a href="https://ubuntu.com/desktop/organizations">Read about Ubuntu in organizations&nbsp;&rsaquo;</a>
             </div>
           </div>
           <div class="col-3 col-medium-2 p-equal-height-row__col">

--- a/templates/navigation/navigation.html
+++ b/templates/navigation/navigation.html
@@ -16,9 +16,9 @@
       </div>
       <ul class="p-navigation__items">
         <li class="p-navigation__item">
-          <button
+          <a href="/search"
              class="js-search-button p-navigation__link--search-toggle"
-             aria-label="Search"></button>
+             aria-label="Search"></a>
         </li>
         <li class="p-navigation__item">
           <button class="js-menu-button p-navigation__link">Menu</button>

--- a/templates/navigation/navigation.html
+++ b/templates/navigation/navigation.html
@@ -16,12 +16,12 @@
       </div>
       <ul class="p-navigation__items">
         <li class="p-navigation__item">
-          <a href="/search"
+          <button
              class="js-search-button p-navigation__link--search-toggle"
-             aria-label="Search"></a>
+             aria-label="Search"></button>
         </li>
         <li class="p-navigation__item">
-          <button href="/navigation" class="js-menu-button p-navigation__link">Menu</button>
+          <button class="js-menu-button p-navigation__link">Menu</button>
         </li>
       </ul>
     </div>

--- a/templates/solutions/open-source-security/index.html
+++ b/templates/solutions/open-source-security/index.html
@@ -1,8 +1,8 @@
 {% extends 'base_index.html' %}
 
 {% block meta_copydoc %}
-  https://docs.google.com/document/d/1mrvhkrVjCCJE39h96CPG_b_ZHWVN0GHzZ_6TdoudeYs {%
-  endblock meta_copydoc %}
+  https://docs.google.com/document/d/1mrvhkrVjCCJE39h96CPG_b_ZHWVN0GHzZ_6TdoudeYs
+{% endblock meta_copydoc %}
 
   {% block title %}Get open source security from Canonical{% endblock %}
 
@@ -116,7 +116,7 @@
           </p>
           <hr class="p-rule--muted" />
           <p>
-            <a href="https://ubuntu.com/desktop/organisations">Adopt Linux securely in your organisation&nbsp;&rsaquo;</a>
+            <a href="https://ubuntu.com/desktop/organizations">Adopt Linux securely in your organization&nbsp;&rsaquo;</a>
           </p>
         </div>
         <hr class="p-rule col-9 col-start-large-4 col-medium-6 p-rule--muted" />


### PR DESCRIPTION
## Done

- Update instances of `/desktop/organisations` to `/desktop/organizations`
- Update menu and search anchor links to buttons. There is no c.com/search and c.com/navigation (unlike on u.com) so there is no need to have them as anchor links.

## QA

- Go to https://canonical-com-1694.demos.haus/microcloud
- Resize the window until you see "Menu" bar, click on it and see that it works as expected
- Click on search button and see that it works as expected

## Issue / Card

Fixes [WD-22028](https://warthogs.atlassian.net/browse/WD-22028)

## Screenshots

[if relevant, include a screenshot]


[WD-22028]: https://warthogs.atlassian.net/browse/WD-22028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ