### PR TITLE
fix: Case study forms

### DIFF
--- a/templates/macros/_macros-cta.jinja
+++ b/templates/macros/_macros-cta.jinja
@@ -11,7 +11,7 @@
         <div class="col-start-large-4 col-9">
           <p class="p-heading--2">
             <a href="{{ link }}"
-            {% if has_modal %}aria-controls="case-study-contact-modal"{% endif %}>
+            {% if has_modal %}class="js-invoke-modal" aria-controls="case-study-contact-modal"{% endif %}>
               {{ title }}&nbsp;&rsaquo;
             </a>
           </p>


### PR DESCRIPTION
## Done

- Fix case study forms that were previously not invoking modal on click

## QA

- Go to a static case study page e.g /case-study/esa
- Scroll to the bottom and click on "Contact" cta
- See that the modal pops up

## Issue / Card

Fixes [WD-22004](https://warthogs.atlassian.net/browse/WD-22004)

## Screenshots

[if relevant, include a screenshot]


[WD-22004]: https://warthogs.atlassian.net/browse/WD-22004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ