### PR TITLE
[WD-22215] Missing fallback OG Images

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -53,9 +53,9 @@
           {% else %}
             <meta name="twitter:card" content="summary_large_image" />
             <meta name="twitter:image"
-                  content="https://assets.ubuntu.com/v1/66303ab2-Canonical%20logo.svg" />
+                  content="https://assets.ubuntu.com/v1/c797f1d7-og_%20canonical.png" />
             <meta property="og:image"
-                  content="https://assets.ubuntu.com/v1/66303ab2-Canonical%20logo.svg" />
+                  content="https://assets.ubuntu.com/v1/c797f1d7-og_%20canonical.png" />
           {% endif %}
 
           {% set current_path = url_for(request.endpoint, **request.view_args) %}


### PR DESCRIPTION
## Done

Added a fallback OG Image tag for URLs that do not specify an og image

## QA

- Check out [the demo](https://canonical-com-1708.demos.haus/) and preview the link to see that it now has a fallback og image

You can check [here](https://www.opengraph.xyz/url/https%3A%2F%2Fcanonical-com-1708.demos.haus%2F) for how the preview looks like 

## Issue / Card

Fixes # [WD-22223](https://warthogs.atlassian.net/browse/WD-22223)
Parent issue [WD-22215](https://warthogs.atlassian.net/browse/WD-22215)

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/0cc7a193-4a3e-42a0-b619-b38dd5ee64b3)

### After
![image](https://github.com/user-attachments/assets/c1448636-62b0-481a-9b53-fd0b78a0ff94)
![image](https://github.com/user-attachments/assets/b1536c37-0411-4de6-8f62-29996bd55bde)


[if relevant, include a screenshot]


[WD-22223]: https://warthogs.atlassian.net/browse/WD-22223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-22215]: https://warthogs.atlassian.net/browse/WD-22215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ