### PR TITLE
add missing fast track roles in careers page

### DIFF
--- a/templates/careers/includes/_fast-track-jobs.html
+++ b/templates/careers/includes/_fast-track-jobs.html
@@ -160,25 +160,53 @@
 
       </div>
 
+      <div class="row">
+
+        <div class="col-3">
+          <a href="/careers/5833620">Rust</a>
+
+          <p class="u-no-padding--top">
+            <small>Lead the Rust revolution</small>
+          </p>
+
+        </div>
+
+        <div class="col-3">
+          <a href="/careers/5792361">Performance and Correctness</a>
+
+          <p class="u-no-padding--top">
+            <small>Deep and sharp technology investigation and optimization</small>
+          </p>
+
+        </div>
+
+      </div>
+
+
     </div>
 
     <div class="col-3 col-medium-2">
 
       <h5 class="p-text--large">Position Level</h5>
+      
       <a href="/careers/5211861">Director</a>
-
       <p class="u-no-padding--top">
         <small>Define strategy and assist teams</small>
       </p>
-      <a href="/careers/5188002">Manager</a>
 
+      <a href="/careers/5188002">Manager</a>
       <p class="u-no-padding--top">
         <small>Lead globally-distributed teams</small>
       </p>
-      <a href="/careers/5142887">Senior Engineer</a>
 
+      <a href="/careers/5142887">Senior Engineer</a>
       <p class="u-no-padding--top">
         <small>Solve open source challenges</small>
+      </p>
+
+      <a href="/careers/6530841">Graduate</a>
+      <p class="u-no-padding--top">
+        <small>Kick-start your career in a team matching your skillset</small>
       </p>
 
     </div>

--- a/templates/careers/includes/_fast-track-jobs.html
+++ b/templates/careers/includes/_fast-track-jobs.html
@@ -182,7 +182,6 @@
 
       </div>
 
-
     </div>
 
     <div class="col-3 col-medium-2">


### PR DESCRIPTION
## Done

- Added missing FT roles in https://canonical.com/careers/engineering
- `Rust Engineering Lead - Linux and Open Source`
- `Performance Engineer - Open Source`
- `Graduate Software Engineer, Open Source and Linux, Canonical Ubuntu`

copy doc: https://docs.google.com/document/d/12GWF6eVKezvENc66p3QZ5ZEO8H2QBIlU56RPZNdCPdI

## QA

- goto: https://canonical-com-1712.demos.haus/careers/engineering
- Check the new 3 links

