### PR TITLE
fix: use correct form return url for /edge-computing and copy

### DIFF
--- a/templates/edge-computing/index.html
+++ b/templates/edge-computing/index.html
@@ -5,7 +5,7 @@
 {% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
 {% from "_macros/vf_equal-heights.jinja" import vf_equal_heights %}
 
-{% block title %}Straightforward, nimble edge computing{% endblock %}
+{% block title %}Straightforward, nimble edge infrastructure{% endblock %}
 
 {% block meta_description %}
   Deploy, manage and secure edge infrastructure on a flexible, cost-effective, robust open source foundation.
@@ -26,7 +26,7 @@
 {% block content %}
 
   {% call(slot) vf_hero(
-    title_text='Straightforward, nimble edge computing',
+    title_text='Straightforward, nimble edge infrastructure',
     subtitle_text='Power edge innovation with the freedom of open source.',
     layout='50/50-full-width-image'
     ) -%}

--- a/templates/edge-computing/index.html
+++ b/templates/edge-computing/index.html
@@ -666,7 +666,7 @@
 
   {% with %}
     {% set formid = "4271" %}
-    {% set returnURL = "https://canonical.com/solutions/edge-computing#success" %}
+    {% set returnURL = "https://canonical.com/edge-computing#success" %}
     {% include "partners/partial/_homepage-form.html" %}
   {% endwith %}
 


### PR DESCRIPTION
## Done

- Fix the form submission return URL for the `/edge-computing`
- Quick copy fixes

## QA

- Check out the demo here: https://canonical-com-1713.demos.haus/edge-computing
- Make sure the form returns to the original page after submission.
- Make sure the latest copy changes are reflected.

## Issue / Card

- [WD-21650](https://warthogs.atlassian.net/browse/WD-21650)


[WD-21650]: https://warthogs.atlassian.net/browse/WD-21650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ