### PR TITLE
ci: Trigger action error when sitemap build fails

### DIFF
--- a/.github/workflows/sitemap.yaml
+++ b/.github/workflows/sitemap.yaml
@@ -18,7 +18,3 @@ jobs:
         run: |
           curl -f -X POST "https://ubuntu.com/sitemap_tree.xml" \
           -H "Authorization: Bearer invalid-secret-for-qa"
-
-      - name: Send message on failure
-        if: failure()
-        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" ${{ secrets.BOT_URL }}?room=web--design

--- a/.github/workflows/sitemap.yaml
+++ b/.github/workflows/sitemap.yaml
@@ -16,5 +16,9 @@ jobs:
 
       - name: Call sitemap generation endpoint
         run: |
-          curl -f -X POST "https://ubuntu.com/sitemap_tree.xml" \
+          curl --fail-with-body -X POST "https://ubuntu.com/sitemap_tree.xml" \
           -H "Authorization: Bearer invalid-secret-for-qa"
+
+      - name: Send message on failure
+        if: failure()
+        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" ${{ secrets.BOT_URL }}?room=web--design

--- a/.github/workflows/sitemap.yaml
+++ b/.github/workflows/sitemap.yaml
@@ -1,10 +1,10 @@
-name: Generate sitemap for static pages
-on:
-  push:
-    branches:
-      - main
-    paths:
-      - "templates/**"
+name: Generate sitemap for static pages on canonical.com
+on: [pull_request]
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - "templates/**"
 
 jobs:
   generate-sitemap:
@@ -16,9 +16,8 @@ jobs:
 
       - name: Call sitemap generation endpoint
         run: |
-          curl -X POST "https://canonical.com/sitemap_tree.xml" \
-          -H "Authorization: Bearer ${{ secrets.SITEMAP_SECRET }}"
-
+          curl -f -X POST "https://ubuntu.com/sitemap_tree.xml" \
+          -H "Authorization: Bearer invalid-secret-for-qa"
 
       - name: Send message on failure
         if: failure()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1380,6 +1380,7 @@ def build_sitemap_tree(exclude_paths=None):
                 return xml_sitemap
             else:
                 logging.warning("Sitemap is empty")
+                return {"error:", "Sitemap is empty"}, 500
 
         except Exception as e:
             logging.error(f"Error generating sitemap: {e}")


### PR DESCRIPTION
## Done

- Add `-f` flag to generate-sitemap GH action
- The action fails if `build_sitemap_tree` returns a non-200 status code

## QA

- See that the `generate-sitemap` action fails
- Check that the failure is reported on ~web MM channel

## Issue / Card

Fixes [WD-21845](https://warthogs.atlassian.net/browse/WD-21845)



[WD-21845]: https://warthogs.atlassian.net/browse/WD-21845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ