### PR TITLE
ci: Trigger error on sitemap build error

### DIFF
--- a/.github/workflows/sitemap.yaml
+++ b/.github/workflows/sitemap.yaml
@@ -1,4 +1,4 @@
-name: Generate sitemap for static pages
+name: Generate sitemap for static pages on canonical.com
 on:
   push:
     branches:
@@ -16,9 +16,8 @@ jobs:
 
       - name: Call sitemap generation endpoint
         run: |
-          curl -X POST "https://canonical.com/sitemap_tree.xml" \
-          -H "Authorization: Bearer ${{ secrets.SITEMAP_SECRET }}"
-
+          curl --fail-with-body -X POST "https://canonical.com/sitemap_tree.xml" \
+          -H "Authorization: Bearer invalid-secret-for-qa"
 
       - name: Send message on failure
         if: failure()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1380,6 +1380,7 @@ def build_sitemap_tree(exclude_paths=None):
                 return xml_sitemap
             else:
                 logging.warning("Sitemap is empty")
+                return "Sitemap is empty", 500
 
         except Exception as e:
             logging.error(f"Error generating sitemap: {e}")


### PR DESCRIPTION
## Done

- Add `-f` flag to generate-sitemap GH action
- The action fails if `build_sitemap_tree` returns a non-200 status code

## QA

- See that the `generate-sitemap` action fails
- Check that the failure is [reported](https://chat.canonical.com/canonical/pl/uxmb7jr9tin7tm5rrcianihxyw) on ~web MM channel 

## Issue / Card

Fixes [WD-21845](https://warthogs.atlassian.net/browse/WD-21845)



[WD-21845]: https://warthogs.atlassian.net/browse/WD-21845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ