### PR TITLE
fix: add sitemap secret

### DIFF
--- a/.github/workflows/sitemap.yaml
+++ b/.github/workflows/sitemap.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Call sitemap generation endpoint
         run: |
           curl --fail-with-body -X POST "https://canonical.com/sitemap_tree.xml" \
-          -H "Authorization: Bearer invalid-secret-for-qa"
+          -H "Authorization: Bearer ${{ secrets.SITEMAP_SECRET }}"
 
       - name: Send message on failure
         if: failure()


### PR DESCRIPTION
## Done

- add sitemap secret to GH action

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
