### PR TITLE
chore: run action on main repo only

### DIFF
--- a/.github/workflows/sitemap.yaml
+++ b/.github/workflows/sitemap.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   generate-sitemap:
+    if: github.repository == 'canonical/canonical.com'
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
## Done

- Run `sitemap.yaml` action on main u.com repo only
- Used in other GH actions to only trigger on main repo e.g [live-links.yaml](https://github.com/canonical/ubuntu.com/blob/main/.github/workflows/live-links.yaml#L9)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

