### PR TITLE
test: add tests for build_sitemap tree

### DIFF
--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,9 +1,10 @@
-# Packages
 import unittest
+from unittest.mock import patch
 import logging
 import re
+import os
 import xml.etree.ElementTree as ET
-from webapp.app import app
+from webapp.app import app, build_sitemap_tree
 
 logging.getLogger("talisker.context").disabled = True
 
@@ -83,6 +84,57 @@ class TestSitemap(unittest.TestCase):
 
         for url in parser_urls:
             assert url in xml_urls, f"URL {url} not found in sitemap_tree.xml"
+
+    def test_sitemap_post_unauthorized(self):
+        """
+        Check that unauthorized access to the sitemap post endpoint returns 401
+        """
+        response = self.client.post(
+            "/sitemap_tree.xml",
+            headers={"Authorization": "Bearer unauthorized-secret"},
+        )
+        assert response.status_code == 401
+        assert b"Unauthorized" in response.data
+
+    def test_sitemap_post_authorized(self):
+        """
+        Check that authorized access to the sitemap post endpoint returns 200
+        """
+        os.environ["SITEMAP_SECRET"] = "test-secret"
+        response = self.client.post(
+            "/sitemap_tree.xml",
+            headers={"Authorization": "Bearer test-secret"},
+        )
+        assert response.status_code == 200
+        assert b"Sitemap successfully generated" in response.data
+
+    @patch("webapp.app.directory_parser.generate_sitemap", return_value="")
+    @patch("builtins.open")
+    @patch("os.getcwd", return_value="/invalid/path")
+    def test_create_sitemap_empty(self, mock_getcwd, mock_open, mock_generate):
+        """
+        Test create_sitemap returns error for empty xml_sitemap
+        """
+        create_sitemap = build_sitemap_tree().__closure__[0].cell_contents
+        result = create_sitemap("/invalid/path/sitemap_tree.xml")
+        self.assertEqual(result, ({"error:", "Sitemap is empty"}, 400))
+
+    @patch(
+        "webapp.app.directory_parser.generate_sitemap",
+        side_effect=Exception("fail"),
+    )
+    @patch("builtins.open")
+    @patch("os.getcwd", return_value="/invalid/path")
+    def test_create_sitemap_exception(
+        self, mock_getcwd, mock_open, mock_generate
+    ):
+        """
+        Test create_sitemap returns error for Exception in generate_sitemap
+        """
+        create_sitemap = build_sitemap_tree().__closure__[0].cell_contents
+        result = create_sitemap("/invalid/path/sitemap_tree.xml")
+        self.assertIn("Generate_sitemap error", result[0])
+        self.assertEqual(result[1], 500)
 
 
 if __name__ == "__main__":

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1380,7 +1380,7 @@ def build_sitemap_tree(exclude_paths=None):
                 return xml_sitemap
             else:
                 logging.warning("Sitemap is empty")
-                return "Sitemap is empty", 500
+                return {"error:", "Sitemap is empty"}, 400
 
         except Exception as e:
             logging.error(f"Error generating sitemap: {e}")


### PR DESCRIPTION
## Done

- Add test coverage for `build_sitemap` tree

## QA

- See that `test-python` action passes

## Issue / Card

Fixes [WD-22432](https://warthogs.atlassian.net/browse/WD-22432)

## Screenshots

[if relevant, include a screenshot]


[WD-22432]: https://warthogs.atlassian.net/browse/WD-22432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ