### PR TITLE
Migrate u.com/managed to c.com/managed

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -519,7 +519,7 @@ solutions:
         - title: Infrastructure
           url: /solutions/infrastructure
         - title: Managed IT services
-          url: https://ubuntu.com/managed
+          url: /managed
         - title: Open source security
           url: /solutions/open-source-security
         - title: IoT and devices

--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -280,3 +280,18 @@ anbox-cloud:
       path: https://documentation.ubuntu.com/anbox-cloud/
     - title: Forum
       path: https://discourse.ubuntu.com/c/project/anbox-user/148
+
+managed:
+  title: Managed Services
+  path: /managed
+
+  children:
+    - title: Kubernetes
+      path: /managed/kubernetes
+    - title: Ceph
+      path: /managed/ceph
+    - title: Apps
+      path: /managed/apps
+    - title: Firefighting
+      path: /managed/firefighting-support
+      

--- a/templates/managed/apps.html
+++ b/templates/managed/apps.html
@@ -1,0 +1,386 @@
+{% extends 'base_index.html' %}
+
+{% block title %}Canonical's Managed Apps | Multi-Cloud and On-Premise{% endblock %}
+
+{% block meta_description %}
+  Our app and cloud experience lets you maintain business focus in a complex tech landscape.
+  Rely on our expert engineers to set-up and operate your apps, with full lifecycle
+  coverage.
+{% endblock meta_description %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1fLRWW-Gtslaia2ypSrLJVBxZVHo5FY5Q84o97Gs2-w4/edit
+{% endblock meta_copydoc %}
+
+{% block content %}
+
+  <section class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col">
+        <h1>Managed Apps</h1>
+      </div>
+      <div class="col">
+        <p>
+          Effortlessly achieve operational excellence for your cloud-native application ecosystem. Our end-to-end, single-vendor managed app portfolio enables you to focus on making the most of your tools, whichever they are and whatever they are running on, without worrying about their operations.
+        </p>
+        <hr class="p-rule--muted" />
+        <p>
+          <a href="/managed/contact-us" class="js-invoke-modal">Discover how to bring your cloud-native apps to new levels&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--25-75">
+      <hr class="p-rule" />
+      <div class="col p-section--shallow">
+        <h2>Ecosystem breakdown</h2>
+      </div>
+      <div class="col" aria-describedby="diagram-desc">
+        {{ image(url="https://assets.ubuntu.com/v1/3e365249-managed%20diagram-30.07.2024.png",
+                alt="A diagram showing that Managed Apps supports cloud-native applications across Canonical infrastructure and public clouds.",
+                width="5503",
+                height="757",
+                hi_def=True,
+                attrs={"class": "u-hide--small"},
+                loading="auto") | safe
+        }}
+        <div class="u-hide--large u-hide--medium" id="diagram-desc">
+          <hr class="p-rule--muted" />
+          <h3 class="p-heading--5">Comprehensive ecosystem</h3>
+          <ul class="p-list--divided">
+            <li class="p-list__item has-bullet">Canonical MLOps</li>
+            <li class="p-list__item has-bullet">Kafka, Spark</li>
+            <li class="p-list__item has-bullet">SQL Databases</li>
+            <li class="p-list__item has-bullet">NoSQL Databases</li>
+          </ul>
+          <div class="col-small-3 col-start-small-2">
+          </div>
+          <hr class="p-rule--muted" />
+          <h3 class="p-heading--5">Native multicloud compatibility</h3>
+          <ul class="p-list--divided">
+            <li class="p-list__item">Canonical infrastructure
+              <ul class="p-list--divided">
+                <li class="p-list__item has-bullet">OpenStack</li>
+                <li class="p-list__item has-bullet">Kubernetes</li>
+                <li class="p-list__item has-bullet">Microcloud</li>
+              </ul>
+            </li>
+            <li class="p-list__item">Public cloud instances
+              <ul class="p-list--divided">
+                <li class="p-list__item has-bullet">Microsoft Azure</li>
+                <li class="p-list__item has-bullet">AWS</li>
+                <li class="p-list__item has-bullet">Google Cloud</li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+  <div class="u-fixed-width p-section--shallow">
+    <hr class="p-rule" />
+    <h2>App portfolio</h2>
+  </div>
+  <div class="row">
+    <div class="col-start-large-4 col-9 col-medium-6">
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3 col-medium-3">
+          <h3 class="p-heading--5">MLOps</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Automate your machine learning operations at any scale with fully managed Kubeflow and MLFlow.</p>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3 col-medium-3">
+          <h3 class="p-heading--5">Data processing</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Deploy high performance Apache Kafka or Spark clusters, and leave the rest to us.</p>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3 col-medium-3">
+          <h3 class="p-heading--5">NoSQL databases</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Enjoy hassle-free relational databases like MongoDB and OpenSearch for any use case.</p>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3 col-medium-3">
+          <h3 class="p-heading--5">SQL databases</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Go in depth with extensible and compliant tools like MySQL or PostgreSQL, minding only the data.</p>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="row">
+        <div class="col-3 col-medium-3">
+          <h3 class="p-heading--5">Landscape</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>
+            Manage your Ubuntu machines at scale without worrying about tooling, with <a href="/landscape/managed">Landscape</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+    <hr class="p-rule--muted" />
+    <div class="col-start-large-7 col-6 p-section--shallow">
+      <p>
+        <a href="/managed/contact-us" class="js-invoke-modal">Tell us about your app ecosystem&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Unlocking operational excellence</h2>
+      </div>
+      <div class="col">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">Accelerate your time to market</li>
+          <li class="p-list__item is-ticked">Cover your team's skill gaps</li>
+          <li class="p-list__item is-ticked">Focus <i>only</i> on what matters</li>
+          <li class="p-list__item is-ticked">Harness the power of hybrid clouds</li>
+          <li class="p-list__item is-ticked">Enjoy fully predictable costs</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Operational coverage</h2>
+      </div>
+      <div class="col">
+        <p>
+          Our extensive team of dedicated engineers works around the clock to provide you with expertise, as well as simultaneous reactivity and proactivity when it comes to operations. We cover all the ops your apps (and their underlying infrastructure) might need:
+        </p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-start-large-4 col-9 col-medium-6">
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">Monitoring</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Our ever-developing in-house <a href="https://canonical.com/observability/managed">observability toolkit</a> alongside our engineers' watchful eyes will ensure that your systems are correctly and completely monitored. Nothing escapes our eyes!
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">Management</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Upgrades and patches are a headache &ndash; knowing when to apply a new release, and taking all the precautions before doing so can be tedious and use precious resources. Let us cover that for you.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">Troubleshooting</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Even the strongest systems sometimes fail. Our military-grade incident and recovery protocols give you quick functionality restoration and extensive root-cause investigations.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">Security enforcement</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              We pay obsessive attention to compliance, security regulations, and legal restrictions, ensuring that both our practices and your stacks are protected against even the greatest threats.
+            </p>
+          </div>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="col-start-large-7 col-6 p-section--shallow">
+        <p>
+          <a href="/managed/contact-us" class="js-invoke-modal">Enforce your applications now&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50 p-section--shallow">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Options to fit any business need</h2>
+      </div>
+      <div class="col">
+        <p>
+          Whether you want to just kick back and not worry about your operations at all, or a hotline-style support that allows you to take the reins and call for immediate help in high-severity situations, our comprehensive solution packages have your back.
+        </p>
+      </div>
+    </div>
+    <div class="row--50-50">
+      <div class="col">
+        <hr class="p-rule--highlight u-no-margin--bottom" />
+        <div style="padding: 0 1rem 1rem 1rem; background-color: #EBEBEB;">
+          <div class="p-section--shallow">
+            <h3>Managed Services</h3>
+            <p class="u-text--muted">
+              Regain your space to innovate, and leave all your operations to us with our fully managed services.
+            </p>
+          </div>
+          <div class="row p-section--shallow">
+            <div class="col-2">
+              <p class="p-text--smal-caps">What's included:</p>
+            </div>
+            <div class="col-4">
+              <ul class="p-list--divided">
+                <li class="p-list__item is-ticked">24/7 end-to-end operational coverage</li>
+                <li class="p-list__item is-ticked">Proactive and reactive excellence</li>
+                <li class="p-list__item is-ticked">Market-standard SLA's</li>
+              </ul>
+            </div>
+          </div>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="/managed">Access your ideal managed service&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+      <div class="col">
+        <hr class="p-rule--highlight u-no-margin--bottom" />
+        <div style="padding: 0 1rem 1rem 1rem; background-color: #EBEBEB;">
+          <div class="p-section--shallow">
+            <h3>Firefighting Support</h3>
+            <p class="u-text--muted">
+              Get engineers on call to help you resolve the most critical issues while managing your own environments.
+            </p>
+          </div>
+          <div class="row">
+            <div class="col-2">
+              <p class="p-text--smal-caps">What's included:</p>
+            </div>
+            <div class="col-4">
+              <ul class="p-list--divided">
+                <li class="p-list__item is-ticked">1-hour response time via video call for high-severity situations</li>
+                <li class="p-list__item is-ticked">
+                  Access to <a href="/managed/firefighting-support">Ops Consulting</a> packages
+                </li>
+                <li class="p-list__item is-ticked">
+                  <a href="/pro">Ubuntu Pro &plus; Support</a> for all covered products
+                </li>
+              </ul>
+            </div>
+          </div>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="/managed/firefighting-support">Get firefighting support&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Natively multi-cloud</h2>
+      </div>
+      <div class="col">
+        <p>
+          You no longer need to worry about tailoring your application ecosystem to a single cloud. Our managed app portfolio is natively multicloud, allowing you to deploy, run, and harness the power of your applications both on-premises and on all the major public clouds.
+        </p>
+        <hr class="p-rule--muted" />
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">Full stack on-premises portfolio</li>
+          <li class="p-list__item is-ticked">
+            Active collaborations with Microsoft Azure, Amazon Web Services, and Google Cloud
+          </li>
+          <li class="p-list__item is-ticked">
+            Seamless integration between any cloud image via <a href="https://juju.is/">Juju</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="row">
+      <hr class="p-rule--muted" />
+      <div class="col-start-large-7 col-6 p-section--shallow">
+        <p>
+          <a href="https://canonical.com/solutions/infrastructure">Discover our infrastructure story&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Use cases</h2>
+      </div>
+      <div class="col">
+        <p>Managed AI</p>
+        <p>
+          <a href="/engage/guide-to-managed-ai-infrastructure">Discover how managed services can bring AI closer to any company</a>
+        </p>
+        <hr class="p-rule--muted" />
+        <p>Managed MongoDB</p>
+        <p>
+          <a href="https://assets.ubuntu.com/v1/aeb556fb-MongoDB%20-%20Datasheet-revised.pdf?_gl=1*u13t3p*_gcl_au*MTA1NjA4ODkwMy4xNzE0NTcwMzMw&_ga=2.3615472.1764863720.1717683420-375269112.1717683420">Harness the power of one of the best NoSQL databases through managed services</a>
+        </p>
+        <hr class="p-rule--muted" />
+        <p>Managed Apps on public cloud</p>
+        <p>
+          <a href="/blog/managed-apps-on-public-cloud-why-operations-matter-part-i">Explore what operational excellence looks like in a public cloud ecosystem</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="p-rule is-fixed-width" />
+  <section class="p-strip is-deep">
+    <div class="u-fixed-width">
+      <h2>Enjoy all the benefits of managed cloud apps now.</h2>
+      <p class="p-heading--2">
+        <a class="js-invoke-modal" href="/managed/contact-us">Get in touch&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </section>
+
+  <div class="u-hide"
+      id="contact-form-container"
+      data-form-location="/shared/forms/interactive/managed-services.html"
+      data-form-id="4053"
+      data-lp-id=""
+      data-return-url="https://ubuntu.com/managed/thank-you"
+      data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
+
+{% endblock content %}

--- a/templates/managed/apps.html
+++ b/templates/managed/apps.html
@@ -29,7 +29,7 @@
         </p>
         <hr class="p-rule--muted" />
         <p>
-          <a href="/managed/contact-us" class="js-invoke-modal">Discover how to bring your cloud-native apps to new levels&nbsp;&rsaquo;</a>
+          <a href="/managed/contact-us" class="js-invoke-modal" aria-controls="managed-modal">Discover how to bring your cloud-native apps to new levels&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
@@ -142,7 +142,7 @@
     <hr class="p-rule--muted" />
     <div class="col-start-large-7 col-6 p-section--shallow">
       <p>
-        <a href="/managed/contact-us" class="js-invoke-modal">Tell us about your app ecosystem&nbsp;&rsaquo;</a>
+        <a href="/managed/contact-us" class="js-invoke-modal" aria-controls="managed-modal">Tell us about your app ecosystem&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>
@@ -187,7 +187,7 @@
           </div>
           <div class="col-6 col-medium-3">
             <p>
-              Our ever-developing in-house <a href="https://canonical.com/observability/managed">observability toolkit</a> alongside our engineers' watchful eyes will ensure that your systems are correctly and completely monitored. Nothing escapes our eyes!
+              Our ever-developing in-house <a href="/observability/managed">observability toolkit</a> alongside our engineers' watchful eyes will ensure that your systems are correctly and completely monitored. Nothing escapes our eyes!
             </p>
           </div>
         </div>
@@ -228,7 +228,7 @@
       <hr class="p-rule--muted" />
       <div class="col-start-large-7 col-6 p-section--shallow">
         <p>
-          <a href="/managed/contact-us" class="js-invoke-modal">Enforce your applications now&nbsp;&rsaquo;</a>
+          <a href="/managed/contact-us" class="js-invoke-modal" aria-controls="managed-modal">Enforce your applications now&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
@@ -334,7 +334,7 @@
       <hr class="p-rule--muted" />
       <div class="col-start-large-7 col-6 p-section--shallow">
         <p>
-          <a href="https://canonical.com/solutions/infrastructure">Discover our infrastructure story&nbsp;&rsaquo;</a>
+          <a href="/solutions/infrastructure">Discover our infrastructure story&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
@@ -370,17 +370,11 @@
     <div class="u-fixed-width">
       <h2>Enjoy all the benefits of managed cloud apps now.</h2>
       <p class="p-heading--2">
-        <a class="js-invoke-modal" href="/managed/contact-us">Get in touch&nbsp;&rsaquo;</a>
+        <a class="js-invoke-modal" aria-controls="managed-modal" href="/managed/contact-us">Get in touch&nbsp;&rsaquo;</a>
       </p>
     </div>
   </section>
 
-  <div class="u-hide"
-      id="contact-form-container"
-      data-form-location="/shared/forms/interactive/managed-services.html"
-      data-form-id="4053"
-      data-lp-id=""
-      data-return-url="https://ubuntu.com/managed/thank-you"
-      data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
+  {{ load_form("/managed") | safe }}
 
 {% endblock content %}

--- a/templates/managed/ceph.html
+++ b/templates/managed/ceph.html
@@ -23,7 +23,7 @@
       <p>Focus on your business applications, while Canonical takes care of your storage needs.</p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
-      <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+      <a href="/managed/contact-us" class="p-button--positive js-invoke-modal" aria-controls="managed-modal">Get in touch</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--3-2 is-highlighted is-cover u-hide--small">
@@ -267,4 +267,7 @@
       </div>
     </div>
   </div>
+
+  {{ load_form("/managed") | safe }}
+
 {% endblock content %}

--- a/templates/managed/ceph.html
+++ b/templates/managed/ceph.html
@@ -1,0 +1,270 @@
+{% extends 'base_index.html' %}
+
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
+{% block title %}Managed Ceph | Ceph{% endblock %}
+
+{% block meta_description %}
+  Canonical is the leading managed Ceph provider, we build, support and manage Ceph clusters in any location.
+{% endblock meta_description %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1Ff3TDYBsukagu85dNZuK0FDdPRSjXEwS6Tv6JphXUvY
+{% endblock meta_copydoc %}
+
+{% block content %}
+  {% call(slot) vf_hero(
+    title_text='Fully managed Ceph',
+    layout='50/50',
+    is_split_on_medium=true
+    ) -%}
+    {%- if slot == 'description' -%}
+      <p>Reduce operational complexity by allowing Canonical's experts to operate and maintain your Ceph cluster.</p>
+      <p>Focus on your business applications, while Canonical takes care of your storage needs.</p>
+    {%- endif -%}
+    {%- if slot == 'cta' -%}
+      <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+    {%- endif -%}
+    {%- if slot == 'image' -%}
+      <div class="p-image-container--3-2 is-highlighted is-cover u-hide--small">
+        {{ image (
+        url="https://assets.ubuntu.com/v1/045c9e3a-fully-managed-ceph.png",
+        alt="",
+        width="1800",
+        height="1128",
+        hi_def=True,
+        loading="lazy",
+        attrs={"class": "p-image-container__image"}) | safe
+        }}
+      </div>
+    {%- endif -%}
+  {% endcall -%}
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>
+          Why choose
+          <br class="u-hide-small" />
+          Canonical's Managed Ceph?
+        </h2>
+      </div>
+      <div class="col">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">
+            Fully managed on your servers, in your own data center, or in a co-location facility
+          </li>
+
+          <li class="p-list__item is-ticked">Built using a proven reference architecture</li>
+
+          <li class="p-list__item is-ticked">Customize the cluster architecture based on your needs</li>
+
+          <li class="p-list__item is-ticked">Integrated with your infrastructure, on-prem, hybrid, or public cloud</li>
+
+          <li class="p-list__item is-ticked">Existing workload analysis and migration services</li>
+
+          <li class="p-list__item is-ticked">Enterprise SLA for all protocols</li>
+
+          <li class="p-list__item is-ticked">Your team retains access to all machines at all times</li>
+
+          <li class="p-list__item is-ticked">Modern monitoring and log management</li>
+
+          <li class="p-list__item is-ticked">We will hand over the keys when you are ready</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+      <h2>Build, operate, transfer and support</h2>
+    </div>
+    <div class="row">
+      <div class="col-6 col-start-large-7">
+        <p>Deploy a fully managed Ceph cluster in a few weeks with these simple steps.</p>
+      </div>
+      <div class="col-9 col-medium-6 col-start-large-4">
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">1. Design</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Our experts work with your team to <a href="/ceph/consulting">design a Ceph cluster</a> suited to your needs. We guide you through hardware and configuration decisions, to ensure that the resulting cluster is tailored to meet your performance, capacity, security and integration requirements.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">2. Model</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              On completion of the design, all decisions are translated into a reusable model. This model allows for reuse across multiple environments, and guarantees repeatable deployments and integrations with infrastructure-as-code (IaC) and continuous integration and continuous delivery (CI/CD) systems.
+            </p>
+
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">3. Deploy</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Our experts will deploy the Ceph cluster in any location, that could be your own on-premise data center, or a co-location facility. Once your hardware is stood up, we test it end-to-end, ensuring all components are functional, and the networking is correctly configured. Then we build the cluster, validate it, and finally benchmark it's performance before your data is onboarded.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">4. Operate</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              The Ceph cluster is fully managed 24x7 by our team of experts. We provide monitoring, incident and problem resolution and take care of day-to-day maintenance tasks, including Ceph upgrades, and our <a href="/advantage">24x7 commercial support</a> includes security updates, and bug fixes.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">5. Transfer</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Optionally, on your request, we will transfer control of your Ceph cluster back to your organization, we can provide <a href="/training">training</a> to ensure your team will be able to operate the Ceph cluster and perform a formal handover process. We continue to provide commercial support to make sure that you continue to receive security updates, bug fixes and help as required.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+      <div class="p-section--shallow">
+        <div class="row--50-50">
+          <div class="col">
+            <h2>Companies using Ceph</h2>
+          </div>
+          <div class="col">
+            <p>
+              There are multiple users of Ceph across a broad range of industries, from academia to telecommunications and cloud service providers. Ceph is particularly favored for its flexibility, scalability, and robustness.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <hr class="p-rule--muted" />
+
+      <p class="p-heading--5 p-text--small-caps">Notable Ceph Users</p>
+      <div class="p-logo-section--dense">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/57c722c5-cern-logo.png",
+                        alt="CERN",
+                        width="239",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/60fd1f45-deutsche-telekom.png",
+                        alt="Deutsche Telekom",
+                        width="313",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/1e543d4d-Bloomberg-Logo.png",
+                        alt="Bloomberg",
+                        width="313",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/c3382d32-cisco-logo.png",
+                        alt="Cisco",
+                        width="189",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/6ec58036-dreamhost-logo.png",
+                        alt="Dreamhost",
+                        width="433",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/39eef9bb-digitalocean-logo.png",
+                        alt="DigitalOcean",
+                        width="463",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-section--deep">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-6">
+        <h2>Learn more about Ceph</h2>
+      </div>
+      <div class="col-6 col-medium-6">
+        <div class="row">
+          <div class="col-2 col-medium-3">
+            <h3 class="p-heading--5">Webinar</h3>
+          </div>
+          <div class="col-4 col-medium-3">
+            <p>
+              <a href="https://www.brighttalk.com/webcast/6793/520582">Ceph for Enterprise</a>
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-2 col-medium-3">
+            <h3 class="p-heading--5">Case study</h3>
+          </div>
+          <div class="col-4 col-medium-3">
+            <p>
+              <a href="/engage/yahoo-japan-case-study">How Yahoo! Japan built their IaaS storage using Ceph on Ubuntu</a>
+            </p>
+            <hr class="p-rule--muted" />
+            <p>
+              <a href="/engage/wellcome-sanger-case-study">Genomic research centre turns to Ceph for growing storage needs</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/templates/managed/contact-us.html
+++ b/templates/managed/contact-us.html
@@ -1,0 +1,621 @@
+{% extends 'base_index.html' %}
+
+{% block title %}Contact us | Managed apps{% endblock %}
+
+{% block meta_description %}Thank you for enquiring about Canonical's managed IT Services{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1twkl4QVBl8JXEWumQpu0fYzRWG39wLT9xxDeFzqWgdk/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-section--hero">
+  <div class="row--50-50">
+    <div class="col">
+      <h1>Contact us about managed IT Services</h1>
+    </div>
+    <div class="col">
+      <p>Rely on our experienced engineers to deploy and operate your apps, with full lifecycle coverage included.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <form action="/marketo/submit" method="post" id="mktoForm_3545">
+    <div class="p-section">
+      <hr class="p-rule is-fixed-width" />
+      <div class="row--50-50 js-formfield">
+        <div class="col">
+          <label for="about-your-project" class="p-heading--2 js-formfield-title">Tell us about your project</label>
+        </div>
+        <div class="col">
+          <textarea id="about-your-project" rows="5"></textarea>
+        </div>
+      </div>
+    </div>
+    <div class="p-section">
+      <hr class="p-rule is-fixed-width" />
+      <fieldset class="p-fieldset-section js-formfield js-toggle-checkbox-visibility"
+                aria-labelledby="ubuntu-versions-legend">
+        <div class="row--50-50">
+          <div class="col">
+            <label class="p-heading--2 js-formfield-title" id="ubuntu-versions-legend">
+              If you use Ubuntu, which version(s) are you using?
+            </label>
+          </div>
+          <div class="col">
+            <div class="u-sv3">
+              <strong>LTS within standard support</strong>
+              <label class="p-checkbox">
+                <input type="checkbox"
+                       aria-labelledby="24-04"
+                       class="p-checkbox__input js-checkbox-visibility"
+                       value="24.04 LTS" />
+                <span class="p-checkbox__label" id="24-04">24.04 LTS</span>
+              </label>
+              <label class="p-checkbox">
+                <input type="checkbox"
+                       aria-labelledby="22-04"
+                       class="p-checkbox__input js-checkbox-visibility"
+                       value="22.04 LTS" />
+                <span class="p-checkbox__label" id="22-04">22.04 LTS</span>
+              </label>
+              <label class="p-checkbox">
+                <input type="checkbox"
+                       aria-labelledby="20-04"
+                       class="p-checkbox__input js-checkbox-visibility"
+                       value="20.04 LTS" />
+                <span class="p-checkbox__label" id="20-04">20.04 LTS</span>
+              </label>
+            </div>
+            <div class="u-sv3">
+              <strong>LTS out of standard support</strong>
+              <label class="p-checkbox">
+                <input type="checkbox"
+                       aria-labelledby="18-04"
+                       class="p-checkbox__input js-checkbox-visibility"
+                       value="18.04 LTS" />
+                <span class="p-checkbox__label" id="18-04">18.04 LTS</span>
+              </label>
+              <label class="p-checkbox">
+                <input type="checkbox"
+                       aria-labelledby="16-04"
+                       class="p-checkbox__input js-checkbox-visibility"
+                       value="16.04 LTS" />
+                <span class="p-checkbox__label" id="16-04">16.04 LTS</span>
+              </label>
+              <label class="p-checkbox">
+                <input type="checkbox"
+                       aria-labelledby="14-04"
+                       class="p-checkbox__input js-checkbox-visibility"
+                       value="14.04 LTS" />
+                <span class="p-checkbox__label" id="14-04">14.04 LTS</span>
+              </label>
+            </div>
+            <div class="u-sv3">
+              <strong>Outdated or non-LTS releases</strong>
+              <label class="p-checkbox">
+                <input type="checkbox"
+                       aria-labelledby="22-10"
+                       class="p-checkbox__input js-checkbox-visibility"
+                       value="22.10 (interim release)" />
+                <span class="p-checkbox__label" id="22-10">non-LTS release</span>
+              </label>
+              <label class="p-checkbox">
+                <input type="checkbox"
+                       aria-labelledby="12-04"
+                       class="p-checkbox__input js-checkbox-visibility"
+                       value="12.04 LTS" />
+                <span class="p-checkbox__label" id="12-04">12.04 LTS</span>
+              </label>
+            </div>
+            <div class="u-sv3">
+              <strong>Other</strong>
+              <label class="p-checkbox">
+                <input type="checkbox"
+                       aria-labelledby="dont-use-ubuntu-today"
+                       class="p-checkbox__input js-checkbox-visibility__other"
+                       value="I don't use Ubuntu today" />
+                <span class="p-checkbox__label" id="dont-use-ubuntu-today">I don't use
+                Ubuntu today</span>
+              </label>
+              <label class="p-checkbox">
+                <input type="checkbox"
+                       aria-labelledby="i-dont-know"
+                       class="p-checkbox__input js-checkbox-visibility__other"
+                       value="I don't know" />
+                <span class="p-checkbox__label" id="i-dont-know">I don't know</span>
+              </label>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div class="p-section">
+      <hr class="p-rule is-fixed-width" />
+      <fieldset class="p-fieldset-section js-formfield js-required-checkbox"
+                aria-required="true"
+                aria-labelledby="kind-of-device-legend">
+        <div class="row--50-50">
+          <div class="col">
+            <legend class="p-heading--2 js-formfield-title is-required"
+                    id="kind-of-device-legend">What kind of device are you using?</legend>
+          </div>
+          <div class="col">
+            <label class="p-checkbox">
+              <input class="p-checkbox__input"
+                     type="checkbox"
+                     aria-labelledby="desktop-workstation"
+                     value="desktop/workstation" />
+              <span class="p-checkbox__label" id="desktop-workstation">Desktop/workstation</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="physical-server"
+                     class="p-checkbox__input"
+                     value="physical server" />
+              <span class="p-checkbox__label" id="physical-server">Physical server</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="public-cloud"
+                     class="p-checkbox__input"
+                     value="public cloud" />
+              <span class="p-checkbox__label" id="public-cloud">Public cloud</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="virtual-machine"
+                     class="p-checkbox__input"
+                     value="virtual machine" />
+              <span class="p-checkbox__label" id="virtual-machine">Virtual machine</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="iot-edge-device"
+                     class="p-checkbox__input"
+                     value="iot/edge device" />
+              <span class="p-checkbox__label" id="iot-edge-device">IoT/Edge device</span>
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div class="p-section">
+      <hr class="p-rule is-fixed-width" />
+      <fieldset class="p-fieldset-section js-formfield js-remove-radio-names"
+                aria-labelledby="how-many-machines-legend"
+                aria-required="true"
+                id="how-many-machines">
+        <div class="row--50-50">
+          <div class="col">
+            <legend class="p-heading--2 js-formfield-title is-required"
+                    id="how-many-machines-legend">
+              How many
+              {% if howManyVM %}
+                VMs
+              {% else %}
+                devices
+              {% endif %}
+              ?
+            </legend>
+          </div>
+          <div class="col">
+            <label class="p-radio">
+              <input required
+                     class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="less-5-machines"
+                     name="how-many-machines-do-you-have"
+                     value="less than 5" />
+              <span class="p-radio__label" id="less-5-machines">&lt;&nbsp;5 machines</span>
+
+            </label>
+            <label class="p-radio">
+              <input type="radio"
+                     aria-labelledby="15-to-15-machines"
+                     class="p-radio__input"
+                     name="how-many-machines-do-you-have"
+                     value="5 to 15 machines" />
+              <span class="p-radio__label" id="15-to-15-machines">5&nbsp;&ndash;&nbsp;15 machines</span>
+            </label>
+            <label class="p-radio">
+              <input type="radio"
+                     aria-labelledby="15-to-50-machines"
+                     class="p-radio__input"
+                     name="how-many-machines-do-you-have"
+                     value="15 to 50 machines" />
+              <span class="p-radio__label" id="15-to-50-machines">15&nbsp;&ndash;&nbsp;50 machines</span>
+            </label>
+            <label class="p-radio">
+              <input type="radio"
+                     aria-labelledby="50-to-100-machines"
+                     class="p-radio__input"
+                     name="how-many-machines-do-you-have"
+                     value="50 to 100 machines" />
+              <span class="p-radio__label" id="50-to-100-machines">50&nbsp;&ndash;&nbsp;100 machines</span>
+            </label>
+            <label class="p-radio">
+              <input type="radio"
+                     aria-labelledby="greater-than-100"
+                     class="p-radio__input"
+                     name="how-many-machines-do-you-have"
+                     value="greater than 100" />
+              <span class="p-radio__label" id="greater-than-100">&gt;&nbsp;100 machines</span>
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div class="p-section">
+      <hr class="p-rule is-fixed-width" />
+      <fieldset class="p-fieldset-section js-formfield"
+                aria-labelledby="how-do-you-consume-open-source-legend">
+        <div class="row--50-50">
+          <div class="col">
+            <legend class="p-heading--2 js-formfield-title"
+                    id="how-do-you-consume-open-source-legend">How do you consume open source?</legend>
+          </div>
+          <div class="col">
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="ubuntu-repositories"
+                     class="p-checkbox__input"
+                     value="Ubuntu repositories" />
+              <span class="p-checkbox__label" id="ubuntu-repositories">Ubuntu repositories</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="github-upstream"
+                     class="p-checkbox__input"
+                     value="GitHub/Upstream" />
+              <span class="p-checkbox__label" id="github-upstream">GitHub/Upstream</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="internally-approved-repository"
+                     class="p-checkbox__input"
+                     value="Internally approved repository" />
+              <span class="p-checkbox__label" id="internally-approved-repository">Internally approved repository</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="i-dont-know"
+                     class="p-checkbox__input"
+                     value="I don't know" />
+              <span class="p-checkbox__label" id="i-dont-know">I don't know</span>
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div class="p-section">
+      <hr class="p-rule is-fixed-width" />
+      <fieldset class="p-fieldset-section js-formfield"
+                aria-labelledby="hardening-requirements-legend">
+        <div class="row--50-50">
+          <div class="col">
+            <legend class="p-heading--2 js-formfield-title"
+                    id="hardening-requirements-legend">
+              Do you have specific compliance or hardening requirements?
+            </legend>
+          </div>
+          <div class="col">
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="pci"
+                     class="p-checkbox__input"
+                     value="PCI-DSS" />
+              <span class="p-checkbox__label" id="pci">PCI-DSS</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="hipaa"
+                     class="p-checkbox__input"
+                     value="HIPAA" />
+              <span class="p-checkbox__label" id="hipaa">HIPAA</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="fisma"
+                     class="p-checkbox__input"
+                     value="FISMA" />
+              <span class="p-checkbox__label" id="fisma">FISMA</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="fips-140"
+                     class="p-checkbox__input"
+                     value="FIPS 140" />
+              <span class="p-checkbox__label" id="fips-140">FIPS 140</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="ncsc"
+                     class="p-checkbox__input"
+                     value="NCSC" />
+              <span class="p-checkbox__label" id="ncsc">NCSC</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="disa-stig"
+                     class="p-checkbox__input"
+                     value="DISA-STIG" />
+              <span class="p-checkbox__label" id="disa-stig">DISA-STIG</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="fedramp"
+                     class="p-checkbox__input"
+                     value="FedRAMP" />
+              <span class="p-checkbox__label" id="fedramp">FedRAMP</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="cis-benchmark"
+                     class="p-checkbox__input"
+                     value="CIS Benchmark" />
+              <span class="p-checkbox__label" id="cis-benchmark">CIS Benchmark</span>
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div class="p-section">
+      <hr class="p-rule is-fixed-width" />
+      <fieldset class="p-fieldset-section js-formfield"
+                aria-labelledby="responsible-for-tracking-legend">
+        <div class="row--50-50">
+          <div class="col">
+            <legend class="p-heading--2 js-formfield-title"
+                    id="responsible-for-tracking-legend">
+              Who is responsible for tracking, testing and applying CVE patches in a timely manner?
+            </legend>
+          </div>
+          <div class="col">
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="pindividual-developers"
+                     class="p-checkbox__input"
+                     value="Individual developers" />
+              <span class="p-checkbox__label" id="pindividual-developers">Individual developers</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="project-team"
+                     class="p-checkbox__input"
+                     value="The project team" />
+              <span class="p-checkbox__label" id="project-team">The project team</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="3rd-party"
+                     class="p-checkbox__input"
+                     value="Third-party vendor" />
+              <span class="p-checkbox__label" id="3rd-party">Third-party vendor</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="i-dont-know"
+                     class="p-checkbox__input"
+                     value="I don't know" />
+              <span class="p-checkbox__label" id="i-dont-know">I don't know</span>
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div class="p-section">
+      <hr class="p-rule is-fixed-width" />
+      <div class="row--50-50 js-formfield">
+        <div class="col">
+          <label for="advice" class="p-heading--2 js-formfield-title">What advice are you looking for?</label>
+        </div>
+        <div class="col">
+          <textarea id="advice"
+                    aria-label="Tell us about your challenge and your goals"
+                    placeholder="Tell us about your challenge and your goals"
+                    rows="5"></textarea>
+        </div>
+      </div>
+    </div>
+    <div class="p-section">
+      <hr class="p-rule is-fixed-width" />
+      <fieldset class="p-fieldset-section"
+                id="about-you"
+                aria-labelledby="about-you-legend">
+        <div class="row--50-50">
+          <div class="col">
+            <legend class="p-heading--2" id="about-you-legend">How should we get in touch?</legend>
+          </div>
+          <div class="col">
+            <ul class="p-list">
+              <li class="p-list__item">
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
+                <label class="is-required" for="company">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
+                <label class="is-required" for="title">Job title:</label>
+                <input required id="title" name="title" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
+                <label class="is-required" for="email">Email address:</label>
+                <input required
+                       id="email"
+                       name="email"
+                       maxlength="255"
+                       type="email"
+                       pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+              </li>
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input id="phone" name="phone" maxlength="255" type="tel" />
+              </li>
+
+              {% include "shared/forms/_country.html" %}
+              
+            </ul>
+            <ul class="p-list">
+              <li class="p-list__item">
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input"
+                         value="yes"
+                         aria-labelledby="canonicalUpdatesOptIn"
+                         name="canonicalUpdatesOptIn"
+                         type="checkbox" />
+                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+                </label>
+              </li>
+              <li class="p-list__item u-sv3">
+                By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+              </li>
+              {# These are honey pot fields to catch bots #}
+              <li class="u-off-screen">
+                <label class="website" for="website">Website:</label>
+                <input name="website"
+                       type="text"
+                       class="website"
+                       autocomplete="off"
+                       value=""
+                       id="website"
+                       tabindex="-1" />
+              </li>
+              <li class="u-off-screen">
+                <label class="name" for="name">Name:</label>
+                <input name="name"
+                       type="text"
+                       class="name"
+                       autocomplete="off"
+                       value=""
+                       id="name"
+                       tabindex="-1" />
+              </li>
+              {# End of honey pots #}
+              <li class="p-list__item">
+                <button type="submit" class="p-button--positive js-submit-button">Submit</button>
+              </li>
+            </ul>
+            <div class="u-off-screen">
+              <label for="Comments_from_lead__c">
+                <h3 class="p-heading--4">Your comments</h3>
+                <textarea id="Comments_from_lead__c"
+                          name="Comments_from_lead__c"
+                          rows="5"
+                          maxlength="2000"></textarea>
+              </label>
+            </div>
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="formid"
+                   value="3545" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="returnURL"
+                   value="/managed#success" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="Consent_to_Processing__c"
+                   value="yes" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_campaign"
+                   id="utm_campaign"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_medium"
+                   id="utm_medium"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_source"
+                   id="utm_source"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_content"
+                   id="utm_content"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_term"
+                   id="utm_term"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="GCLID__c"
+                   id="GCLID__c"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="Facebook_Click_ID__c"
+                   id="Facebook_Click_ID__c"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   id="preferredLanguage"
+                   name="preferredLanguage"
+                   maxlength="255"
+                   value="" />
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </form>
+</section>
+
+<section class="p-section">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>Need help with Ubuntu?</h2>
+    </div>
+    <div class="col">
+      <p>If you are just looking for some free support for yourself, you can try:</p>
+      <ul class="p-list">
+        <li class="p-list__item">
+          <a href="https://askubuntu.com/">Ask Ubuntu</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://ubuntuforums.org/">The Ubuntu forum</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://help.ubuntu.com/">Help docs</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<script>
+  document.querySelector('form').addEventListener('submit', function(event) {
+    dataLayer.push({
+      'event': 'GAEvent',
+      'eventCategory': 'Form',
+      'eventAction': 'Managed services contact-us',
+      'eventLabel': 'Managed',
+      'eventValue': undefined
+    });
+  });
+</script>
+
+
+{% endblock content %}

--- a/templates/managed/firefighting-support.html
+++ b/templates/managed/firefighting-support.html
@@ -26,7 +26,7 @@
             The best self-managed alternative to <a href="/managed">Canonical Managed Services</a>. Get engineers on call to help you resolve the most critical issues, while continuing to manage your own environments.
           </p>
           <hr class="p-rule--muted" />
-          <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Enhance your cloud support now</a>
+          <a href="/managed/contact-us" class="p-button--positive js-invoke-modal" aria-controls="managed-modal">Enhance your cloud support now</a>
         </div>
       </div>
     </div>
@@ -53,7 +53,7 @@
       </div>
       <div class="col">
         <p>
-          Whether you’re running a cloud based on <a href="/openstack">OpenStack</a> or <a href="https://canonical.com/microcloud">MicroCloud</a>, or using applications like Kafka, Kubeflow, Spark, or OpenSearch, operations management can be tough! That's why Canonical offers <a href="/managed">fully managed services</a>, which relieve you of that worry. However, be it due to security regulations or other issues, giving our engineers access to your environments is not something you can always do.
+          Whether you're running a cloud based on <a href="/openstack">OpenStack</a> or <a href="/microcloud">MicroCloud</a>, or using applications like Kafka, Kubeflow, Spark, or OpenSearch, operations management can be tough! That's why Canonical offers <a href="/managed">fully managed services</a>, which relieve you of that worry. However, be it due to security regulations or other issues, giving our engineers access to your environments is not something you can always do.
         </p>
         <p>
           This is why we launched Firefighting Support, a package that gives you dual, highly-enhanced cloud support from Canonical's Support and Managed Solutions engineering teams.
@@ -101,7 +101,7 @@
           <li class="p-list__item is-ticked">Full control of your environments</li>
         </ul>
         <hr class="p-rule--muted" />
-        <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Get Firefighting Support</a>
+        <a href="/managed/contact-us" class="p-button--positive js-invoke-modal" aria-controls="managed-modal">Get Firefighting Support</a>
       </div>
     </div>
   </section>
@@ -464,17 +464,11 @@
   <section class="p-strip is-deep">
     <div class="u-fixed-width">
       <h2>
-        <a href="/managed/contact-us" class="js-invoke-modal">Contact us and discuss your options&nbsp;&rsaquo;</a>
+        <a href="/managed/contact-us" class="js-invoke-modal" aria-controls="managed-modal">Contact us and discuss your options&nbsp;&rsaquo;</a>
       </h2>
     </div>
   </section>
 
-  <div class="u-hide"
-       id="contact-form-container"
-       data-form-location="/shared/forms/interactive/managed-services.html"
-       data-form-id="4053"
-       data-lp-id=""
-       data-return-url="https://ubuntu.com/managed/thank-you"
-       data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
+  {{ load_form("/managed") | safe }}
 
 {% endblock content %}

--- a/templates/managed/firefighting-support.html
+++ b/templates/managed/firefighting-support.html
@@ -1,0 +1,480 @@
+{% extends 'base_index.html' %}
+
+{% block title %}Firefighting Support: enhanced cloud support from Canonical{% endblock %}
+
+{% block meta_description %}
+  Get enhanced cloud support from Canonical. Firefighting Support is an alternative to managed services that keeps your cloud or AI infrastructure running smoothly.
+{% endblock meta_description %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1sWNMmLoyOFUI9qZE3fqPhgZWJSpb-e6-juGrW7A5rr0/edit
+{% endblock meta_copydoc %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block content %}
+  <section class="p-strip is-shallow">
+    <div class="p-section">
+      <div class="row--50-50">
+        <div class="col">
+          <h1>Firefighting Support</h1>
+        </div>
+        <div class="col">
+          <p>
+            The best self-managed alternative to <a href="/managed">Canonical Managed Services</a>. Get engineers on call to help you resolve the most critical issues, while continuing to manage your own environments.
+          </p>
+          <hr class="p-rule--muted" />
+          <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Enhance your cloud support now</a>
+        </div>
+      </div>
+    </div>
+    <div class="p-section u-hide--small">
+      <div class="u-fixed-width u-align--center">
+        {{ image (
+        url="https://assets.ubuntu.com/v1/81320e0d-smart-city.png",
+        alt="",
+        width="916",
+        height="526",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+        }}
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Alternative to direct management</h2>
+      </div>
+      <div class="col">
+        <p>
+          Whether you’re running a cloud based on <a href="/openstack">OpenStack</a> or <a href="https://canonical.com/microcloud">MicroCloud</a>, or using applications like Kafka, Kubeflow, Spark, or OpenSearch, operations management can be tough! That's why Canonical offers <a href="/managed">fully managed services</a>, which relieve you of that worry. However, be it due to security regulations or other issues, giving our engineers access to your environments is not something you can always do.
+        </p>
+        <p>
+          This is why we launched Firefighting Support, a package that gives you dual, highly-enhanced cloud support from Canonical's Support and Managed Solutions engineering teams.
+        </p>
+        <p>
+          You thus get managed service level of security and peace of mind, while still completely managing your environments by yourself in full privacy.
+        </p>
+        <div class="u-hide--small u-hide--medium">
+          {{ image (
+          url="https://assets.ubuntu.com/v1/774930ee-security.png",
+          alt="",
+          width="1202",
+          height="784",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+          }}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Key benefits</h2>
+      </div>
+      <div class="col">
+        <p>
+          We've designed Firefighting Support to give you a level of cloud support as close as possible to a fully managed service
+        </p>
+        <hr class="p-rule--muted" />
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">
+            Access to a video call with a Canonical Managed Solutions engineer within 1 hour of flagging a high severity incident
+          </li>
+          <li class="p-list__item is-ticked">
+            <a href="/pro">Ubuntu Pro</a> with 24/7 support included for all covered products
+          </li>
+          <li class="p-list__item is-ticked">
+            Dual team cloud support for your products: the Support and Managed Solutions teams work together to resolve your issues
+          </li>
+          <li class="p-list__item is-ticked">Access to Ops Consulting packages</li>
+          <li class="p-list__item is-ticked">Full control of your environments</li>
+        </ul>
+        <hr class="p-rule--muted" />
+        <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Get Firefighting Support</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+          <h2>
+            Is Firefighting Support
+            <br class="u-hide--small u-hide--medium" />
+            right for you?
+          </h2>
+        </div>
+        <div class="col">
+          <p>
+            Firefighting Support is a useful tool in most circumstances. Nevertheless, we've created the service to address three key fields:
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="row--25-75">
+      <div class="col">
+        <div class="row u-hide--small">
+          <div class="col-3 col-medium-2">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/a5f69f96-File system type@2x 1.png",
+            alt="",
+            width="561",
+            height="562",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+          <div class="col-3 col-medium-2">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/79fba6f3-Create a security key@3x 1.png",
+            alt="",
+            width="561",
+            height="562",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+          <div class="col-3 col-medium-2">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/d2a8836e-wifi.png",
+            alt="",
+            width="561",
+            height="562",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Government clouds</h3>
+            <p>
+              Generally, governments and intergovernmental institutions have very stringent regulations that forbid third parties from providing direct operational management. This, however, does not make your operations easier. Firefighting Support gives you extra peace of mind while allowing you to remain fully compliant with your security policies.
+            </p>
+          </div>
+          <hr class="p-rule--muted u-hide--medium u-hide--large" />
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Highly private telecommunications networks</h3>
+            <p>
+              There are telco networks that even the most secure third parties can't touch. But managing their workloads can be tough, especially for emerging teams. Canonical's Firefighting Support can allow your private networks to operate more smoothly by having your back in urgent situations.
+            </p>
+          </div>
+          <hr class="p-rule--muted u-hide--medium u-hide--large" />
+
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Cloud upgrades</h3>
+            <p>
+              It's time to upgrade your cloud to the newest version, and it's rightfully intimidating. Consider Firefighting Support, so you can benefit from the expertise and experience of our Managed Solutions engineers, who will help you immediately fix any issues that may arise during the upgrade.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--25-75-on-large">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Your options</h2>
+      </div>
+      <div class="col">
+        <table aria-label="Vanilla framework table example">
+          <thead style="height:100px;">
+            <tr>
+              <th></th>
+              <th class="p-text--small-caps">
+                <a href="/managed">Fully managed solutions</a>
+              </th>
+              <th class="p-text--small-caps">Firefighting Support</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>What it is</th>
+              <td>
+                Canonical engineers deploy your environment and manage all operations. We maintain admin rights and a permanent connection.
+              </td>
+              <td>
+                Canonical engineers provide cloud support and guidance in high-severity situations, while you manage your operations.
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <a href="/pro">Ubuntu Pro</a> + Support 24/7
+              </th>
+              <td>Included</td>
+              <td>Included</td>
+            </tr>
+            <tr>
+              <th>Service levels</th>
+              <td>1-hour SLA for high severity cases, all other cases addressed in under 24 hours</td>
+              <td>1-hour SLA for high severity cases</td>
+            </tr>
+            <tr>
+              <th>Incident management</th>
+              <td>Unlimited, covering cases we identify ourselves or flagged by you</td>
+              <td>Only for high severity cases that impact the product's core functionality</td>
+            </tr>
+            <tr>
+              <th>Service requests</th>
+              <td>Unlimited</td>
+              <td>One at a time per environment</td>
+            </tr>
+            <tr>
+              <th>Backup and recovery</th>
+              <td>Unlimited</td>
+              <td>Not covered</td>
+            </tr>
+            <tr>
+              <th>Software and package updates</th>
+              <td>Unlimited</td>
+              <td>Not covered</td>
+            </tr>
+            <tr>
+              <th>Capacity reports</th>
+              <td>Available</td>
+              <td>Unavailable</td>
+            </tr>
+            <tr>
+              <th>Admin access</th>
+              <td>Required</td>
+              <td>Not required</td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="p-section--shallow u-hide--small">
+          {{ image (
+          url="https://assets.ubuntu.com/v1/530afcbc-GettyImages-1340944503 1.png",
+          alt="",
+          width="1832",
+          height="745",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+          }}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--25-75">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>FAQ</h2>
+      </div>
+      <div class="col">
+        <div class="row">
+          <div class="col-3">
+            <p class="p-heading--5">What's the difference between Firefighting Support and Ubuntu Pro support?</p>
+          </div>
+          <div class="col-6">
+            <p>
+              Firefighting Support is an enhanced level of security that includes Ubuntu Pro. You get better SLAs and an additional team that understands your environment before helping you in high-severity incidents. You still get all the benefits of <a href="/pro">Ubuntu Pro</a>, and then some.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3">
+            <p class="p-heading--5">Can I get Firefighting Support if I already have Ubuntu Pro?</p>
+          </div>
+          <div class="col-6">
+            <p>
+              Yes, you can. Your cloud may need to undergo a cloud validation from our team, and you will only pay an additional upgrade fee.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3">
+            <p class="p-heading--5">How much does it cost?</p>
+          </div>
+          <div class="col-6">
+            <p>
+              This depends on the products you want to cover and the number of nodes. Our pricing model is simple,  intuitive, and works on a per node per year basis. Get in touch with our team to find out more.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3">
+            <p class="p-heading--5">Which products does Firefighting Support cover?</p>
+          </div>
+          <div class="col-6">
+            <p>
+              Firefighting Support covers <a href="/openstack">Charmed OpenStack</a>, <a href="/kubernetes">Canonical Kubernetes</a>, and our entire <a href="/managed/apps">Managed Apps</a> portfolio.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+          <h2>Unlock Ops Consulting</h2>
+        </div>
+        <div class="col">
+          <p>
+            Want to discuss your tech plans in more depth? Curious about how you can start managing your environments yourself? Or do you simply want to learn more about the products in your stack?
+          </p>
+          <p>
+            Talk to Canonical Managed Solutions engineers through Ops Consulting, a package that gives you access to one-to-one calls with our topic experts.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="row--25-75">
+      <div class="col">
+        <div class="row u-hide--small">
+          <div class="col-3 col-medium-2">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/7c4e7c58-Summary of installation settings@2x.png",
+            alt="",
+            width="561",
+            height="562",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+          <div class="col-3 col-medium-2">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/cd172f35-Hardware Check@2x.png",
+            alt="",
+            width="561",
+            height="562",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+          <div class="col-3 col-medium-2">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/745df342-Accessibility@2x.png",
+            alt="",
+            width="561",
+            height="562",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Upgrade support</h3>
+            <p>
+              We understand that upgrading infrastructure or apps can be challenging. If we can't upgrade it for you via Managed Services, you can still discuss the best upgrade practices with our engineers through Ops Consulting and get guidance on how to do it yourself.
+            </p>
+          </div>
+          <hr class="p-rule--muted u-hide--medium u-hide--large" />
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Operational experience</h3>
+            <p>
+              If there are topics that give you headaches when managing your environments, our engineers can advise you on how to avoid common mistakes and how to fix recurrent problems. We've been managing environments for over a decade, so we've always got insightful tips.
+            </p>
+          </div>
+          <hr class="p-rule--muted u-hide--medium u-hide--large" />
+
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Team training</h3>
+            <p>
+              Have you already benefited from our Managed Solutions offering, and feel confident to take over the reins and manage your environments by yourself? We've still got you covered, with training material and best practices to be shared in consulting sessions.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+          <h2>Ops Consulting packages</h2>
+        </div>
+        <div class="col">
+          <p>
+            You can access Ops Consulting regardless of the size of your infrastructure or current projects, as long as you've got one of our Firefighting Support or <a href="/managed">fully managed</a> services active.
+          </p>
+          <p>
+            We offer three packages that give you a number of consulting hours you can book in a month to discuss topics of your choice with our engineers. The hours do not roll over, but you never have to commit for more than a month.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="row--25-75">
+      <div class="col">
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <hr class="p-rule--highlight" />
+            <p class="p-heading--3">10h/month</p>
+            <p class="p-heading--4">$3,500</p>
+            <p>
+              Occasional meetings for non-urgent matters, allowing you to discuss concerns and improve the efficiency of your operations.
+            </p>
+          </div>
+          <div class="col-3 col-medium-2">
+            <hr class="p-rule--highlight" />
+            <p class="p-heading--3">20h/month</p>
+            <p class="p-heading--4">$6,000</p>
+            <p>
+              Regular meetings that allow you to have in-depth discussions on pressing matters, or get a baseline training in operational management for your products.
+            </p>
+          </div>
+          <div class="col-3 col-medium-2">
+            <hr class="p-rule--highlight" />
+            <p class="p-heading--3">40h/month</p>
+            <p class="p-heading--4">$10,000</p>
+            <p>
+              Daily or highly recurrent meetings with engineers, helping you gain skills quickly or prepare for a significant change in your environment.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <hr class="p-rule is-fixed-width" />
+  <section class="p-strip is-deep">
+    <div class="u-fixed-width">
+      <h2>
+        <a href="/managed/contact-us" class="js-invoke-modal">Contact us and discuss your options&nbsp;&rsaquo;</a>
+      </h2>
+    </div>
+  </section>
+
+  <div class="u-hide"
+       id="contact-form-container"
+       data-form-location="/shared/forms/interactive/managed-services.html"
+       data-form-id="4053"
+       data-lp-id=""
+       data-return-url="https://ubuntu.com/managed/thank-you"
+       data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
+
+{% endblock content %}

--- a/templates/managed/form-data.json
+++ b/templates/managed/form-data.json
@@ -1,0 +1,79 @@
+{
+  "form": {
+    "/managed": {
+      "templatePath": "/managed/index",
+      "childrenPaths": [
+        "/managed/apps",
+        "/managed/ceph",
+        "/managed/kubernetes",
+        "/managed/openstack",
+        "/managed/firefighting-support"
+      ],
+      "isModal": true,
+      "modalId": "managed-modal",
+      "formData": {
+        "title": "You innovate, we operate!",
+        "formId": "4053",
+        "returnUrl": "/managed#success",
+        "product": "Managed services"
+      },
+      "fieldsets": [
+        {
+          "title": "What services can we help with?",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "label": "Openstack"
+            },
+            {
+              "type": "checkbox",
+              "label": "Kubernetes"
+            },
+            {
+              "type": "checkbox",
+              "label": "Ceph"
+            },
+            {
+              "type": "checkbox",
+              "label": "Database and Applications"
+            },
+            {
+              "type": "checkbox",
+              "label": "Observability"
+            }
+          ]
+        },
+        {
+          "title": "Tell us more",
+          "id": "about-use-case",
+          "isRequired": false,
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "about-use-case",
+              "placeholder": "What are you currently working on? What does your current infrastructure and services look like? Anything extra you’d like to communicate about your needs or interests?"
+            }
+          ]
+        },
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number"
+            },
+            {
+              "type": "country",
+              "id": "country",
+              "label": "Country"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/templates/managed/index.html
+++ b/templates/managed/index.html
@@ -1,0 +1,551 @@
+{% extends 'base_index.html' %}
+
+{% block title %}Managed IT Services for open source{% endblock %}
+
+{% block meta_description %}Discover how to simplify open source consumption and cut your operational costs using IT
+managed services without spending months on hiring and training.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/19GoMudyrd9Zt1e7kfj-koL-Lt0RGYzWHRPuuKYUPvqw/edit
+{% endblock meta_copydoc %}
+
+{% block body_class %}is-paper{% endblock body_class %}
+
+{% block content %}
+
+<section class="u-no-margin--bottom">
+  <div class="p-section--shallow">
+    <div class="row">
+      <div class="col-medium-6 col-9 col-start-large-4">
+        <h1>Managed IT Services you can rely on</h1>
+        <p>Gain the space to focus on your core business by outsourcing the management of your operations with
+          Canonical's Managed IT services. Whatever the size of your company, our engineers can deploy and manage your
+          environments efficiently and securely.</p>
+        <hr class="p-rule" />
+        <a class="p-button--positive js-invoke-modal" href="/managed/contact-us">Ask a Managed Solutions expert</a>
+      </div>
+    </div>
+  </div>
+  <div class="p-suru"></div>
+</section>
+
+<section class="p-section--shallow">
+  <div class="row">
+    <hr class="p-rule" />
+    <div class="col-3">
+      <p class="p-muted-heading">Trusted by</p>
+    </div>
+    <div class="col-9">
+      <div class="p-logo-section">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/52bac407-rabobank-logo.png",
+            alt="Rabo bank",
+            width="128",
+            height="128",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/b0662ad2-tele2-logo.png",
+            alt="Tele2",
+            width="62",
+            height="128",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/a98c1a19-telefonica-logo.png",
+            alt="Telefonica",
+            width="162",
+            height="128",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/f40e5590-tomtom-logo%201.png",
+            alt="Tomtom",
+            width="123",
+            height="128",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/94adb36e-barnes&noble-logo.png",
+            alt="Barnes & Noble",
+            width="143",
+            height="128",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/3eea9789-firmus-logo.png",
+            alt="firmus",
+            width="113",
+            height="128",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/f2b3519a-tomtom-logo%202.png",
+            alt="Gamma",
+            width="141",
+            height="128",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/b68a93ee-docaposte-logo.png",
+            alt="docapost",
+            width="143",
+            height="128",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/67d846b9-dyson-logo.png",
+            alt="dyson",
+            width="78",
+            height="128",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/de997f4e-onetrail-logo.png",
+            alt="onetrail",
+            width="106",
+            height="128",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+            }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="u-fixed-width">
+  <hr class="p-rule" />
+  <div class="p-strip is-deep">
+    <h2>
+      Case study: <a href="/engage/kubernetes-openstack-case-study-firmus">Firmus builds a sustainable
+        supercloud with&nbsp;Canonical</a>
+    </h2>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>We mind your ops,<br />you mind your business</h2>
+    </div>
+    <div class="col">
+      <p>Open source IT solutions are the future when it comes to technology, but can often be challenging to maintain.
+        Managed IT services are a solution that allows you to harness the power of open source without the hassle of
+        maintenance.
+      </p>
+      <p>
+        Canonical's Managed Solutions is a service that identifies, deploys, and manages open source ecosystems for you
+        at predictable costs. This way, you can access our market-leading open source expertise and focus more of your
+        resources on your core business.
+      </p>
+      <hr class="p-rule" />
+      <a class="p-button--positive js-invoke-modal" href="/managed/contact-us">Tell us what you need</a>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>Key benefits</h2>
+    </div>
+    <div class="col">
+      <ul class="p-list--divided">
+        <li class="p-list__item is-ticked">
+          Access to market-leading technological expertise
+        </li>
+        <li class="p-list__item is-ticked">
+          Enterprise-grade security and compliance
+        </li>
+        <li class="p-list__item is-ticked">
+          24/7 monitoring and incident resolution
+        </li>
+        <li class="p-list__item is-ticked">
+          Significant reductions in CAPEX
+        </li>
+        <li class="p-list__item is-ticked">
+          Ingrained observability
+        </li>
+        <li class="p-list__item is-ticked">
+          24/7 support included with <a href="/pro">Ubuntu Pro</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="p-section--shallow">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Managed packages</h2>
+      </div>
+      <div class="col">
+        <p>Besides providing managed services for most of our products, we propose a series of pre-packaged solutions
+          for the most frequent business challenges. </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="row p-section--shallow">
+    <div class="col-9 col-start-large-4 col-medium-5 col-start-medium-2">
+      <hr class="p-rule" />
+      <div class="row">
+        <div class="col-3 col-medium-2">
+          <hr class="p-rule--highlight" />
+          <h3 class="p-heading--4">Private cloud</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Enjoy your own private cloud without worrying about its deployment or maintenance</p>
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">
+              Hardware consulting and certification
+            </li>
+            <li class="p-list__item is-ticked">
+              Fully automated ecosystem, from bare metal automation to apps, made in-house
+            </li>
+            <li class="p-list__item is-ticked">
+              Accelerated time to market
+            </li>
+            <li class="p-list__item is-ticked">
+              Proactive upgrades
+            </li>
+          </ul>
+          <a href="/openstack/managed">Explore managed private cloud options&nbsp;&rsaquo;</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row p-section--shallow">
+    <div class="col-9 col-start-large-4 col-medium-5 col-start-medium-2">
+      <hr class="p-rule" />
+      <div class="row">
+        <div class="col-3 col-medium-2">
+          <hr class="p-rule--highlight" />
+          <h3 class="p-heading--4">AI infrastructure</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Stay ahead of the competition with fully managed MLOps infrastructure that enables you to deploy high
+            complexity models</p>
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">
+              Fully integrated <a href="/ai/mlops">MLOps solution</a>, available on-prem or on public cloud
+            </li>
+            <li class="p-list__item is-ticked">
+              Faster project delivery
+            </li>
+            <li class="p-list__item is-ticked">
+              Reliable experts to speed up your AI journey
+            </li>
+          </ul>
+          <a href="https://charmed-kubeflow.io/docs/get-started-with-charmed-kubeflow">Get started with
+            Kubeflow&nbsp;&rsaquo;</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row p-section--shallow">
+    <div class="col-9 col-start-large-4 col-medium-5 col-start-medium-2">
+      <hr class="p-rule" />
+      <div class="row">
+        <div class="col-3 col-medium-2">
+          <hr class="p-rule--highlight" />
+          <h3 class="p-heading--4">Telco cloud</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Expand your reach and achieve market-leading uptime for your telco clouds</p>
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">
+              Fully compliant ecosystems with consistent security hardening
+            </li>
+            <li class="p-list__item is-ticked">
+              24/7 observability and monitoring
+            </li>
+            <li class="p-list__item is-ticked">
+              Infinite scalability from the get-go
+            </li>
+          </ul>
+          <a href="/blog/telco-cloud-what-is-that">Learn more about telco clouds&nbsp;&rsaquo;</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row p-section--shallow">
+    <div class="col-9 col-start-large-4 col-medium-5 col-start-medium-2">
+      <hr class="p-rule" />
+      <div class="row">
+        <div class="col-3 col-medium-2">
+          <hr class="p-rule--highlight" />
+          <h3 class="p-heading--4">Cloud apps</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <p>Enhance the security and reliability of your containers, databases, and service buses with fully managed
+            apps</p>
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">
+              Extensive suite of in-house automated apps
+            </li>
+            <li class="p-list__item is-ticked">
+              Adaptable security and compliance certifications
+            </li>
+            <li class="p-list__item is-ticked">
+              Assured high availability via site/geo redundancy
+            </li>
+          </ul>
+          <a href="/managed/apps">Explore our managed apps story&nbsp;&rsaquo;</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>Our process</h2>
+    </div>
+    <div class="col">
+      <p>Our Managed Solutions process is easy and intuitive. You’ll initially be consulted by our specialists to design
+        the best managed solution for your needs. Afterwards, it’s all on us:</p>
+      <ol class="p-stepped-list">
+        <li class="p-stepped-list__item">
+          <hr class="p-rule" />
+          <h3 class="p-heading--5 p-stepped-list__title">
+            Deployment
+          </h3>
+          <div class="p-stepped-list__content">
+            Specialised Canonical engineers deploy your required architecture sustainably and efficiently.
+          </div>
+        </li>
+        <li class="p-stepped-list__item">
+          <hr class="p-rule" />
+          <h3 class="p-heading--5 p-stepped-list__title">
+            Management
+          </h3>
+          <div class="p-stepped-list__content">
+            Our team manages all your ‘day 2’ operations, from observability to upgrades. We handle all issues, and
+            consistently re-enforce the security of your environment.
+          </div>
+        </li>
+        <li class="p-stepped-list__item">
+          <hr class="p-rule" />
+          <h3 class="p-heading--5 p-stepped-list__title">
+            Optional handover
+          </h3>
+          <div class="p-stepped-list__content">
+            We’re lock-in free, so if after a while you want to start managing your environments by yourself, we can
+            teach you how and give you remote support for high-severity cases.
+          </div>
+        </li>
+      </ol>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="row--25-75">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>Your options</h2>
+    </div>
+    <div class="col">
+      <div class="p-strip is-shallow u-no-margin--bottom">
+        <table aria-label="A table that shows advantages of Managed solutions over firefighting support">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Managed solutions</th>
+              <th>Firefighting Support</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <h3 class="p-heading--5">What it is</h3>
+              </td>
+              <td>Canonical engineers deploy your environment and manage all operations. We maintain admin
+                rights and a permanent connection.</td>
+              <td>Canonical engineers provide support and guidance in high-severity situations, while you
+                manage your operations.</td>
+            </tr>
+            <tr>
+              <td>
+                <h3 class="p-heading--5"><a href="/pro">Ubuntu Pro</a> + Support 24/7</h3>
+              </td>
+              <td>Included</td>
+              <td>Included</td>
+            </tr>
+            <tr>
+              <td>
+                <h3 class="p-heading--5">Service levels</h3>
+              </td>
+              <td>1-hour SLA for high severity cases, all other cases addressed in under 24 hours</td>
+              <td>1-hour SLA for high severity cases</td>
+            </tr>
+            <tr>
+              <td>
+                <h3 class="p-heading--5">Incident management</h3>
+              </td>
+              <td>Unlimited, covering cases we identify ourselves or flagged by you</td>
+              <td>Only for high severity cases that impact the product’s core functionality </td>
+            </tr>
+            <tr>
+              <td>
+                <h3 class="p-heading--5">Service requests</h3>
+              </td>
+              <td>Unlimited</td>
+              <td>One at a time per environment</td>
+            </tr>
+            <tr>
+              <td>
+                <h3 class="p-heading--5">Backup & recovery</h3>
+              </td>
+              <td>Unlimited</td>
+              <td>Not covered</td>
+            </tr>
+            <tr>
+              <td>
+                <h3 class="p-heading--5">Software & package updates</h3>
+              </td>
+              <td>Unlimited</td>
+              <td>Not covered</td>
+            </tr>
+            <tr>
+              <td>
+                <h3 class="p-heading--5">Capacity reports</h3>
+              </td>
+              <td>Available</td>
+              <td>Unavailable</td>
+            </tr>
+            <tr>
+              <td>
+                <h3 class="p-heading--5">Admin access</h3>
+              </td>
+              <td>Required</td>
+              <td>Not required</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-section--deep">
+  <div class="p-section--shallow">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Add-on support <br />for managed solutions</h2>
+      </div>
+      <div class="col">
+        <p>Go beyond operation management with our suite of add-ons designed to give you access to training, priority
+          support, or assistance with non-operational queries.</p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-9 col-start-large-4 col-medium-5 col-start-medium-2">
+      <hr class="p-rule" />
+      <div class="row">
+        <div class="col-3 col-medium-2">
+          <h3 class="p-heading--5">Ops consulting</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <ul class="p-list--divided">
+            <li class="p-list__item has-bullet">
+              On-demand, private sessions with Managed Services engineers specialised in specific products or
+              operations
+            </li>
+            <li class="p-list__item has-bullet">
+              Useful when learning to self-manage, training new teams, or planning migrations
+            </li>
+            <li class="p-list__item has-bullet">
+              Essential before and after major changes in infrastructure, as well as handovers
+            </li>
+            <li class="p-list__item has-bullet">
+              Available in monthly packages of 10, 20, or 40 hourse
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-9 col-start-large-4 col-medium-5 col-start-medium-2">
+      <hr class="p-rule" />
+      <div class="row">
+        <div class="col-3 col-medium-2">
+          <h3 class="p-heading--5">Dedicated Support Engineer (DSE)</h3>
+        </div>
+        <div class="col-6 col-medium-3">
+          <ul class="p-list--divided">
+            <li class="p-list__item has-bullet">
+              Your own Canonical Managed Services engineer, who will prioritise your cases and needs
+            </li>
+            <li class="p-list__item has-bullet">
+              Dedicated one-on-one engineering time eight hours a day, five days a week, at your discretion
+            </li>
+            <li class="p-list__item has-bullet">
+              Recommended in deployments of over 200 nodes
+            </li>
+            <li class="p-list__item has-bullet">
+              Fixed price per year, no matter the node count
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/managed-services.html"
+  data-form-id="4053" data-lp-id="" data-return-url="https://ubuntu.com/managed/thank-you"
+  data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+{% endblock content %}

--- a/templates/managed/index.html
+++ b/templates/managed/index.html
@@ -21,7 +21,7 @@ managed services without spending months on hiring and training.{% endblock meta
           Canonical's Managed IT services. Whatever the size of your company, our engineers can deploy and manage your
           environments efficiently and securely.</p>
         <hr class="p-rule" />
-        <a class="p-button--positive js-invoke-modal" href="/managed/contact-us">Ask a Managed Solutions expert</a>
+        <a class="p-button--positive js-invoke-modal" aria-controls="managed-modal" href="/managed/contact-us">Ask a Managed Solutions expert</a>
       </div>
     </div>
   </div>
@@ -180,7 +180,7 @@ managed services without spending months on hiring and training.{% endblock meta
         resources on your core business.
       </p>
       <hr class="p-rule" />
-      <a class="p-button--positive js-invoke-modal" href="/managed/contact-us">Tell us what you need</a>
+      <a class="p-button--positive js-invoke-modal" aria-controls="managed-modal" href="/managed/contact-us">Tell us what you need</a>
     </div>
   </div>
 </section>
@@ -543,9 +543,6 @@ managed services without spending months on hiring and training.{% endblock meta
   </div>
 </section>
 
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/managed-services.html"
-  data-form-id="4053" data-lp-id="" data-return-url="https://ubuntu.com/managed/thank-you"
-  data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-</div>
+{{ load_form("/managed") | safe }}
 
 {% endblock content %}

--- a/templates/managed/kubernetes.html
+++ b/templates/managed/kubernetes.html
@@ -29,9 +29,9 @@
       </p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
-      <a href="/kubernetes/contact-us?product=kubernetes-managed"
+      <a href="/managed/contact-us"
          class="js-invoke-modal p-button--positive"
-         aria-controls="kubernetes-modal">Talk to an expert</a>
+         aria-controls="managed-modal">Talk to an expert</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--cinematic is-cover">
@@ -174,9 +174,9 @@
           <li class="p-list__item is-ticked">Minimize risks with our security first approach</li>
         </ul>
         <div class="p-cta-block">
-          <a href="/kubernetes/contact-us?product=kubernetes-managed"
+          <a href="/managed/contact-us"
              class="js-invoke-modal p-button"
-             aria-controls="kubernetes-modal">Let us manage your K8s</a>
+             aria-controls="managed-modal">Let us manage your K8s</a>
           <a href="/engage/managed-services-overcoming-cio-challenges-2021">Managed IT services - read the whitepaper&nbsp;&rsaquo;</a>
         </div>
       </div>
@@ -445,11 +445,13 @@
   <section class="p-strip is-deep">
     <div class="u-fixed-width">
       <p class="p-heading--2">
-        <a href="/kubernetes/contact-us?product=kubernetes-managed"
+        <a href="/managed/contact-us"
            class="js-invoke-modal"
-           aria-controls="kubernetes-modal">Talk to us about managing your Kubernetes cluster&nbsp;&rsaquo;</a>
+           aria-controls="managed-modal">Talk to us about managing your Kubernetes cluster&nbsp;&rsaquo;</a>
       </p>
     </div>
   </section>
+
+  {{ load_form("/managed") | safe }}
 
 {% endblock content %}

--- a/templates/managed/kubernetes.html
+++ b/templates/managed/kubernetes.html
@@ -1,0 +1,455 @@
+{% extends 'base_index.html' %}
+
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Managed Kubernetes | Kubernetes{% endblock %}
+
+{% block meta_description %}
+  Canonical is the leading managed private cloud provider. We will build, support and manage your Ubuntu Kubernetes private cloud for only $5-15 per server per day.
+{% endblock meta_description %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1Qv379nYnod9e4jMrsdDND8D7mbPyqELi2lowjkfD-gU/edit#heading=h.oq0utgh3ss8u
+{% endblock meta_copydoc %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block content %}
+  {% call(slot) vf_hero(
+    title_text='Fully managed Kubernetes',
+    subtitle_text='Cost effective, on demand, <br class="u-hide--medium u-hide--small" />container orchestration',
+    layout='50/50-full-width-image'
+    ) -%}
+    {%- if slot == 'description' -%}
+      <p>
+        Focus on your applications while Canonical builds and manages your Kubernetes clusters. Run your Kubernetes anywhere with a flexible pricing model. Take back control whenever you are ready.
+      </p>
+    {%- endif -%}
+    {%- if slot == 'cta' -%}
+      <a href="/kubernetes/contact-us?product=kubernetes-managed"
+         class="js-invoke-modal p-button--positive"
+         aria-controls="kubernetes-modal">Talk to an expert</a>
+    {%- endif -%}
+    {%- if slot == 'image' -%}
+      <div class="p-image-container--cinematic is-cover">
+        {{ image(url="https://assets.ubuntu.com/v1/0b6071a9-hero.png",
+                alt="",
+                width="3696",
+                height="1540",
+                hi_def=True,
+                loading="auto",
+                attrs={"class": "p-image-container__image"}) | safe
+        }}
+      </div>
+    {% endif -%}
+  {% endcall -%}
+
+  <section class="p-section--shallow">
+    {%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=true) -%}
+      {%- if slot == 'title' -%}
+        <hr class="u-hide--medium u-hide--large" />
+        <h2>Kubernetes-as-a-service from our team of experts</h2>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_1' -%}
+        <h3 class="p-heading--5">Predictable economics</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_1' -%}
+        <div class="p-section--shallow">
+          <p>
+            Predictable pricing model that gives you the flexibility to run Kubernetes on VMs, bare-metal or public cloud. Our predictive capacity planning helps you prepare for the future and grow your workloads without any spikes.
+          </p>
+        </div>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_2' -%}
+        <h3 class="p-heading--5">Customizable clusters</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_2' -%}
+        <div class="p-section--shallow">
+          <p>
+            We work with you to design the Kubernetes you need, anywhere. We deploy it and manage it for you. We will scale it up to accommodate any traffic peaks, just let us know you're adding more nodes! We'll remotely test the hardware and expand your cloud with zero downtime.
+          </p>
+        </div>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_3' -%}
+        <h3 class="p-heading--5">Transfer control</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_3' -%}
+        <div class="p-section--shallow">
+          <p>
+            Our goal is to accelerate your Kubernetes adoption and help you optimize your operations. On request, we’ll give you back the keys when you want to drive. No hidden costs, no lock in. We can even provide training on demand to help get your team upskilled. Once you have control, we provide 24/7 enterprise support for your cloud.
+          </p>
+        </div>
+        <div class="p-cta-block">
+          <a href="https://ubuntu.com/pricing/infra#:~:text=Fully%20managed%20OpenStack%2C%20Kubernetes%20and%20LMA">Explore pricing for self-managed with support&nbsp;&rsaquo;</a>
+        </div>
+      {%- endif -%}
+    {%- endcall -%}
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule--highlight is-fixed-width u-no-margin--bottom" />
+    <div class="u-fixed-width">
+      <h2 class="p-muted-heading">They trust us to run their K8s</h2>
+      <div class="p-logo-section">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/3f9ca352-aci.png",
+                        alt="ACI",
+                        width="308",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/26b90b50-dsv-logo.png",
+                        alt="DSV",
+                        width="169",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/9752bc70-hyperoptic-logo.png",
+                        alt="Hyperoptic",
+                        width="348",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/c1e66cb9-tamkeen-logo.png",
+                        alt="Tamkeen",
+                        width="313",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/645d6940-esa-logo.png",
+                        alt="ESA",
+                        width="241",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--shallow">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Leave the Kubernetes complexity to us</h2>
+      </div>
+      <div class="col">
+        <p>Our managed Kubernetes service allows you to:</p>
+        <hr class="p-rule--muted u-no-margin--bottom" />
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">Build a vendor agnostic open source Kubernetes, no lock-in</li>
+          <li class="p-list__item is-ticked">Maintain your business focus</li>
+          <li class="p-list__item is-ticked">Fill in skill gaps within your IT</li>
+          <li class="p-list__item is-ticked">Hire and train strategic roles only, eliminating the need to keep the lights on</li>
+          <li class="p-list__item is-ticked">Expand your operations globally without having to build a global team</li>
+          <li class="p-list__item is-ticked">Minimize risks with our security first approach</li>
+        </ul>
+        <div class="p-cta-block">
+          <a href="/kubernetes/contact-us?product=kubernetes-managed"
+             class="js-invoke-modal p-button"
+             aria-controls="kubernetes-modal">Let us manage your K8s</a>
+          <a href="/engage/managed-services-overcoming-cio-challenges-2021">Managed IT services - read the whitepaper&nbsp;&rsaquo;</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <div class="col">
+          <h2>The most sophisticated management system</h2>
+        </div>
+        <div class="col">
+          <p>
+            Canonical Kubernetes is built from the ground up following best practices and according to your needs. Free up your teams for strategic activities, as we manage it 24/7. We will provide you a full set of analytics on the health of your cluster and ensure it stays up-to-date and secure.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="u-fixed-width">
+      {{ image(url="https://assets.ubuntu.com/v1/a5fdbd9a-most sophisticated.png",
+            alt="",
+            width="3696",
+            height="1541",
+            hi_def=True,
+            loading="lazy") | safe
+      }}
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Care&ndash;free SLA</h2>
+      </div>
+      <div class="col">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">Enterprise SLA for your cloud, upgrades included.</li>
+          <li class="p-list__item is-ticked">
+            99.9% guaranteed uptime. All cluster components are highly available and proactively monitored to minimize unplanned downtime.
+          </li>
+          <li class="p-list__item is-ticked">
+            Scale on demand with additional nodes. We will remotely test new hardware and scale your Kubernetes with zero downtime.
+          </li>
+          <li class="p-list__item is-ticked">We develop the technology, we know how to fix it in the shortest possible time.</li>
+          <li class="p-list__item is-ticked u-no-padding--bottom">
+            Our operations are certified, and under regular independent audits to meet and exceed the industry standards for quality and security.
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+          <h2>
+            Kubernetes monitoring
+            <br class="u-hide--medium u-hide--small" />
+            and analytics
+          </h2>
+        </div>
+        <div class="col">
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">
+              We build a robust cloud solution for you that provides dashboards for logging, monitoring and alerting.
+            </li>
+            <li class="p-list__item is-ticked">
+              We actively monitor your Kubernetes 24/7, providing observability, alerting, capacity planning and continuous service checks to ensure your cloud stays healthy.
+            </li>
+            <li class="p-list__item is-ticked u-no-padding--bottom">
+              We provide proactive management and visibility to help you gain a clear predictability over the costs, avoiding any surprises.
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="u-fixed-width">
+      {{ image(url="https://assets.ubuntu.com/v1/b4915f70-monitoring and analytics.png",
+            alt="",
+            width="3696",
+            height="1541",
+            hi_def=True,
+            loading="lazy") | safe
+      }}
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Security and compliance</h2>
+      </div>
+      <div class="col">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">
+            Every Kubernetes cluster built by Canonical is always upgradable to newer versions. Absolutely no snowflakes
+          </li>
+          <li class="p-list__item is-ticked">
+            Zero downtime upgrades. Canonical guarantees upgrades to newer versions of Kubernetes on request. Nobody else does.
+          </li>
+          <li class="p-list__item is-ticked">Regulatory compliance, ISO 27000 certified, GDPR compliant, SOC2 Type 2.</li>
+          <li class="p-list__item is-ticked">
+            <a href="/blog/canonicals-managed-services-achieve-msp-cloud-verify-certification"
+               aria-label="Read more about MSP Cloud Verify certified">MSP Cloud Verify certified</a> &ndash; the only managed service provider certification program accredited worldwide.
+          </li>
+        </ul>
+        <div class="p-cta-block">
+          <a href="/engage/MSPAlliance-Canonical-Webinar?utm_medium=takeover&utm_campaign=7014K000000mYJnQAM">Watch our webinar “How to manage risks with top 1% managed service providers”&nbsp;&rsaquo;</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Multi&ndash;cloud ready</h2>
+      </div>
+      <div class="col">
+        <p>
+          We recommend a multi-cloud operations strategy for the best mix of latency and price across both fixed and variable workloads. Canonical is a leading partner for all major public clouds, so we provide cloud-neutral advice for both private and public operations. The right location for a workload should be driven by economics, not habit. Give yourself the freedom to choose.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule--highlight is-fixed-width u-no-margin--bottom" />
+    <div class="u-fixed-width">
+      <h2 class="p-muted-heading">They trust us to run their K8s</h2>
+      <div class="p-logo-section">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/a5dd0732-aws.png",
+                        alt="AWS",
+                        width="151",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/d5e7c6be-gc.png",
+                        alt="Google Cloud",
+                        width="382",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/d013a6c0-azure.png",
+                        alt="Microsoft Azure",
+                        width="272",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/3919ce49-vmware-logo.png",
+                        alt="VM Ware",
+                        width="323",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/35eea5a0-maas-logo.png",
+                        alt="MAAS",
+                        width="250",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/da276080-openstack-logo.png",
+                        alt="OpenStack",
+                        width="413",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    {%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=true) -%}
+      {%- if slot == 'title' -%}
+        <hr class="u-hide--medium u-hide--large" />
+        <h2>Managed IT services in a single hand&ndash;shake</h2>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_1' -%}
+        <h3 class="p-heading--5">Full stack support</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_1' -%}
+        <div class="p-section--shallow">
+          <p>
+            As the publisher of Ubuntu, Canonical uniquely supports the full stack. Complex problems in cloud infrastructure require analysis and fixes all the way down to the kernel. With us, there are no loose ends. The teams managing your clouds are working side by side with the engineers developing your clouds.
+          </p>
+        </div>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_2' -%}
+        <h3 class="p-heading--5">Flexible infrastructure</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_2' -%}
+        <div class="p-section--shallow">
+          <p>
+            Metal as a Service (<a href="https://maas.io/?_ga=2.238641412.542907870.1630927385-1660063247.1626983102">MAAS</a>) enables flexible lifecycle management of operating system loads on physical servers and VM hosts. Choose between the most popular Kubernetes CNIs, such as Calico, Flannel and Multus, or the widest range of SDNs if you're running on top of <a href="/openstack">OpenStack</a>. Use proven software-defined storage like <a href="/ceph">Ceph</a> and Swift, or integrate your existing SAN.
+          </p>
+        </div>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_3' -%}
+        <h3 class="p-heading--5">AI/ML ready</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_3' -%}
+        <div class="p-section--shallow">
+          <p>
+            Canonical OpenStack and Kubernetes are ready for your Machine Learning enabled applications. Trusted by leaders in the industry, Ubuntu provides the best basis to run <a href="/ai">AI/ML frameworks</a>.
+          </p>
+        </div>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_4' -%}
+        <h3 class="p-heading--5">App&ndash;store included</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_4' -%}
+        <div class="p-section--shallow">
+          <p>
+            Operate standard software workloads exactly the same way on public clouds and on-prem, using Kubernetes. Benefit from a <a href="https://charmhub.io/">large portfolio of open source applications</a> that can easily be integrated with your cloud.
+          </p>
+        </div>
+        <div class="p-cta-block">
+          <a href="/managed" class="p-button--positive">Explore our Managed IT services</a>
+        </div>
+      {%- endif -%}
+    {%- endcall -%}
+  </section>
+
+  <hr class="p-rule is-fixed-width" />
+  <section class="p-strip is-deep">
+    <div class="u-fixed-width">
+      <p class="p-heading--2">
+        <a href="/kubernetes/contact-us?product=kubernetes-managed"
+           class="js-invoke-modal"
+           aria-controls="kubernetes-modal">Talk to us about managing your Kubernetes cluster&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </section>
+
+{% endblock content %}


### PR DESCRIPTION
*This will be merged into a /managed feature branch*

## Done

- feat: Migrate pages from u.com
- feat: Update navigation
- feat: Migrate the managed modal form

*Notes*
- [/managed/apps/kafka](https://ubuntu.com/managed/apps/kafka) will not be migrated, as it was supposed to be decommissioned with the build of [/data/kafka/managed](https://canonical.com/data/kafka/managed)
- [/openstack/managed](https://ubuntu.com/openstack/managed) will be migrated in [this ticket](https://warthogs.atlassian.net/browse/WD-17600)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-22525
