### PR TITLE
[WD-19023] Update meganav to include kernel bubble

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -448,6 +448,9 @@ products:
           - title: IoT Professional Services
             description: Bring IoT devices to market
             url: https://ubuntu.com/core/services
+          - title: Kernel
+            description: Ubuntu kernel on certified hardware
+            url: https://ubuntu.com/kernel
 
       secondary_links:
         title: Quick links


### PR DESCRIPTION
## Done

- Updated meganav as per the suggestion in this [copydoc](https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?tab=t.0)

## QA

- View the site in your web browser at: https://canonical-com-1729.demos.haus/
- In the top menu, click Products > Iot and Edge
- Verify Kernel is present there. Click on it and it should redirect you to https://ubuntu.com/kernel

## Issue / Card

Fixes #[WD-19023](https://warthogs.atlassian.net/browse/WD-19023)

## Screenshots

![image](https://github.com/user-attachments/assets/ef308c82-1e21-40fb-9793-9c0169fdc969)


[WD-19023]: https://warthogs.atlassian.net/browse/WD-19023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ