### PR TITLE
Add new page data/spark/managed

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -226,6 +226,8 @@ spark:
       path: /data/spark
     - title: What is Spark
       path: /data/spark/what-is-spark
+    - title: Managed
+      path: /data/spark/managed
     - title: Support
       path: /data/spark/support
     - title: Docs

--- a/templates/data/spark/managed.html
+++ b/templates/data/spark/managed.html
@@ -1,0 +1,428 @@
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1fHeYFVZhSgEwerFzEhNtotR0e25UeItYArVr3LpTwVI/edit?tab=t.0#heading=h.myk2f07cm3hi
+{% endblock meta_copydoc %}
+
+{% block title %}Managed Spark services by Canonical{% endblock %}
+
+{% block meta_description %}
+  Learn about Canonical’s managed services for Apache Spark, the industry-leading open source analytics engine used for big data workloads
+{% endblock %}
+
+{% block canonical_url %}{{ request.host_url }}data/spark/managed{% endblock %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block content %}
+
+  <section class="p-section--hero">
+    <div class="row--25-75-on-large">
+      <div class="col">
+        {{ image(url="https://assets.ubuntu.com/v1/8c624408-apache%20spark.png",
+                alt="",
+                width="568",
+                height="321",
+                hi_def=True,
+                loading="auto") | safe
+        }}
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <h1>Managed Spark by Canonical</h1>
+          <p>Speed up your time to value with open source Apache Spark as a managed service.</p>
+          <p>
+            Benefit from increased agility, backed by an SLA. Canonical delivers the service in your cloud tenancy or data centre.
+          </p>
+        </div>
+        <div class="p-cta-block u-no-margin--bottom u-no-padding--bottom">
+          <a href="/contact-us"
+             aria-controls="data-spark-modal"
+             class="p-button--positive js-invoke-modal">Contact us</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+      <div class="p-section--shallow">
+        <h2>Managed Spark on your cloud</h2>
+      </div>
+      <div class="p-logo-section">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/36a0cd3b-microsoft-azure-2021.png",
+                          alt="Microsoft Azure",
+                          width="78",
+                          height="256",
+                          hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/9faa9b91-aws-logo.png",
+                          alt="AWS",
+                          width="125",
+                          height="256",
+                          hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/497cabc1-google-cloud-logo.png",
+                          alt="Google Cloud",
+                          width="397",
+                          height="256",
+                          hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/f7a0c5ff-kubernetes-logomark-logo.png",
+                          alt="Kubernetes",
+                          width="105",
+                          height="384",
+                          hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/165fa040-openstack-logo.png",
+                          alt="OpenStack",
+                          width="426",
+                          height="256",
+                          hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+      <div class="p-section--shallow">
+        <h2>Why choose Canonical’s Managed Spark</h2>
+      </div>
+      <div class="p-section--shallow">
+        <div class="p-image-container is-highlighted">
+          {{ image(url="https://assets.ubuntu.com/v1/30891bca-Image.png",
+                    alt="",
+                    width="1800",
+                    height="1015",
+                    hi_def=True,
+                    attrs={"class": "p-image-container__image"},
+                    loading="lazy") | safe
+          }}
+        </div>
+      </div>
+    </div>
+    <hr class="p-rule--muted is-fixed-width u-hide--medium u-hide--small" />
+    <div class="p-equal-height-row">
+      <div class="p-equal-height-row__col">
+        <div class="p-equal-height-row__item">
+          <h3 class="p-heading--5">Streamline operations</h3>
+        </div>
+        <div class="p-equal-height-row__item">
+          <p>
+            Offload critical Spark operational service delivery to Canonical, so that your internal team can focus on your business goals.
+          </p>
+        </div>
+      </div>
+      <div class="p-equal-height-row__col">
+        <div class="p-equal-height-row__item">
+          <h3 class="p-heading--5">High availability</h3>
+        </div>
+        <div class="p-equal-height-row__item">
+          <p>
+            Our deep expertise in open source software enables us to manage systems with high uptime, ensuring that even the strictest SLAs will be met. We guarantee 99.9% availability of the Spark service.
+          </p>
+        </div>
+      </div>
+      <div class="p-equal-height-row__col">
+        <div class="p-equal-height-row__item">
+          <h3 class="p-heading--5">Secure and compliant</h3>
+        </div>
+        <div class="p-equal-height-row__item">
+          <p>Our operations are certified, and undergo regular independent audits for your assurance.</p>
+        </div>
+      </div>
+      <div class="p-equal-height-row__col">
+        <div class="p-equal-height-row__item">
+          <h3 class="p-heading--5">Innovate at scale with your data</h3>
+        </div>
+        <div class="p-equal-height-row__item">
+          <p>
+            Delivering at web scale can be immensely challenging. Canonical’s managed services for Spark scale efficiently – so your Spark service remains stable and exceptionally cost-effective as your business grows.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="p-section--shallow">
+      <div class="row">
+        <hr class="p-rule" />
+        <div class="col-6 col-medium-6">
+          <h2>Our process</h2>
+        </div>
+        <div class="col-6 col-medium-6">
+          <p>
+            Our Managed Solutions process is easy and intuitive. You’ll initially be consulted by our specialists to design the best managed solution for your needs. Afterwards, it’s all on us:
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-medium-6 col-start-large-4">
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">1. Deployment</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>Specialized Canonical engineers deploy a database sustainably and efficiently on any cloud.</p>
+            <div class="p-image-wrapper u-hide--small">
+              {{ image(url="https://assets.ubuntu.com/v1/f887a7db-deploy+fast.svg",
+                            alt="",
+                            width="263",
+                            height="150",
+                            hi_def=True,
+                            attrs={"class": "p-image-container__image"},
+                            loading="lazy") | safe
+              }}
+            </div>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">2. Management</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Our team manages all your ‘day 2’ operations, from observability to upgrades. We handle all issues, and consistently enforce the security of your environment.
+            </p>
+            <div class="p-image-wrapper u-hide--small">
+              {{ image(url="https://assets.ubuntu.com/v1/3089fff7-one+platform.svg",
+                            alt="",
+                            width="228",
+                            height="150",
+                            hi_def=True,
+                            attrs={"class": "p-image-container__image"},
+                            loading="lazy") | safe
+              }}
+            </div>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">3. Optional handover</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              There’s no vendor lock-in with Canonical, so if after a while you want to start managing your environments by yourself, we can teach you how and give you remote support for high-severity cases.
+            </p>
+            <div class="p-image-wrapper u-hide--small">
+              {{ image(url="https://assets.ubuntu.com/v1/3a4d4155-Training.svg",
+                            alt="",
+                            width="300",
+                            height="150",
+                            hi_def=True,
+                            attrs={"class": "p-image-container__image"},
+                            loading="lazy") | safe
+              }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Key features</h2>
+      </div>
+      <div class="col">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">
+            <h3 class="p-heading--5 u-no-padding--top u-no-margin--bottom">Backed by an SLA</h3>
+            Backed by a 99.9% uptime SLA. Your data is the backbone of your business. Canonical ensures that it’s available with a high uptime commitment. Canonical managed services for Spark keep the data flowing.
+          </li>
+          <li class="p-list__item is-ticked">
+            <h3 class="p-heading--5 u-no-padding--top u-no-margin--bottom">Secure by design</h3>
+            Service delivery with security in mind. Minimize risks. Canonical managed services are routinely audited for conformance to industry standards and legislation like GDPR, ISO:27001, and SOC-2 Type II.
+          </li>
+          <li class="p-list__item is-ticked">
+            <h3 class="p-heading--5 u-no-padding--top u-no-margin--bottom">Turnkey service</h3>
+            A complete solution, on your cloud tenancy or in your data centre. Canonical covers the full project engagement including architecture design, deployment, transition, and day-to-day operations.
+          </li>
+          <li class="p-list__item is-ticked">
+            <h3 class="p-heading--5 u-no-padding--top u-no-margin--bottom">Service health dashboards</h3>
+            Service health dashboards for full transparency. We provide you with access to Spark health dashboards, so that you can verify the health and uptime of your service directly.
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row p-section--shallow">
+      <div class="col-6 col-medium-3">
+        <h2>Managed Spark pricing</h2>
+      </div>
+      <div class="col-6 col-medium-3">
+        <p>A low total cost of ownership. Up to five times lower than cloud services when fully costed.</p>
+      </div>
+    </div>
+    <div class="row--50-50">
+      <div class="col">
+        <hr class="p-rule--highlight u-no-margin--bottom" />
+        <div class="p-card--overlay u-no-padding--top" style="min-height: 600px">
+          <div class="row">
+            <div class="col-4 col-medium-2 col-small-3">
+              <h3 class="u-align-text--left u-no-margin--bottom">
+                Managed Spark on VMs
+              </h3>
+            </div>
+            <div class="col-2 col-medium-1 col-small-1">
+              <h3 class="u-align-text--right u-no-margin--bottom">Annual price $3099</h3>
+              <p class="u-align-text--right">
+                per VM*
+              </p>
+            </div>
+          </div>
+          <p>The low cost solution for maximum scalability.</p>
+          <hr class="p-rule--muted" />
+          <div class="p-section--shallow u-no-margin--bottom">
+            <ul class="p-list--divided">
+              <li class="p-list__item is-ticked">Highly automated service delivery for security and efficiency</li>
+              <li class="p-list__item is-ticked">Real operations staff proactively monitoring and on call 24/7</li>
+              <li class="p-list__item is-ticked">Includes upgrades and security patches</li>
+            </ul>
+            <p>* Management fee does not include the cloud.</p>
+          </div>
+        </div>
+      </div>
+      <div class="col">
+        <hr class="p-rule--highlight u-no-margin--bottom" />
+        <div class="p-card--overlay u-no-padding--top" style="min-height: 600px">
+          <div class="row">
+            <div class="col-4 col-medium-2 col-small-3">
+              <h3 class="u-align-text--left u-no-margin--bottom">
+                Managed Spark on K8s
+              </h3>
+            </div>
+            <div class="col-2 col-medium-1 col-small-1">
+              <h3 class="u-align-text--right u-no-margin--bottom">Annual price $9470</h3>
+              <p class="u-align-text--right">
+                per node*
+              </p>
+            </div>
+          </div>
+          <p>Secure, managed service delivered to your on-premise data centre by our Spark operations team.</p>
+          <hr class="p-rule--muted" />
+          <div class="p-section--shallow u-no-margin--bottom">
+            <ul class="p-list--divided">
+              <li class="p-list__item is-ticked">
+                Deliver a web scale Spark data platform on-premise with our managed services team
+              </li>
+              <li class="p-list__item is-ticked">
+                Combine managed OpenStack with Managed Spark for maximum efficiency gains
+              </li>
+              <li class="p-list__item is-ticked">
+                Strong SLA and compliance commitments ensure your data is not left compromised
+              </li>
+            </ul>
+            <p>* All nodes in the cluster must be covered. Per-VM pricing is also available.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <hr class="p-rule is-fixed-width" />
+
+  <section class="p-strip is-deep">
+    <div class="u-fixed-width">
+      <p class="p-heading--2">
+        <a href="https://ubuntu.com/managed">Learn more about Managed Services&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>
+          Managed Spark resources
+        </h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://ubuntu.com/engage/spark-security-webinar">Secure Apache Spark Big Data Operations</a>
+          </h3>
+          <p>Watch our webinar and get tips on how to identify and prioritize security requirements and learn pragmatic steps that you can take to secure your Spark applications – wherever they may be running.</p>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="p-section--shallow">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://ubuntu.com/engage/spark_online_data_hub">Build an online datahub with Spark</a>
+          </h3>
+          <p>Read our white paper to discover the value, use cases, and challenges of building an enterprise data hub – whether on the public cloud or on-premise – based on Apache Spark.</p>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="p-section--shallow">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://ubuntu.com/engage/open-source-big-data-ai">Make better decisions with open source Big Data and AI solutions</a>
+          </h3>
+          <p>Learn how to build a smarter enterprise with a secure, integrated open source stack for Big Data and AI.</p>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="p-section--shallow">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://canonical.com/blog/canonical-releases-charmed-spark">What is Spark?</a>
+          </h3>
+          <p>Learn about Charmed Apache Spark on Kubernetes.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-6 col-start-large-7">
+        <p class="u-text--muted">
+          Apache<sup>&reg;</sup>, Apache Spark, Spark<sup>&reg;</sup>, and the Spark logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+
+  {% with %}
+    {% set returnURL = "https://canonical.com/data/spark#success" %}
+    {% include "data/_form-data-spark.html" %}
+  {% endwith %}
+
+{% endblock %}


### PR DESCRIPTION
## Done

* added new page for data/spark/managed

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check the new page at https://canonical-com-1731.demos.haus/data/spark/managed

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-22642

## Screenshots

![image](https://github.com/user-attachments/assets/6c53f890-cc36-4bbd-af0b-1b70b4fb1866)
