### PR TITLE
Design update for data/spark/managed WD-22639

### DIFF
--- a/templates/data/spark/managed.html
+++ b/templates/data/spark/managed.html
@@ -20,11 +20,11 @@
 
   <section class="p-section--hero">
     <div class="row--25-75-on-large">
-      <div class="col">
-        {{ image(url="https://assets.ubuntu.com/v1/8c624408-apache%20spark.png",
-                alt="",
-                width="568",
-                height="321",
+      <div class="col u-hide--medium u-hide--small">
+        {{ image(url="https://assets.ubuntu.com/v1/f0ddc78a-Apache-Spark-Logo.png",
+                alt="Apache spark",
+                width="852",
+                height="156",
                 hi_def=True,
                 loading="auto") | safe
         }}
@@ -117,10 +117,10 @@
       </div>
       <div class="p-section--shallow">
         <div class="p-image-container is-highlighted">
-          {{ image(url="https://assets.ubuntu.com/v1/30891bca-Image.png",
-                    alt="",
-                    width="1800",
-                    height="1015",
+          {{ image(url="https://assets.ubuntu.com/v1/1d9db6de-why-choose-canonicals.png",
+                    alt="Why choose Canonical's Managed Spark",
+                    width="3696",
+                    height="1539",
                     hi_def=True,
                     attrs={"class": "p-image-container__image"},
                     loading="lazy") | safe
@@ -194,16 +194,6 @@
           </div>
           <div class="col-6 col-medium-3">
             <p>Specialized Canonical engineers deploy a database sustainably and efficiently on any cloud.</p>
-            <div class="p-image-wrapper u-hide--small">
-              {{ image(url="https://assets.ubuntu.com/v1/f887a7db-deploy+fast.svg",
-                            alt="",
-                            width="263",
-                            height="150",
-                            hi_def=True,
-                            attrs={"class": "p-image-container__image"},
-                            loading="lazy") | safe
-              }}
-            </div>
           </div>
         </div>
         <hr class="p-rule--muted" />
@@ -215,16 +205,6 @@
             <p>
               Our team manages all your ‘day 2’ operations, from observability to upgrades. We handle all issues, and consistently enforce the security of your environment.
             </p>
-            <div class="p-image-wrapper u-hide--small">
-              {{ image(url="https://assets.ubuntu.com/v1/3089fff7-one+platform.svg",
-                            alt="",
-                            width="228",
-                            height="150",
-                            hi_def=True,
-                            attrs={"class": "p-image-container__image"},
-                            loading="lazy") | safe
-              }}
-            </div>
           </div>
         </div>
         <hr class="p-rule--muted" />
@@ -236,16 +216,6 @@
             <p>
               There’s no vendor lock-in with Canonical, so if after a while you want to start managing your environments by yourself, we can teach you how and give you remote support for high-severity cases.
             </p>
-            <div class="p-image-wrapper u-hide--small">
-              {{ image(url="https://assets.ubuntu.com/v1/3a4d4155-Training.svg",
-                            alt="",
-                            width="300",
-                            height="150",
-                            hi_def=True,
-                            attrs={"class": "p-image-container__image"},
-                            loading="lazy") | safe
-              }}
-            </div>
           </div>
         </div>
       </div>
@@ -296,14 +266,16 @@
         <hr class="p-rule--highlight u-no-margin--bottom" />
         <div class="p-card--overlay u-no-padding--top" style="min-height: 600px">
           <div class="row">
-            <div class="col-4 col-medium-2 col-small-3">
+            <div class="col-4 col-medium-2 col-small-2">
               <h3 class="u-align-text--left u-no-margin--bottom">
                 Managed Spark on VMs
               </h3>
             </div>
-            <div class="col-2 col-medium-1 col-small-1">
-              <h3 class="u-align-text--right u-no-margin--bottom">Annual price $3099</h3>
-              <p class="u-align-text--right">
+            <div class="col-2 col-medium-1 col-small-2">
+              <h3 class="u-align-text--right u-no-margin--bottom">$3099</h3>
+              <p class="u-align-text--right u-text--muted">
+                Per year,
+                <br />
                 per VM*
               </p>
             </div>
@@ -324,14 +296,16 @@
         <hr class="p-rule--highlight u-no-margin--bottom" />
         <div class="p-card--overlay u-no-padding--top" style="min-height: 600px">
           <div class="row">
-            <div class="col-4 col-medium-2 col-small-3">
+            <div class="col-4 col-medium-2 col-small-2">
               <h3 class="u-align-text--left u-no-margin--bottom">
                 Managed Spark on K8s
               </h3>
             </div>
-            <div class="col-2 col-medium-1 col-small-1">
-              <h3 class="u-align-text--right u-no-margin--bottom">Annual price $9470</h3>
-              <p class="u-align-text--right">
+            <div class="col-2 col-medium-1 col-small-2">
+              <h3 class="u-align-text--right u-no-margin--bottom">$9470</h3>
+              <p class="u-align-text--right u-text--muted">
+                Per year,
+                <br />
                 per node*
               </p>
             </div>
@@ -399,7 +373,7 @@
         <hr class="p-rule--muted" />
         <div class="p-section--shallow">
           <h3 class="p-heading--5 u-no-margin--bottom">
-            <a href="https://canonical.com/blog/canonical-releases-charmed-spark">What is Spark?</a>
+            <a href="/data/spark/what-is-spark">What is Spark?</a>
           </h3>
           <p>Learn about Charmed Apache Spark on Kubernetes.</p>
         </div>


### PR DESCRIPTION
## Done

- updated graphics and pricing headings on the data/spark/managed page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- check https://canonical-com-1740.demos.haus/data/spark/managed

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-22639
Figma in https://www.figma.com/design/uJUwbUAGDog4KCMivrMpnl/canonical.com-data?node-id=3799-22384&t=DUTMumb7lH8G7X5v-0

## Screenshots

![image](https://github.com/user-attachments/assets/712b6ce8-5873-4cce-92d1-401aec2405f6)

