### PR TITLE
Add candidate dashboard video for CRO req

### DIFF
--- a/webapp/application.py
+++ b/webapp/application.py
@@ -260,6 +260,10 @@ def _get_application(harvest, application_id):
                 application["hiring_lead"][
                     "video_src"
                 ] = "https://www.youtube.com/embed/UvDSXgPbpt8"
+            elif job_id == 2804114:  # Chief Revenue Officer
+                application["hiring_lead"][
+                    "video_src"
+                ] = "https://www.youtube.com/embed/hO1rXwoRjx0"
             elif (
                 # Currently only user with video
                 # as we don't have a source to pull this video from


### PR DESCRIPTION
## Rationale

TS would like us to add a new HL video for the CRO req. This was already done for the ESR req, so we follow the pattern used there. However, in the addition for the ESR req, the video was not displaying because we were comparing `job_id`, which is an int, with a string value. This change fixes the previous video addition for ESR req and adds a new one for CRO req as per TS request.

## Done

- fix job ID comparison for previous ESR req video addition
- add video for CRO req

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- Ensure that a Candidate Dash from the ESR req now shows the desired HL video embedded on the page.
- Ensure that a Candidate Dash from the CRO req now shows the desired HL video embedded on the page.

## Issue / Card

[TSP-916](https://warthogs.atlassian.net/browse/TSP-916)


[TSP-916]: https://warthogs.atlassian.net/browse/TSP-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ