### PR TITLE
[WD-22790] chore: updated contribution link

### DIFF
--- a/templates/projects/index.html
+++ b/templates/projects/index.html
@@ -2,6 +2,8 @@
 
 {% block title %}Projects and technologies{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1GTnsk_Fk-ZHJQi--6X2TuaURwUCwnxZQjKdWDFBsaS0{% endblock %}
+
 {% block meta_description %}
   Canonical guides and contributes to the development of many open source projects in addition to Ubuntu. They include MIR, a next-generation display server, and Juju, a leading service orchestration tool.
 {% endblock %}
@@ -39,7 +41,7 @@
           Ubuntu is one of the world's biggest and most influential open source projects. With new features continually being developed, there is plenty of opportunity to get involved.
         </p>
         <p>
-          <a href="https://discourse.ubuntu.com/t/contribute/26">Contribute to Ubuntu&nbsp;&rsaquo;</a>
+          <a href="https://ubuntu.com/community/contribute">Contribute to Ubuntu&nbsp;&rsaquo;</a>
         </p>
       </div>
       <div class="col-6 col-medium-3">


### PR DESCRIPTION
## Done

- Updated link
- Added missing copydoc link

## QA

- View the site in your web browser at: http://0.0.0.0:8002/
- Click on the "Contribute to Ubuntu" link
- Verify it takes you to https://ubuntu.com/community/contribute
- Bonus: If you have copydoc extension, open the copydoc to see it opens up the right document.

## Issue / Card

Fixes #[WD-22790](https://warthogs.atlassian.net/browse/WD-22790)
Fixes #1744 
