### PR TITLE
feat: Rebrand search page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.http==1.0.4
 canonicalwebteam.image-template==1.5.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.discourse==6.2.0
-canonicalwebteam.search==2.1.1
+canonicalwebteam.search==2.1.2
 canonicalwebteam.form-generator==2.0.1
 canonicalwebteam.directory-parser==1.2.10
 bleach==5.0.1

--- a/templates/search.html
+++ b/templates/search.html
@@ -160,10 +160,10 @@
             <h2 class="p-heading--4">Still no luck?</h2>
           </div>
           <div class="col-6 col-medium-3">
-            <p class="u-no-margin--bottom">
+            <p>
               <a href="/">Visit the Canonical homepage</a>
             </p>
-            <p class="u-no-margin--bottom">
+            <p>
               <a href="/contact-us">Contact us</a>
             </p>
           </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -12,19 +12,18 @@
 {% endblock %}
 
 {% block content %}
-
   <div class="p-strip is-shallow">
-    <div class="u-fixed-width">
+    <div class="p-section--shallow u-fixed-width">
       {% if query %}
         {% if estimatedTotal == 0 %}
-          <h1 class="p-heading--2">Sorry we couldn't find "{{ query }}"</h1>
+          <h1>Sorry we couldn't find "{{ query }}"</h1>
           {% if siteSearch %}
             <h3>
               on <a href="https://{{ siteSearch }}">{{ siteSearch }}</a>
             </h3>
           {% endif %}
         {% else %}
-          <h1 class="p-heading--2">Search results for "{{ query }}"</h1>
+          <h1>Search results for "{{ query }}"</h1>
           {% if siteSearch %}
             <h3>
               on <a href="https://{{ siteSearch }}">{{ siteSearch }}</a>
@@ -32,39 +31,84 @@
           {% endif %}
         {% endif %}
       {% else %}
-        <h1>Search Canonical and Ubuntu sites</h1>
+        <h1>Search Ubuntu and Canonical sites</h1>
       {% endif %}
+    </div>
+    {# search form #}
+    <div class="p-section--shallow">
+      <div class="u-fixed-width">
+        <form class="p-search-box" action="/search">
+          <label for="search-input" class="u-off-screen">Search</label>
+          <!-- honeypot search input -->
+          <input type="search"
+                id="search"
+                class="p-search-box__input u-hide "
+                name="search"
+                placeholder="Search our sites"
+                aria-label="Search our sites"
+                value="" />
+          <!-- end of honeypot search input -->
+          <input class="p-search-box__input"
+                name="q"
+                id="search-input"
+                type="search"
+                {% if query %}value="{{ query }}"{% endif %}
+                placeholder="e.g. juju" />
+          {% if siteSearch %}<input name="siteSearch" type="hidden" value="{{ siteSearch }}" />{% endif %}
+          <button type="submit" alt="search" class="p-search-box__button" alt="search">
+            <i class="p-icon--search">Submit</i>
+          </button>
+        </form>
+      </div>
     </div>
   </div>
 
-  {# search form #}
-  <div class="u-fixed-width">
-    <form class="p-search-box" action="/search">
-      <label for="search-input" class="u-off-screen">Search</label>
-      <input class="p-search-box__input"
-             name="q"
-             id="search-input"
-             type="search"
-             {% if query %}value="{{ query }}"{% endif %}
-             placeholder="e.g. ubuntu pro" />
-      {% if siteSearch %}<input name="siteSearch" type="hidden" value="{{ siteSearch }}" />{% endif %}
-      <button type="submit" alt="Search" class="p-search-box__button">
-        <i class="p-icon--search">Submit</i>
-      </button>
-    </form>
-  </div>
+  {% if not query %}
+    {% set featured_section = featured["products"]["side_nav_sections"][0] %}
+    {% if featured_section %}
+      <section class="p-section">
+        <div class="p-section--shallow u-fixed-width">
+          <hr class="p-rule" />
+          <h2>{{ featured_section["title"] }}</h2>
+        </div>
+        <div class="p-list--horizontal-section-wrapper">
+          <ul class="p-list--horizontal-section">
+            {% for section in featured_section["primary_links"]["links"] %}
+            <li class="p-list__item">
+              <div class="col-3 col-medium-2">
+                <h3 class="p-heading--5 u-no-margin--bottom"><a href="{{ section["url"] }}">{{ section["title"] }}</a></h3>
+                <p>{{ section["description"] }}</p>
+              </div>
+            </li>
+          {% endfor %}
+          </ul>
+        </div>
+      </section>
+      <hr class="p-rule is-fixed-width" />
+      <section class="p-strip is-deep">
+        <div class="u-fixed-width">
+          <p class="p-heading--2">
+            <a href="/contact-us">Get in touch&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </section>
+    {% endif %}
+  {% endif %}
 
   {% if results %}
     {% if results.entries %}
       {% for item in results.entries %}
-        <div class="p-strip is-shallow">
+        <div class="p-section--shallow">
           <div class="row">
-            <div class="col-12">
-              <h5>
-                <a href="{{ item.link }}" class="title-main">{{ item.htmlTitle | safe }}</a>
-              </h5>
+            {% if not loop.first %}
+            <hr class="p-rule--muted u-no-margin--bottom" />
+            {% endif %}
+            <div class="col">
+              <h2 class="p-heading--3 u-no-margin--bottom">
+                <a href="{{ item.link }}">{{ item.htmlTitle | safe }}</a>
+              </h2>
+              <p class="u-no-margin--bottom"><a href="{{ item.link }}" class="u-text--muted">{{ item.htmlFormattedUrl | safe }}</a></p>
               <p>{{ item.htmlSnippet | safe }}</p>
-              <small><a href="{{ item.link }}">{{ item.htmlFormattedUrl | safe }}</a></small>
             </div>
           </div>
         </div>
@@ -86,27 +130,42 @@
         </div>
       </div>
     {% else %}
-      <div class="p-strip">
+      <div class="p-section--deep">
         <div class="row">
-          <div class="col-6">
-            <h3>Why not try widening your search?</h3>
-            <p>You can do this by:</p>
+          <div class="p-notification--negative">
+            <div class="p-notification__content">
+              <h5 class="p-notification__title">Your search "{{ query }}" did not match any notices.</h5>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-4 col-medium-3">
+            <h2 class="p-heading--4">
+            Why not try widening your search? You can do this by:
+            </h2>
+          </div>
+          <div class="col-4 col-medium-3">
             <ul class="p-list">
               <li class="p-list__item is-ticked">Adding alternative words or phrases</li>
               <li class="p-list__item is-ticked">Using individual words instead of phrases</li>
               <li class="p-list__item is-ticked">Trying a different spelling</li>
             </ul>
           </div>
-          <div class="col-6">
-            <h3>Still no luck?</h3>
-            <ul class="p-list">
-              <li class="p-list__item is-ticked">
-                <a href="/">Visit the Canonical homepage</a>
-              </li>
-              <li class="p-list__item is-ticked">
-                <a href="/contact-us">Contact us</a>
-              </li>
-            </ul>
+        </div>
+        <div class="u-fixed-width">
+          <hr class="p-rule" />
+        </div>
+        <div class="row">
+          <div class="col-4 col-medium-3">
+            <h2 class="p-heading--4">Still no luck?</h2>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p class="u-no-margin--bottom">
+              <a href="/">Visit the Canonical homepage</a>
+            </p>
+            <p class="u-no-margin--bottom">
+              <a href="/contact-us">Contact us</a>
+            </p>
           </div>
         </div>
       </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -6,6 +6,7 @@ import calendar
 import os
 import re
 from urllib.parse import parse_qs, urlencode, urlparse
+import yaml
 
 import bleach
 import flask
@@ -262,6 +263,8 @@ def home_sitemap():
     return response
 
 
+with open("navigation.yaml") as nav_file:
+    navigation = yaml.load(nav_file.read(), Loader=yaml.FullLoader)
 app.add_url_rule(
     "/search",
     "search",
@@ -270,6 +273,7 @@ app.add_url_rule(
         session=search_session,
         template_path="search.html",
         search_engine_id=search_engine_id,
+        featured=navigation,
     ),
 )
 


### PR DESCRIPTION
## Done

- Bump canonicalwebteam.search module to 2.1.2
- Rebrand search page, similar to https://github.com/canonical/ubuntu.com/pull/15216

## QA

- Go to https://canonical-com-1765.demos.haus/search
- Check that design matches [Figma](https://www.figma.com/design/RIeBDWnFQVtYOQltavDcXf/Search--==ubuntu.com-and-canonical.com-?node-id=1-84&p=f&m=dev)
- Perform searches for no result and result pages 

## Issue / Card

Fixes [WD-22374](https://warthogs.atlassian.net/browse/WD-22374)

## Screenshots

[if relevant, include a screenshot]


[WD-22374]: https://warthogs.atlassian.net/browse/WD-22374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ