### PR TITLE
fix: migrate homepage form to form generator

### DIFF
--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -277,10 +277,6 @@
     </div>
   </section>
 
-  {% with %}
-    {% set formid = "5311" %}
-    {% set returnURL = "https://canonical.com#success" %}
-    {% include "partners/partial/_homepage-form.html" %}
-  {% endwith %}
+  {{ load_form("/contact-us") | safe }}
 
 {% endblock %}

--- a/templates/form-data.json
+++ b/templates/form-data.json
@@ -1,0 +1,340 @@
+{
+  "form": {
+    "/": {
+      "templatePath": "/index.html",
+      "isModal": true,
+      "modalId": "homepage-modal",
+      "formData": {
+        "title": "Contact Canonical",
+        "introText": "Fill in this form and we'll be in touch within one working day.",
+        "formId": "5311",
+        "returnUrl": "#contact-form-success",
+        "product": ""
+      },
+      "fieldsets": [
+        {
+          "title": "Tell us about your project",
+          "id": "about-your-project",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "about-your-project",
+              "label": "About your project"
+            }
+          ]
+        },
+        {
+          "title": "If you use Ubuntu, which version(s) are you using?",
+          "id": "ubuntu-versions",
+          "inputType": "checkbox-visibility",
+          "fields": [
+            {
+              "fieldTitle": "LTS within standard support",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "24-04",
+                  "value": "24.04 LTS",
+                  "label": "24.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "22-04",
+                  "value": "22.04 LTS",
+                  "label": "22.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "20-04",
+                  "value": "20.04 LTS",
+                  "label": "20.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "LTS out of standard support",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "18-04",
+                  "value": "18.04 LTS",
+                  "label": "18.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "16-04",
+                  "value": "16.04 LTS",
+                  "label": "16.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "14-04",
+                  "value": "14.04 LTS",
+                  "label": "14.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "Outdated or non-LTS releases",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "22-10",
+                  "value": "22.10",
+                  "label": "non-LTS release"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "12-04",
+                  "value": "12.04 LTS",
+                  "label": "12.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "Other",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "dont-use-ubuntu-today",
+                  "value": "I don't use Ubuntu today",
+                  "label": "I don't use Ubuntu today"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "ubuntu-i-dont-know",
+                  "value": "I don't know",
+                  "label": "I don't know"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "What kind of device are you using?",
+          "id": "kind-of-device",
+          "isRequired": true,
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "desktop-workstation",
+              "value": "desktop/workstation",
+              "label": "Desktop workstation"
+            },
+            {
+              "type": "checkbox",
+              "id": "physical-server",
+              "value": "physical/server",
+              "label": "Physical server"
+            },
+            {
+              "type": "checkbox",
+              "id": "public-cloud",
+              "value": "public/cloud",
+              "label": "Public cloud"
+            },
+            {
+              "type": "checkbox",
+              "id": "virtual-machine",
+              "value": "virtual/machine",
+              "label": "Virtual machine"
+            },
+            {
+              "type": "checkbox",
+              "id": "iot-edge-device",
+              "value": "iot/edge device",
+              "label": "IoT/Edge device"
+            }
+          ]
+        },
+        {
+          "title": "How many devices?",
+          "id": "how-many-machines",
+          "inputName": "how-many-machines-do-you-have",
+          "inputType": "radio",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "radio",
+              "id": "less-5-machines",
+              "value": "less than 5",
+              "label": "< 5 machines"
+            },
+            {
+              "type": "radio",
+              "id": "5-to-15-machines",
+              "value": "5 to 15 machines",
+              "label": "5 - 15 machines"
+            },
+            {
+              "type": "radio",
+              "id": "15-to-50-machines",
+              "value": "15 to 50 machines",
+              "label": "15 - 50 machines"
+            },
+            {
+              "type": "radio",
+              "id": "50-to-100-machines",
+              "value": "50 to 100 machines",
+              "label": "50 - 100 machines"
+            },
+            {
+              "type": "radio",
+              "id": "greater-than-100",
+              "value": "greater than 100",
+              "label": "> 100 machines"
+            }
+          ]
+        },
+        {
+          "title": "How do you consume open source?",
+          "id": "how-do-you-consume-open-source",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "ubuntu-repositories",
+              "value": "Ubuntu repositories",
+              "label": "Ubuntu repositories"
+            },
+            {
+              "type": "checkbox",
+              "id": "github-upstream",
+              "value": "GitHub/Upstream",
+              "label": "GitHub/Upstream"
+            },
+            {
+              "type": "checkbox",
+              "id": "internally-approved-repository",
+              "value": "Internally approved repository",
+              "label": "Internally approved repository"
+            },
+            {
+              "type": "checkbox",
+              "id": "opensource-i-dont-know",
+              "value": "I don't know",
+              "label": "I don't know"
+            }
+          ]
+        },
+        {
+          "title": "Do you have specific compliance or hardening requirements?",
+          "id": "hardening-requirements",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "pci",
+              "value": "PCI-DSS",
+              "label": "PCI-DSS"
+            },
+            {
+              "type": "checkbox",
+              "id": "hipaa",
+              "value": "HIPAA",
+              "label": "HIPAA"
+            },
+            {
+              "type": "checkbox",
+              "id": "fisma",
+              "value": "FISMA",
+              "label": "FISMA"
+            },
+            {
+              "type": "checkbox",
+              "id": "fips-140",
+              "value": "FIPS 140",
+              "label": "FIPS 140"
+            },
+            {
+              "type": "checkbox",
+              "id": "ncsc",
+              "value": "NCSC",
+              "label": "NCSC"
+            },
+            {
+              "type": "checkbox",
+              "id": "disa-stig",
+              "value": "DISA-STIG",
+              "label": "DISA-STIG"
+            },
+            {
+              "type": "checkbox",
+              "id": "fedramp",
+              "value": "FedRAMP",
+              "label": "FedRAMP"
+            },
+            {
+              "type": "checkbox",
+              "id": "cis-benchmark",
+              "value": "CIS Benchmark",
+              "label": "CIS Benchmark"
+            }
+          ]
+        },
+        {
+          "title": "Who is responsible for tracking, testing and applying CVE patches in a timely manner?",
+          "id": "responsible-for-tracking",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "individual-developers",
+              "value": "Individual developers",
+              "label": "Individual developers"
+            },
+            {
+              "type": "checkbox",
+              "id": "project-team",
+              "value": "The project team",
+              "label": "The project team"
+            },
+            {
+              "type": "checkbox",
+              "id": "third-party-vendor",
+              "value": "Third-party vendor",
+              "label": "Third-party vendor"
+            },
+            {
+              "type": "checkbox",
+              "id": "tracking-i-dont-know",
+              "value": "I don't know",
+              "label": "I don't know"
+            }
+          ]
+        },
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number"
+            },
+            {
+              "type": "country",
+              "label": "Country",
+              "isRequired": true
+            },
+            {
+              "type": "text",
+              "id": "title",
+              "label": "Job title",
+              "isRequired": true
+            },
+            {
+              "type": "text",
+              "id": "selfReportedAttribution",
+              "label": "How did you hear about us?",
+              "isRequired": false
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/templates/form-data.json
+++ b/templates/form-data.json
@@ -335,6 +335,342 @@
           ]
         }
       ]
+    },
+    "/contact-us": {
+      "templatePath": "/contact-us.html",
+      "isModal": true,
+      "modalId": "homepage-modal",
+      "formData": {
+        "title": "Contact Canonical",
+        "introText": "Fill in this form and we'll be in touch within one working day.",
+        "formId": "5311",
+        "returnUrl": "https://canonical.com#contact-form-success",
+        "product": ""
+      },
+      "fieldsets": [
+        {
+          "title": "Tell us about your project",
+          "id": "about-your-project",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "about-your-project",
+              "label": "About your project"
+            }
+          ]
+        },
+        {
+          "title": "If you use Ubuntu, which version(s) are you using?",
+          "id": "ubuntu-versions",
+          "inputType": "checkbox-visibility",
+          "fields": [
+            {
+              "fieldTitle": "LTS within standard support",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "24-04",
+                  "value": "24.04 LTS",
+                  "label": "24.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "22-04",
+                  "value": "22.04 LTS",
+                  "label": "22.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "20-04",
+                  "value": "20.04 LTS",
+                  "label": "20.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "LTS out of standard support",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "18-04",
+                  "value": "18.04 LTS",
+                  "label": "18.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "16-04",
+                  "value": "16.04 LTS",
+                  "label": "16.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "14-04",
+                  "value": "14.04 LTS",
+                  "label": "14.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "Outdated or non-LTS releases",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "22-10",
+                  "value": "22.10",
+                  "label": "non-LTS release"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "12-04",
+                  "value": "12.04 LTS",
+                  "label": "12.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "Other",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "dont-use-ubuntu-today",
+                  "value": "I don't use Ubuntu today",
+                  "label": "I don't use Ubuntu today"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "ubuntu-i-dont-know",
+                  "value": "I don't know",
+                  "label": "I don't know"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "What kind of device are you using?",
+          "id": "kind-of-device",
+          "isRequired": true,
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "desktop-workstation",
+              "value": "desktop/workstation",
+              "label": "Desktop workstation"
+            },
+            {
+              "type": "checkbox",
+              "id": "physical-server",
+              "value": "physical/server",
+              "label": "Physical server"
+            },
+            {
+              "type": "checkbox",
+              "id": "public-cloud",
+              "value": "public/cloud",
+              "label": "Public cloud"
+            },
+            {
+              "type": "checkbox",
+              "id": "virtual-machine",
+              "value": "virtual/machine",
+              "label": "Virtual machine"
+            },
+            {
+              "type": "checkbox",
+              "id": "iot-edge-device",
+              "value": "iot/edge device",
+              "label": "IoT/Edge device"
+            }
+          ]
+        },
+        {
+          "title": "How many devices?",
+          "id": "how-many-machines",
+          "inputName": "how-many-machines-do-you-have",
+          "inputType": "radio",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "radio",
+              "id": "less-5-machines",
+              "value": "less than 5",
+              "label": "< 5 machines"
+            },
+            {
+              "type": "radio",
+              "id": "5-to-15-machines",
+              "value": "5 to 15 machines",
+              "label": "5 - 15 machines"
+            },
+            {
+              "type": "radio",
+              "id": "15-to-50-machines",
+              "value": "15 to 50 machines",
+              "label": "15 - 50 machines"
+            },
+            {
+              "type": "radio",
+              "id": "50-to-100-machines",
+              "value": "50 to 100 machines",
+              "label": "50 - 100 machines"
+            },
+            {
+              "type": "radio",
+              "id": "greater-than-100",
+              "value": "greater than 100",
+              "label": "> 100 machines"
+            }
+          ]
+        },
+        {
+          "title": "How do you consume open source?",
+          "id": "how-do-you-consume-open-source",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "ubuntu-repositories",
+              "value": "Ubuntu repositories",
+              "label": "Ubuntu repositories"
+            },
+            {
+              "type": "checkbox",
+              "id": "github-upstream",
+              "value": "GitHub/Upstream",
+              "label": "GitHub/Upstream"
+            },
+            {
+              "type": "checkbox",
+              "id": "internally-approved-repository",
+              "value": "Internally approved repository",
+              "label": "Internally approved repository"
+            },
+            {
+              "type": "checkbox",
+              "id": "opensource-i-dont-know",
+              "value": "I don't know",
+              "label": "I don't know"
+            }
+          ]
+        },
+        {
+          "title": "Do you have specific compliance or hardening requirements?",
+          "id": "hardening-requirements",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "pci",
+              "value": "PCI-DSS",
+              "label": "PCI-DSS"
+            },
+            {
+              "type": "checkbox",
+              "id": "hipaa",
+              "value": "HIPAA",
+              "label": "HIPAA"
+            },
+            {
+              "type": "checkbox",
+              "id": "fisma",
+              "value": "FISMA",
+              "label": "FISMA"
+            },
+            {
+              "type": "checkbox",
+              "id": "fips-140",
+              "value": "FIPS 140",
+              "label": "FIPS 140"
+            },
+            {
+              "type": "checkbox",
+              "id": "ncsc",
+              "value": "NCSC",
+              "label": "NCSC"
+            },
+            {
+              "type": "checkbox",
+              "id": "disa-stig",
+              "value": "DISA-STIG",
+              "label": "DISA-STIG"
+            },
+            {
+              "type": "checkbox",
+              "id": "fedramp",
+              "value": "FedRAMP",
+              "label": "FedRAMP"
+            },
+            {
+              "type": "checkbox",
+              "id": "cis-benchmark",
+              "value": "CIS Benchmark",
+              "label": "CIS Benchmark"
+            }
+          ]
+        },
+        {
+          "title": "Who is responsible for tracking, testing and applying CVE patches in a timely manner?",
+          "id": "responsible-for-tracking",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "individual-developers",
+              "value": "Individual developers",
+              "label": "Individual developers"
+            },
+            {
+              "type": "checkbox",
+              "id": "project-team",
+              "value": "The project team",
+              "label": "The project team"
+            },
+            {
+              "type": "checkbox",
+              "id": "third-party-vendor",
+              "value": "Third-party vendor",
+              "label": "Third-party vendor"
+            },
+            {
+              "type": "checkbox",
+              "id": "tracking-i-dont-know",
+              "value": "I don't know",
+              "label": "I don't know"
+            }
+          ]
+        },
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number"
+            },
+            {
+              "type": "country",
+              "label": "Country",
+              "isRequired": true
+            },
+            {
+              "type": "text",
+              "id": "title",
+              "label": "Job title",
+              "isRequired": true
+            },
+            {
+              "type": "text",
+              "id": "selfReportedAttribution",
+              "label": "How did you hear about us?",
+              "isRequired": false
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -829,12 +829,7 @@ meta_copydoc %}
     </section>
   </div>
 
-  {% with %}
-    {% set formid = "5311" %}
-    {% set returnURL = "https://canonical.com#success" %}
-    {% include "partners/partial/_homepage-form.html" %}
-  {% endwith %}
-
+  {{ load_form("/") | safe }}
   <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
 
 {% endblock %}

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -59,7 +59,7 @@
                   {% if field.id %}
                     {% set field_id = field.id %}
                   {% elif field.fieldTitle is not defined %}
-                    {% set field_id = fieldset_id + '-' + field.label %}
+                    {% set field_id = fieldset_id + '-' + field.label|slug %}
                   {% endif %}
 
                   {% if field.value %}

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -18,12 +18,11 @@
         {% set fieldset_inputName = fieldset_id %}
       {% endif %}
 
-      <div class="p-section">
+      <div class="{% if loop.index != fieldsets|length %}p-section{% endif %}">
         <hr class="p-rule is-fixed-width" />
-        <fieldset class="p-fieldset-section u-no-padding{% if fieldset.inputType == 'checkbox-visibility' %} js-toggle-checkbox-visibility {% elif fieldset.isRequired and fieldset.inputType == 'checkbox' %} js-required-checkbox {% elif fieldset.inputType == 'radio' %} js-remove-radio-names{% endif %}"
+        <fieldset class="p-fieldset-section{% if fieldset.inputType == 'checkbox-visibility' %} js-toggle-checkbox-visibility{% elif fieldset.isRequired and fieldset.inputType == 'checkbox' %} js-required-checkbox{% elif fieldset.inputType == 'radio' %} js-remove-radio-names{% endif %} {% if fieldset.inputType == 'checkbox' or fieldset.inputType == 'checkbox-visibility' %}js-remove-checkbox-names{% endif %}"
                   id="{{ fieldset_id }}"
-                  aria-labelledby="{{ fieldset_id }}"
-                  {% if fieldset_id == 'about-you' %}style="overflow: unset;"{% endif %}>
+                  aria-labelledby="{{ fieldset_id }}">
           <div class="row--50-50 {% if fieldset.noCommentsFromLead != True %}js-formfield{% endif %}">
             <div class="col">
               <legend class="p-heading--4 js-formfield-title {% if fieldset.isRequired %}is-required{% endif %}"
@@ -55,18 +54,17 @@
                           type="email"
                           pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
                 {% endif %}
-
                 {% for field in fieldset.fields %}
 
                   {% if field.id %}
                     {% set field_id = field.id %}
-                  {% else %}
-                    {% set field_id = fieldset_id + '-' + field.label|slug %}
+                  {% elif field.fieldTitle is not defined %}
+                    {% set field_id = fieldset_id + '-' + field.label %}
                   {% endif %}
 
                   {% if field.value %}
                     {% set field_value = field.value %}
-                  {% else %}
+                  {% elif field.fieldTitle is not defined %}
                     {% set field_value = field.label %}
                   {% endif %}
 
@@ -77,20 +75,6 @@
                       {% endif %}
                       {% include "shared/forms/_country.html" %}
                     {% endwith %}
-                  {% elif field.type == "radio" %}
-                    <label class="p-radio">
-                      <input {% if fieldset.isRequired %}required{% endif %}
-                            class="p-radio__input"
-                            id="{{ field_id }}"
-                            type="radio"
-                            aria-labelledby="{{ field_id }}"
-                            name="{{ fieldset_inputName }}"
-                            value="{{ field_value }}" />
-                      <span class="p-radio__label">{{ field.label }}</span>
-                    </label>
-                    {% if field.hasTextarea %}
-                      <textarea class="js-other-input u-hide" data-input-id="{{ field_id }}" id="{{ field_id }}-textarea"></textarea>
-                    {% endif %}
                   {% else %}
                     <li class="p-list__item">
                       {% if field.type == "text" or field.type == "tel" or field.type == "email" %}
@@ -104,24 +88,47 @@
                                {% if field.type=="email" %}pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"{% endif %} />
                       {% elif field.type == "long-text" %}
                         <textarea {% if fieldset.isRequired %}required{% endif %}
-                                  id="{{ field.id }}"
+                                  id="{{ field_id }}"
                                   rows="5"
                                   maxlength="2000"
                                   {% if field.placeholder %}placeholder="{{ field.placeholder }}"{% endif %}></textarea>
+                      {% elif field.type == "radio" %}
+                        <label class="p-radio">
+                          <input {% if fieldset.isRequired %}required{% endif %}
+                                 class="p-radio__input"
+                                 type="radio"
+                                 aria-labelledby="{{ field_id }}"
+                                 name="{{ fieldset_inputName }}"
+                                 value="{{ field_value }}"
+                                 id="{{ field_id }}"
+                                 {% if field.isSelected %}checked{% endif %} />
+                          <span class="p-radio__label" >{{ field.label }}</span>
+                        </label>
+                        {% if field.hasTextarea %}
+                          <textarea class="js-other-input u-hide"
+                                    data-input-id="{{ field_id }}"
+                                    id="{{ field_id }}-textarea"></textarea>
+                        {% endif %}
                       {% elif field.type == "checkbox" %}
                         <label class="p-checkbox">
                           <input class="p-checkbox__input js-checkbox-visibility"
                                  type="checkbox"
                                  aria-labelledby="{{ field.label }}"
-                                 value="{{ field_value }}" />
-                          <span class="p-checkbox__label" id="{{ field_id }}">{{ field.label }}</span>
+                                 value="{{ field_value }}"
+                                 {% if field.isSelected %}checked{% endif %} />
+                          <span class="p-checkbox__label">{{ field.label }}</span>
                         </label>
+                        {% if field.hasTextarea %}
+                          <textarea class="js-other-input u-hide"
+                                    data-input-id="{{ field_id }}"
+                                    id="{{ field_id }}-textarea"></textarea>
+                        {% endif %}
                       {% elif field.fieldTitle is defined and field.fieldTitle|length > 0 %}
                         <div class="p-section--shallow">
                           <strong>{{ field.fieldTitle }}</strong>
                           {% for option in field.options %}
                             <label class="p-checkbox">
-                              <input class="p-checkbox__input js-checkbox-visibility{% if field.fieldTitle=='Other' %}__other{% endif %}"
+                              <input class="p-checkbox__input js-checkbox-visibility{% if field.fieldTitle=="Other" %}__other{% endif %}"
                                      type="checkbox"
                                      aria-labelledby="{{ option.label }}"
                                      value="{{ option.value }}" />
@@ -140,125 +147,132 @@
                   {% endif %}
                 {% endfor %}
               </ul>
-              {% if loop.index == fieldsets|length %}
-                <ul class="p-list">
-                  <li class="p-list__item">
-                    <label class="p-checkbox">
-                      <input class="p-checkbox__input js-checkbox-visibility"
-                             value="yes"
-                             aria-labelledby="canonicalUpdatesOptIn"
-                             name="canonicalUpdatesOptIn"
-                             type="checkbox" />
-                      <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
-                    </label>
-                  </li>
-                  <li class="p-list__item u-sv3">
-                    By submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.
-                  </li>
-                  {# These are honey pot fields to catch bots #}
-                  <li class="u-off-screen">
-                    <label class="website" for="website">Website:</label>
-                    <input name="website"
-                           type="text"
-                           class="website"
-                           autocomplete="off"
-                           value=""
-                           id="website"
-                           tabindex="-1" />
-                  </li>
-                  <li class="u-off-screen">
-                    <label class="name" for="name">Name:</label>
-                    <input name="name"
-                           type="text"
-                           class="name"
-                           autocomplete="off"
-                           value=""
-                           id="name"
-                           tabindex="-1" />
-                  </li>
-                  {# End of honey pots #}
-                  <li class="p-list__item">
-                    <button type="submit" class="p-button--positive js-submit-button">Submit</button>
-                  </li>
-                </ul>
-                <div class="u-off-screen">
-                  <label for="Comments_from_lead__c">
-                    <h3 class="p-heading--4">Your comments</h3>
-                    <textarea id="Comments_from_lead__c"
-                              name="Comments_from_lead__c"
-                              rows="5"
-                              maxlength="2000"></textarea>
-                  </label>
-                </div>
-                <input type="hidden"
-                       aria-hidden="true"
-                       aria-label="hidden field"
-                       name="formid"
-                       value="{{ form_id }}" />
-                <input type="hidden"
-                       aria-hidden="true"
-                       aria-label="hidden field"
-                       name="returnURL"
-                       value={% if path %}"https://canonical.com{{ path }}/#contact-form-success"{% else %}{{ formData.returnUrl }}{% endif %} />
-                <input type="hidden"
-                       aria-hidden="true"
-                       aria-label="hidden field"
-                       name="Consent_to_Processing__c"
-                       value="yes" />
-                <input type="hidden"
-                       aria-hidden="true"
-                       aria-label="hidden field"
-                       name="utm_campaign"
-                       id="utm_campaign"
-                       value="" />
-                <input type="hidden"
-                       aria-hidden="true"
-                       aria-label="hidden field"
-                       name="utm_medium"
-                       id="utm_medium"
-                       value="" />
-                <input type="hidden"
-                       aria-hidden="true"
-                       aria-label="hidden field"
-                       name="utm_source"
-                       id="utm_source"
-                       value="" />
-                <input type="hidden"
-                       aria-hidden="true"
-                       aria-label="hidden field"
-                       name="utm_content"
-                       id="utm_content"
-                       value="" />
-                <input type="hidden"
-                       aria-hidden="true"
-                       aria-label="hidden field"
-                       name="utm_term"
-                       id="utm_term"
-                       value="" />
-                <input type="hidden"
-                       aria-hidden="true"
-                       aria-label="hidden field"
-                       name="GCLID__c"
-                       id="GCLID__c"
-                       value="" />
-                <input type="hidden"
-                       aria-hidden="true"
-                       aria-label="hidden field"
-                       name="Facebook_Click_ID__c"
-                       id="Facebook_Click_ID__c"
-                       value="" />
-                <input type="hidden"
-                       aria-hidden="true"
-                       aria-label="hidden field"
-                       id="preferredLanguage"
-                       name="preferredLanguage"
-                       maxlength="255"
-                       value="" />
-              {% endif %}
             </div>
           </div>
         </fieldset>
       </div>
     {% endfor %}
+
+    <div class="u-sv-3"></div>
+    <div class="row--50-50">
+      <div class="col"></div>
+      <div class="col">
+        <ul class="p-list">
+          <li class="p-list__item">
+            <label class="p-checkbox">
+              <input class="p-checkbox__input js-checkbox-visibility"
+                     value="yes"
+                     aria-labelledby="canonicalUpdatesOptIn"
+                     name="canonicalUpdatesOptIn"
+                     type="checkbox" />
+              <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive
+                information about
+              Canonical's products and services.</span>
+            </label>
+          </li>
+          <li class="p-list__item u-sv3">
+            By submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.
+          </li>
+          {# These are honey pot fields to catch bots #}
+          <li class="u-off-screen">
+            <label class="website" for="website">Website:</label>
+            <input name="website"
+                   type="text"
+                   class="website"
+                   autocomplete="off"
+                   value=""
+                   id="website"
+                   tabindex="-1" />
+          </li>
+          <li class="u-off-screen">
+            <label class="name" for="name">Name:</label>
+            <input name="name"
+                   type="text"
+                   class="name"
+                   autocomplete="off"
+                   value=""
+                   id="name"
+                   tabindex="-1" />
+          </li>
+          {# End of honey pots #}
+          <li class="p-list__item">
+            <button type="submit" class="p-button--positive js-submit-button">Submit</button>
+          </li>
+        </ul>
+        <div class="u-off-screen">
+          <label for="Comments_from_lead__c">
+            <h3 class="p-heading--4">Your comments</h3>
+            <textarea id="Comments_from_lead__c"
+                      name="Comments_from_lead__c"
+                      rows="5"
+                      maxlength="2000"></textarea>
+          </label>
+        </div>
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="formid"
+               value="{{ form_id }}" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="returnURL"
+               value={% if path %}"https://canonical.com{{ path }}/#contact-form-success"{% else %}{{ formData.returnUrl }}{% endif %} />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="Consent_to_Processing__c"
+               value="yes" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="utm_campaign"
+               id="utm_campaign"
+               value="" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="utm_medium"
+               id="utm_medium"
+               value="" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="utm_source"
+               id="utm_source"
+               value="" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="utm_content"
+               id="utm_content"
+               value="" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="utm_term"
+               id="utm_term"
+               value="" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="GCLID__c"
+               id="GCLID__c"
+               value="" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="Facebook_Click_ID__c"
+               id="Facebook_Click_ID__c"
+               value="" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               id="preferredLanguage"
+               name="preferredLanguage"
+               maxlength="255"
+               value="" />
+      </div>
+    </div>
   </form>
 </section>


### PR DESCRIPTION
## Done

- FIx faling form ID 5311 (homepage_form) used on homepage and contact us page
- Update `form-fields.html` to include checkbox Others text field and radio fields
- Note: incorrect /edge-computing form uses incorrect form ID, requested for the copy doc to update the form [here](https://docs.google.com/document/d/1pWMeqRw3io8DlHhNDq4tZ5EKDvLJbVS4vA1kQthzLMc/edit?disco=AAABkWDVkEg). Once this is resolved, we can remove `_homepage-form.html` entirely

## QA

- Go to https://canonical-com-1769.demos.haus/#get-in-touch and https://canonical-com-1769.demos.haus/contact-us#get-in-touch
- Submit payload
- See that it goes through Marketo


## Issue / Card

Fixes [WD-23250](https://warthogs.atlassian.net/browse/WD-23250)

## Screenshots

[if relevant, include a screenshot]


[WD-23250]: https://warthogs.atlassian.net/browse/WD-23250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ