### PR TITLE
feat: update /solutions/telco with two new blog links

### DIFF
--- a/templates/solutions/telco/index.html
+++ b/templates/solutions/telco/index.html
@@ -593,6 +593,12 @@
               <li class="p-list__item">
                 <a href="https://ubuntu.com/blog/telecom-security-how-to-safeguard-your-open-source-telco-infrastructure">Safeguarding your telco infrastructure with Ubuntu Pro</a>
               </li>
+              <li class="p-list__item">
+                <a href="https://ubuntu.com/blog/omdia-report-5g-edge-computing">How enterprises are responding to the growing demand for 5G edge computing</a>
+              </li>
+              <li class="p-list__item">
+                <a href="https://canonical.com/blog/bt-group-and-canonical-deliver-5g-to-uk-stadiums">BT Group and Canonical deliver 5G to UK stadiums</a>
+              </li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Add two new blog links to /solutions/telco

## QA

- Visit [/solutions/telco](https://canonical-com-1770.demos.haus/solutions/telco)
- Scroll down to the 'Learn more' section.
- Under "Access our blog" there should be two new links (the last two): "How enterprises are responding to the growing demand for 5G edge computing" and "BT Group and Canonical deliver 5G to UK stadiums"

## Issue / Card

https://warthogs.atlassian.net/browse/WD-23334

## Screenshots

<img width="1325" alt="Screenshot 2025-07-01 at 10 55 06 am" src="https://github.com/user-attachments/assets/cbf6cd3b-9715-441f-a9b1-be59a09bf20d" />

