### PR TITLE
feat: Add '_radio_' flag to radio buttons name attr

### DIFF
--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -56,7 +56,7 @@
                      class="p-radio__input"
                      type="radio"
                      aria-labelledby="less-5-machines"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="less than 5" />
               <span class="p-radio__label" id="less-5-machines">&lt;&nbsp;5 machines</span>
 
@@ -65,7 +65,7 @@
               <input type="radio"
                      aria-labelledby="15-to-15-machines"
                      class="p-radio__input"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="5 to 15 machines" />
               <span class="p-radio__label" id="15-to-15-machines">5&nbsp;&ndash;&nbsp;15 machines</span>
             </label>
@@ -73,7 +73,7 @@
               <input type="radio"
                      aria-labelledby="15-to-50-machines"
                      class="p-radio__input"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="15 to 50 machines" />
               <span class="p-radio__label" id="15-to-50-machines">15&nbsp;&ndash;&nbsp;50 machines</span>
             </label>
@@ -81,7 +81,7 @@
               <input type="radio"
                      aria-labelledby="50-to-100-machines"
                      class="p-radio__input"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="50 to 100 machines" />
               <span class="p-radio__label" id="50-to-100-machines">50&nbsp;&ndash;&nbsp;100 machines</span>
             </label>
@@ -89,7 +89,7 @@
               <input type="radio"
                      aria-labelledby="greater-than-100"
                      class="p-radio__input"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="greater than 100" />
               <span class="p-radio__label" id="greater-than-100">&gt;&nbsp;100 machines</span>
             </label>

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -98,7 +98,7 @@
                                  class="p-radio__input"
                                  type="radio"
                                  aria-labelledby="{{ field_id }}"
-                                 name="{{ fieldset_inputName }}"
+                                 name="_radio_{{ fieldset_inputName }}"
                                  value="{{ field_value }}"
                                  id="{{ field_id }}"
                                  {% if field.isSelected %}checked{% endif %} />


### PR DESCRIPTION
## Done

- Add '_radio_' flag to radio buttons name attr
- This coincides with the work [here](https://github.com/canonical/ubuntu.com/pull/15296) that adds a check for this flag

## QA

- Go to https://canonical-com-1775.demos.haus/observability/contact-us
- Disable JS
- Fill in and submit the form
- See that it successfully submits
- Check the payload makes it to Marketo

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-23428
