### PR TITLE
Feat(WD-23632): Updated Notification banner

### DIFF
--- a/templates/solutions/iot-and-devices/index.html
+++ b/templates/solutions/iot-and-devices/index.html
@@ -19,8 +19,12 @@
     <div class="u-fixed-width">
       <div class="p-notification--information is-inline">
         <div class="p-notification__content">
-          <h5 class="p-notification__title">Ubuntu 20.04 LTS is moving out of standard support in May 2025.</h5>
-          <p class="p-notification__message">We recommend migrating to the next LTS or upgrading to Ubuntu Pro. <a href="https://ubuntu.com/20-04">Learn more about your options</a>.</p>
+          <p class="p-notification__title p-heading--5">
+            <a href="https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare">The Standard Support period for Ubuntu 20.04 LTS has ended. Discover your options.</a>
+          </p>
+          <p class="p-notification__message">
+            <span>Take action today</span>
+          </p>
         </div>
       </div>
     </div>
@@ -693,6 +697,6 @@
     </div>
   </section>
 
-  {{ load_form('/solutions/iot-and-devices') | safe }}
+  {{ load_form("/solutions/iot-and-devices") | safe }}
 
 {% endblock %}


### PR DESCRIPTION
## Done

Updated notification banner to match with  https://ubuntu.com/
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Check if the banner on demo is same as https://ubuntu.com/

## Issue / Card
Fixes # [WD-23632](https://warthogs.atlassian.net/browse/WD-23632)


## Screenshots
Previous
![image](https://github.com/user-attachments/assets/b3338665-5444-4845-a8d4-b643ff0ce6ce)


Updated
![image](https://github.com/user-attachments/assets/340de549-0e06-40c9-baf1-d0faf62cde30)
