### PR TITLE
Bugfix: WD-23663 Replaced correct asset on solutions page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1240,8 +1240,7 @@
                       <div class="p-equal-height-row__item">
                         <div class="p-image-container">
                           <a href="https://ubuntu.com/engage/data-lake-spark-openstack" inert>
-
-                            {{ image(url="https://assets.ubuntu.com/v1/d626dcc8-A data lake on your cloud with Spark, Kubernetes and OpenStack.png",
+                            {{ image(url="https://assets.ubuntu.com/v1/d626dcc8-A%20data%20lake%20on%20your%20cloud%20with%20Spark,%20Kubernetes%20and%20OpenStack.png",
                                                         alt="",
                                                         width="1200",
                                                         height="676",
@@ -1291,7 +1290,7 @@
                       <div class="p-equal-height-row__item">
                         <div class="p-image-container">
                           <a href="https://www.youtube.com/watch?v=yQukQb-n99E" inert>
-                            {{ image(url="https://assets.ubuntu.com/v1/b5521efb-Re-inventing distroless with Chiselled Ubuntu containers.png",
+                            {{ image(url="https://assets.ubuntu.com/v1/b5521efb-Re-inventing%20distroless%20with%20Chiselled%20Ubuntu%20containers.png",
                                                         alt="",
                                                         width="1200",
                                                         height="676",
@@ -1322,7 +1321,7 @@
                       <div class="p-equal-height-row__item">
                         <div class="p-image-container">
                           <a href="https://ubuntu.com/engage/choose-a-database" inert>
-                            {{ image(url="https://assets.ubuntu.com/v1/6e5ed992-The architects guide to picking the right database.png",
+                            {{ image(url="https://assets.ubuntu.com/v1/6e5ed992-The%20architects%20guide%20to%20picking%20the%20right%20database.png",
                                                         alt="",
                                                         width="1200",
                                                         height="676",
@@ -1345,7 +1344,7 @@
                       <div class="p-equal-height-row__item">
                         <div class="p-image-container">
                           <a href="https://ubuntu.com/engage/cra-regulations-for-ubuntu" inert>
-                            {{ image(url="https://assets.ubuntu.com/v1/9ba9a348-Prepare your devices for the CRA.png",
+                            {{ image(url="https://assets.ubuntu.com/v1/9ba9a348-Prepare%20your%20devices%20for%20the%20CRA.png",
                                                         alt="",
                                                         width="1200",
                                                         height="676",
@@ -1368,7 +1367,7 @@
                       <div class="p-equal-height-row__item">
                         <div class="p-image-container">
                           <a href="https://ubuntu.com/engage/cloud-native-network-and-5G" inert>
-                            {{ image(url="https://assets.ubuntu.com/v1/dc92770f-Cloud-native network transformation and the 5G edge.png",
+                            {{ image(url="https://assets.ubuntu.com/v1/dc92770f-Cloud-native%20network%20transformation%20and%20the%205G%20edge.png",
                                                         alt="",
                                                         width="1200",
                                                         height="676",

--- a/templates/solutions/index.html
+++ b/templates/solutions/index.html
@@ -1053,7 +1053,7 @@
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--medium u-hide--small">
-                {{ image(url="https://assets.ubuntu.com/v1/a7100e33-telco.png",
+                {{ image(url="https://assets.ubuntu.com/v1/e115ce21-automotive.png",
                                 alt="",
                                 width="568",
                                 height="852",


### PR DESCRIPTION
## Done

- Replaced correct asset on solutions page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [demo](https://canonical-com-1786.demos.haus/solutions)
- Check the last section, previously telco and automotive had same assets
![image](https://github.com/user-attachments/assets/b3f90467-19ca-4fa5-89d0-7d3341a45645)


## Issue / Card

Fixes #[WD-23663](https://warthogs.atlassian.net/browse/WD-23663)

## Screenshots

[if relevant, include a screenshot]


[WD-23663]: https://warthogs.atlassian.net/browse/WD-23663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ