### PR TITLE
Bugfix:(WD-23689) Color change on hover on disabled button

### DIFF
--- a/static/sass/_pattern_homepage.scss
+++ b/static/sass/_pattern_homepage.scss
@@ -39,12 +39,11 @@
         $button-background-color: #cc420a,
         $button-hover-background-color: #b23a09,
         $button-active-background-color: #b23a09,
-        $button-disabled-background-color:
-          $colors--theme--button-positive-default,
+        $button-disabled-background-color: #cc420a,
         $button-border-color: #cc420a,
         $button-hover-border-color: #b23a09,
         $button-active-border-color: #b23a09,
-        $button-disabled-border-color: $colors--theme--button-positive-default,
+        $button-disabled-border-color: #cc420a,
         $button-text-color: $colors--theme--button-positive-text
       );
 
@@ -63,12 +62,11 @@
         $button-background-color: none,
         $button-hover-background-color: none,
         $button-active-background-color: none,
-        $button-disabled-background-color:
-          $colors--theme--button-positive-default,
+        $button-disabled-background-color: none,
         $button-border-color: #fc764c,
         $button-hover-border-color: #fe8a66,
         $button-active-border-color: #fe8a66,
-        $button-disabled-border-color: $colors--theme--button-positive-default,
+        $button-disabled-border-color: #fc764c,
         $button-text-color: $colors--theme--button-positive-text
       );
 


### PR DESCRIPTION
## Done

- fixed Color change on hover on disabled button

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [Demo](https://canonical-com-1788.demos.haus/#get-in-touch)
- Try to hover on disabled button and it shall stay same, compare it with live version on canonical.com, try submitting the form and see if the color of button remains same

## Issue / Card

Fixes # [WD-23689](https://warthogs.atlassian.net/browse/WD-23689)

## Screenshots

[if relevant, include a screenshot]


[WD-23689]: https://warthogs.atlassian.net/browse/WD-23689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ