### PR TITLE
feat: Add maas discourse API keys

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -69,6 +69,16 @@ env:
       key: charmhub-api-username
       name: discourse-api
 
+  - name: MAAS_DISCOURSE_API_KEY
+    secretKeyRef:
+      key: maas-api-key
+      name: discourse-api
+
+  - name: MAAS_DISCOURSE_API_USERNAME
+    secretKeyRef:
+      key: maas-api-username
+      name: discourse-api
+
   - name: SERVICE_ACCOUNT_EMAIL
     secretKeyRef:
       key: scheduler_account_email


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
