### PR TITLE
add anchore logo to solutions page

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -973,9 +973,3 @@ html {
 .scroll-section__content h2 {
   margin-top: 0;
 }
-
-.logo-section--flex {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -973,3 +973,9 @@ html {
 .scroll-section__content h2 {
   margin-top: 0;
 }
+
+.logo-section--flex {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}

--- a/templates/solutions/index.html
+++ b/templates/solutions/index.html
@@ -892,6 +892,16 @@
                       }}
                     </div>
                     <div class="p-logo-section__item">
+                      {{ image(url="https://assets.ubuntu.com/v1/e939b742-Anchore_Logo_White-500.png",
+                                            alt="Anchore",
+                                            width="562",
+                                            height="208",
+                                            hi_def=True,
+                                            loading="lazy",
+                                            attrs={"class": "p-logo-section__logo"},) | safe
+                      }}
+                    </div>                   
+                    <div class="p-logo-section__item">
                       {{ image(url="https://assets.ubuntu.com/v1/aeb0fef9-blackduck-logo.png",
                                             alt="Black Duck",
                                             width="309",

--- a/templates/solutions/index.html
+++ b/templates/solutions/index.html
@@ -880,7 +880,7 @@
                 <hr class="p-rule--muted" />
                 <h3 class="p-text--small-caps">Partners include</h3>
                 <div class="p-logo-section">
-                  <div class="p-logo-section__items">
+                  <div class="p-logo-section__items logo-section--flex">
                     <div class="p-logo-section__item">
                       {{ image(url="https://assets.ubuntu.com/v1/7542e42b-aikido-logo.png",
                                             alt="Aikido",
@@ -894,11 +894,11 @@
                     <div class="p-logo-section__item">
                       {{ image(url="https://assets.ubuntu.com/v1/e939b742-Anchore_Logo_White-500.png",
                                             alt="Anchore",
-                                            width="562",
-                                            height="208",
+                                            width="140",
+                                            height="52",
                                             hi_def=True,
                                             loading="lazy",
-                                            attrs={"class": "p-logo-section__logo"},) | safe
+                                            attrs={"class": "p-logo-section__logo", "style": "max-width: 140px; height: auto;"}, ) | safe
                       }}
                     </div>                   
                     <div class="p-logo-section__item">

--- a/templates/solutions/index.html
+++ b/templates/solutions/index.html
@@ -880,7 +880,7 @@
                 <hr class="p-rule--muted" />
                 <h3 class="p-text--small-caps">Partners include</h3>
                 <div class="p-logo-section">
-                  <div class="p-logo-section__items logo-section--flex">
+                  <div class="p-logo-section__items">
                     <div class="p-logo-section__item">
                       {{ image(url="https://assets.ubuntu.com/v1/7542e42b-aikido-logo.png",
                                             alt="Aikido",
@@ -892,13 +892,13 @@
                       }}
                     </div>
                     <div class="p-logo-section__item">
-                      {{ image(url="https://assets.ubuntu.com/v1/e939b742-Anchore_Logo_White-500.png",
+                      {{ image(url="https://assets.ubuntu.com/v1/2b628f5a-anchore-logo.png",
                                             alt="Anchore",
-                                            width="140",
-                                            height="52",
+                                            width="186",
+                                            height="208",
                                             hi_def=True,
                                             loading="lazy",
-                                            attrs={"class": "p-logo-section__logo", "style": "max-width: 140px; height: auto;"}, ) | safe
+                                            attrs={"class": "p-logo-section__logo"}, ) | safe
                       }}
                     </div>                   
                     <div class="p-logo-section__item">


### PR DESCRIPTION
## Done
- Add anchore logo to solutions page

## QA

- Go to [Demo](https://canonical-com-1802.demos.haus/solutions)
- Scroll down to `open source security ` section
- Check that there is Anchore logo

[Copy docs](https://docs.google.com/document/d/1vdnlbFSCidiNBXZ1zVKHWNIv1kl6C0vMmQAMYfz3yhU/edit?tab=t.0)

## Issue / Card https://warthogs.atlassian.net/browse/WD-23795

Fixes #

## Screenshots

[if relevant, include a screenshot]
