### PR TITLE
Update ISSUE_TEMPLATE.md, add a note about security advisory

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -9,6 +9,7 @@ assignees: ''
 
 *Note - filling in this form will file an issue against the canonical.com website*.
 *Please provide as many details as possible in order to provide maintainers more context about the issue. Don't skip/remove any of the sections below. If there is no data to provide in one of the sections, please specify it by typing "N/A" or similar. That will help maintainers reproduce the issue and be able to help quickly. Thanks.*
+*If you want to report a vulnerability, please don't use this form and report it [here](https://github.com/canonical/canonical.com/security/advisories/new) instead.*
 
 ## Summary
 


### PR DESCRIPTION
## Done

Since we utilize a security advisory for reporting vulnerabilities, it's worth pointing external contributors to it as well

