### PR TITLE
feat: fix blocked cookie policy

### DIFF
--- a/scripts/build-modules.sh
+++ b/scripts/build-modules.sh
@@ -2,7 +2,7 @@ rm -rf static/js/dist
 rm -rf static/js/modules
 
 mkdir -p static/js/modules/cookie-policy
-cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js static/js/modules/cookie-policy
+cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js static/js/modules/cookie-policy/cookie-loader.js
 
 mkdir -p static/js/modules/fuse
 cp node_modules/fuse.js/dist/fuse.js static/js/modules/fuse

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -213,7 +213,7 @@
           <script defer src="{{ versioned_static('js/source-inheritance.js') }}"></script>
           
           <!-- Cookie policy -->
-          <script src="{{ versioned_static('js/modules/cookie-policy/cookie-policy.js') }}"></script>
+          <script src="{{ versioned_static('js/modules/cookie-policy/cookie-loader.js') }}"></script>
           <script src="{{ versioned_static('js/dist/cookie-policy-with-callback.js') }}"></script>
 
            <!-- Google Tag Manager -->


### PR DESCRIPTION
## Problem
Adblockers, such as those built into brave and firefox are blocking requests for the `cookie-policy.js` file, as it seems to be matching their rules.

## Done

Updated the name to a more adblocker-friendly one. 

## QA

- View the [demo](https://canonical-com-1805.demos.haus/) in an incognito browser
- Check that there are no cpNs (cookie policy) related errors in the console
- Accept the cookie policy and browse the page
- Also try rejecting the cookie policy, or selecting multiple options and confirm there are no console errors
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/1798
Addresses [WD-23839](https://warthogs.atlassian.net/browse/WD-23839)

[WD-23839]: https://warthogs.atlassian.net/browse/WD-23839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ