### PR TITLE
feat: add autocomplete attributes to form elements in form-generator template

### DIFF
--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -37,6 +37,7 @@
                           id="firstName"
                           name="firstName"
                           maxlength="255"
+                          autocomplete="given-name"
                           type="text" />                              
                   <label class="is-required"
                           for="lastName">Last name:</label>
@@ -44,6 +45,7 @@
                           id="lastName"
                           name="lastName"
                           maxlength="255"
+                          autocomplete="family-name"
                           type="text" />
                   <label class="is-required"
                             for="email">Email:</label>
@@ -51,6 +53,7 @@
                           id="email"
                           name="email"
                           maxlength="255"
+                          autocomplete="email"
                           type="email"
                           pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
                 {% endif %}
@@ -84,6 +87,7 @@
                                id="{{ field_id }}"
                                name="{{ field_id }}"
                                maxlength="255"
+                               autocomplete="{% if field.type == 'tel' %}tel{% elif field.type == 'email' %}email{% elif field.label and field.label == 'Company' or field.label == 'Company name' %}organization{% elif field.label and field.label == 'Job title' %}organization-title{% endif %}"
                                type="{{ field.type }}"
                                {% if field.type=="email" %}pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"{% endif %} />
                       {% elif field.type == "long-text" %}

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -87,7 +87,7 @@
                                id="{{ field_id }}"
                                name="{{ field_id }}"
                                maxlength="255"
-                               autocomplete="{% if field.type == 'tel' %}tel{% elif field.type == 'email' %}email{% elif field.label and field.label == 'Company' or field.label == 'Company name' %}organization{% elif field.label and field.label == 'Job title' %}organization-title{% endif %}"
+                               autocomplete="{% if field.type == 'tel' %}tel{% elif field.type == 'email' %}email{% elif field.label and ( field.label == 'Company' or field.label == 'Company name' ) %}organization{% elif field.label and field.label == 'Job title' %}organization-title{% endif %}"
                                type="{{ field.type }}"
                                {% if field.type=="email" %}pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"{% endif %} />
                       {% elif field.type == "long-text" %}


### PR DESCRIPTION
## Done

- Added `autocomplete` attribute depending on the type of field
  -  First name (given-name)
  -  Last name (family-name)
  - Email (email)
  - Phone number (tel)
  - Company/Company name (organization)
  - Job title (organization-title)

## QA

- Open any form, for example https://canonical-com-1810.demos.haus/solutions/industrial#get-in-touch
- Verify the autocomplete fields work in personal information section
