### PR TITLE
[WD-24063] fix: modal form not opening on canonical.com/solutions/cloud-native-development

### DIFF
--- a/static/js/tabbed-content.js
+++ b/static/js/tabbed-content.js
@@ -213,6 +213,10 @@
         tabContainer.querySelectorAll("[aria-controls]")
       );
 
+      // remove any button that invokes a modal
+      // for example, there might be a "get in touch" button within a tab
+      tabs = tabs.filter((tab) => !tab.classList.contains("js-invoke-modal"));
+
       // If the tab list container has pagination buttons
       // define the target buttons by matching the tablist data attribute
       // to the button container ID


### PR DESCRIPTION
## Done

- Fixed the case where a modal trigger button be within tabbed content

## QA

- View the site in your web browser at: https://canonical-com-1814.demos.haus/solutions/cloud-native-development
- Click on the "Get in touch" button and verify the modal opens up
- Close modal, scroll down and find the "Let us build it" tab in "Choose your app modernization journey" section
- Select he tab, and click on "Get in touch" button.
- Verify the modal form opens up.

## Issue / Card

Fixes #[WD-24063](https://warthogs.atlassian.net/browse/WD-24063)

[WD-24063]: https://warthogs.atlassian.net/browse/WD-24063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ