### PR TITLE
[WD-22202] feat: Adjust sliding navigation menu animation speed 

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -165,6 +165,11 @@ $navigation-heading-color: #fff9;
     justify-content: space-between;
   }
 
+  .p-navigation--sliding .p-navigation__dropdown.is-full-width 
+  .p-navigation__dropdown-content--full-width {
+    @include vf-animation(all, brisk, out);
+  }
+
   .p-navigation--reduced,
   .p-navigation--sliding {
     .p-navigation__dropdown.is-full-width


### PR DESCRIPTION
## Done

- Adjust animation speed for the sliding navigation to make it bit slower and match ubuntu.com's slide navigation animation speed.

## QA

- View the site locally in your web browser at: https://canonical-com-1816.demos.haus/
- Click on menu items (Products, Solution etc.) to toggle menu and verify the sliding navigation works and speed matches that of ubuntu.com

## Issue / Card

Fixes #[WD-22202](https://warthogs.atlassian.net/browse/WD-22202)


[WD-22202]: https://warthogs.atlassian.net/browse/WD-22202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ