### PR TITLE
chore: Bump module versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask-base==2.6.0
-canonicalwebteam.blog==6.4.6
+canonicalwebteam.blog==6.5.0
 canonicalwebteam.http==1.0.4
-canonicalwebteam.image-template==1.5.0
+canonicalwebteam.image-template==1.7.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.discourse==6.2.0
 canonicalwebteam.search==2.1.2


### PR DESCRIPTION
## Done

- Bumped versions for `image-template` and `blog` modules

## QA

- View the site locally in your web browser at: https://canonical-com-1819.demos.haus/
- Verify the the images are loading as expected
- Visit https://canonical-com-1819.demos.haus/blog and open random blogs
- For example: https://canonical-com-1819.demos.haus/blog/raising-the-bar-for-automotive-cybersecurity-in-open-source-canonicals-iso-sae-21434-certification
- Verify the blogs are working fine
