### PR TITLE
feat: add bubble nav to /data/valkey

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -197,6 +197,20 @@ postgresql:
     - title: Docs
       path: /data/docs/postgresql/iaas
 
+valkey:
+  title: Valkey
+  path: /data/valkey
+
+  parent:
+    - title: All data solutions
+    - path: /data
+
+  children:
+    - title: Overview
+      path: /data/valkey
+    - title: What is Valkey
+      path: /data/valkey/what-is-valkey
+
 mysql:
   title: MySQL
   path: /data/mysql
@@ -250,7 +264,7 @@ telco:
 data-and-ai:
   title: Data & AI
   path: /solutions/data-and-ai
-  
+
   children:
     - title: Data lakehouse
       path: /data/lakehouse


### PR DESCRIPTION
## Done

- Add bubble nav to /data/valkey

## QA

- Go to [/data/valkey](https://canonical-com-1836.demos.haus/data/valkey).
- Check that there is a secondary nav item for "What is Valkey"

## Issue / Card

https://warthogs.atlassian.net/browse/WD-24282

## Screenshots

<img width="1509" height="285" alt="Screenshot 2025-08-04 at 9 53 19 am" src="https://github.com/user-attachments/assets/11fc04f7-3b99-408b-b308-b71bc279a59a" />



