### PR TITLE
WD-24528: Add ESA video to the public sector page

### DIFF
--- a/templates/public-sector/index.html
+++ b/templates/public-sector/index.html
@@ -271,6 +271,14 @@
                  id="esa-tab"
                  role="tabpanel"
                  aria-labelledby="esa">
+
+              <div class="u-embedded-media">
+                <lite-youtube videoid="JKZKpXaJsPI" width="560" height="315" posterquality="maxresdefault" videotitle="The Tech Behind Europe’s Space Missions | Canonical x ESA" class="u-embedded-media__element">
+                <a href="https://www.youtube.com/watch?v=JKZKpXaJsPI" title="Play Video">
+                  <span class="lyt-visually-hidden">The Tech Behind Europe’s Space Missions | Canonical x ESA</span>
+                </a>
+                </lite-youtube>
+              </div>
               {{ image(url="https://assets.ubuntu.com/v1/279a0e2f-esa-logo@3x.png",
                             alt="ESA",
                             width="1800",
@@ -404,7 +412,7 @@
        width="588"
        height="478" />'
     }
-    ],) 
+    ],)
   }}
 
   <section class="p-section">
@@ -482,7 +490,7 @@
        width="210"
        height="478" />'
     }
-    ],) 
+    ],)
   }}
 
   <section class="p-section">


### PR DESCRIPTION
## Done

Add ESA video to the public sector page

## QA

- Open the demo
- Go to /public-sector
- Scroll to the "Our solutions in action" section
- Click on ESA tab
- Play the video and check its the right one.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-24528