### PR TITLE
qa: add failing form fields

### DIFF
--- a/templates/openstack/form-data.json
+++ b/templates/openstack/form-data.json
@@ -32,6 +32,12 @@
                 "type": "tel",
                 "id": "phone",
                 "label": "Phone number"
+              },
+              {
+                "type": "text",
+                "id": "test",
+                "label": "Test field",
+                "isRequired": true
               }
             ]
           }

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -1,6 +1,6 @@
 <section class="p-section">
   <form {% if isModal %}class="js-modal-form"{% endif %}
-        action="https://ubuntu.com/marketo/submit"
+        action="https://ubuntu-com-15419.demos.haus/marketo/submit"
         method="post"
         id="mktoForm_{{ form_id }}"
         onsubmit="getCustomFields(event)">


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
