### PR TITLE
feat: add /mlops/feast to secondary nav

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -88,6 +88,15 @@ lxd:
     - title: Forum
       path: https://discourse.ubuntu.com/c/lxd/126?_ga=2.69179345.1978494405.1700868870-354120313.1700868870
 
+
+mlops:
+  title: MLOps
+  path: /mlops
+
+  children:
+    - title: Feast
+      path: /mlops/feast
+
 mongodb:
   title: MongoDB
   path: /data/mongodb


### PR DESCRIPTION
## Done

- Add feast page to secondary nav
- Note: /mlops page is still in review on this separate PR #1842 

## QA

- Go to https://canonical-com-1846.demos.haus/mlops/feast
- See that the secondary nav has Feast

## Issue / Card

Fixes [WD-23822](https://warthogs.atlassian.net/browse/WD-23822)

## Screenshots

[if relevant, include a screenshot]


[WD-23822]: https://warthogs.atlassian.net/browse/WD-23822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ