### PR TITLE
Update link to operator tutorial in cloud-native solution

### DIFF
--- a/templates/solutions/cloud-native-development/index.html
+++ b/templates/solutions/cloud-native-development/index.html
@@ -157,7 +157,7 @@
                   <a href="https://ubuntu.com/containers/chiseled">Chisel your containers</a> &ndash; trim out what you don't need for maximum efficiency. Chisel is a tool to create minimal Ubuntu containers comprising only the application and its runtime dependencies. It's the Canonical take on distro-less containers.
                 </li>
                 <li class="p-list__item has-bullet">
-                  <a href="https://ops.readthedocs.io/en/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/">Automate application lifecycle management with charms</a> &ndash; let Kubernetes operators do the heavy lifting.
+                  <a href="https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/">Automate application lifecycle management with charms</a> &ndash; let Kubernetes operators do the heavy lifting.
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
On the [Cloud-native app development](https://canonical.com/solutions/cloud-native-development) page, there's a link: Choose your app modernization journey > Build your own > Automate application lifecycle management with charms

This link points to a tutorial in the Ops documentation. We recently moved the Ops documentation to documentation.ubuntu.com, so it would be good to update the link. Not time critical. The link hasn't broken, because there's a redirect. But I figured it would be best to keep the source in good shape.