### PR TITLE
feat: Migrate jaas.ai to c.com/jaas

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -491,7 +491,7 @@ products:
             url: https://charmhub.io/
           - title: JAAS
             description: Auditing and compliance for Juju
-            url: https://jaas.ai/
+            url: /jaas
           - title: Mir
             description: Display server library
             url: /mir

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1419,3 +1419,20 @@ maas/deprecations/MD3: https://discourse.maas.io/t/6216
 maas/deprecations/MD4: https://discourse.maas.io/t/7440
 maas/deprecations/MD5: https://discourse.maas.io/t/10203
 maas/deprecations/MD6: https://discourse.maas.io/t/11245
+
+# Jaas.ai migration redirects
+jaas/docs: https://canonical-jaas-documentation.readthedocs-hosted.com/en/latest/
+jaas/docs/(?P<path>.*): https://canonical-jaas-documentation.readthedocs-hosted.com/en/latest/
+jaas/get-started/?: https://juju.is/docs
+jaas/tutorials: https://juju.is/docs
+jaas/tutorials/(?P<path>.*): https://juju.is/docs
+jaas/store: https://charmhub.io
+jaas/static/img/logos/juju-logo.svg: https://assets.ubuntu.com/v1/7e21b535-logo-juju.svg
+jaas/big-data: https://charmhub.io/?base=all&filter=big-data
+jaas/containers: https://charmhub.io/?base=all&filter=containers
+jaas/kubernetes: https://charmhub.io/?base=kubernetes
+jaas/openstack: https://charmhub.io/?base=linux
+jaas/blog: https://juju.is/blog
+jaas/u/(?P<username>.*)/(?P<charm_or_bundle_name>.*): https://charmhub.io/{username}-{charm_or_bundle_name}
+jaas/u/(?P<username>.*)/(?P<charm_or_bundle_name>.*)/(?P<series_or_version>.*): https://charmhub.io/{username}-{charm_or_bundle_name}
+jaas/u/(?P<username>.*)/(?P<charm_or_bundle_name>.*)/(?P<series_or_version>.*)/(?P<version>.*): https://charmhub.io/{username}-{charm_or_bundle_name}

--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -378,3 +378,17 @@ kubeflow:
       path: /mlops/kubeflow/what-is-kubeflow
     - title: Docs
       path: https://documentation.ubuntu.com/charmed-kubeflow/
+
+jaas:
+  title: JAAS
+  path: /jaas
+
+  children:
+    - title: Overview
+      path: /jaas
+    - title: Juju
+      path: https://juju.is
+    - title: Charmhub
+      path: https://charmhub.io
+    - title: Docs
+      path: https://documentation.ubuntu.com/jaas

--- a/static/js/tabbed-content.js
+++ b/static/js/tabbed-content.js
@@ -104,25 +104,11 @@
         if (tabPanel) {
           tabPanel.focus({ preventScroll: true });
         }
-
-        // For tablist containers with pagination
-        // toggle buttons state on tab click
-        if (prevButton && nextButton) {
-          if (index === 0) {
-            prevButton.disabled = true;
-            nextButton.disabled = false;
-          } else if (index > 0 && index < tabs.length - 1) {
-            prevButton.disabled = false;
-            nextButton.disabled = false;
-          } else {
-            prevButton.disabled = false;
-            nextButton.disabled = true;
-          }
-        }
       });
 
       tab.addEventListener("focus", () => {
         setActiveTab(tab, tabs);
+        updatePaginationButtonStates(prevButton, nextButton, tabs, tabContainer);
       });
 
       tab.index = index;
@@ -169,6 +155,27 @@
     }
   };
 
+  /**
+   * Disables pagination buttons based on the current active tab.
+   */
+  const updatePaginationButtonStates = (prevButton, nextButton, tabs, tabContainer) => {
+    if (prevButton && nextButton) {
+      const currentTab = tabContainer.querySelector(".p-tabs__item[aria-selected='true']");
+      const currentIndex = tabs.indexOf(currentTab);
+      
+      if (currentIndex === 0) {
+        prevButton.disabled = true;
+        nextButton.disabled = false;
+      } else if (currentIndex > 0 && currentIndex < tabs.length - 1) {
+        prevButton.disabled = false;
+        nextButton.disabled = false;
+      } else {
+        prevButton.disabled = false;
+        nextButton.disabled = true;
+      }
+    }
+  }
+  
   /**
       Cycles through an array of tab elements and ensures
       only the target tab and its content are selected

--- a/static/sass/_pattern_forms.scss
+++ b/static/sass/_pattern_forms.scss
@@ -69,4 +69,5 @@
 
 .p-fieldset-section {
   border: none;
+  padding: 0;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -976,3 +976,8 @@ html {
 .scroll-section__content h2 {
   margin-top: 0;
 }
+
+.u-align--cta {
+  align-self: center;
+  margin-bottom: 1.25rem;
+}

--- a/templates/dqlite/index.html
+++ b/templates/dqlite/index.html
@@ -34,7 +34,7 @@
                href="https://github.com/canonical/dqlite"
                aria-label="Follow @canonical on GitHub"></a>
             <noscript>
-              <a class="p-button" href="https://github.com/canonical/dqlite">Follow @canonical on Github</a>
+              <a class="p-button" href="https://github.com/canonical/dqlite">Follow @canonical/dqlite on Github</a>
             </noscript>
             <a class="github-button"
                data-size="large"

--- a/templates/dqlite/index.html
+++ b/templates/dqlite/index.html
@@ -28,7 +28,7 @@
           Dqlite is a fast, embedded, persistent SQL database with Raft consensus that is perfect for fault-tolerant IoT and Edge devices.
         </p>
         <div class="p-cta-block">
-          <div>
+          <div class="u-align--cta">
             <a class="github-button"
                data-size="large"
                href="https://github.com/canonical/dqlite"

--- a/templates/jaas/form-data.json
+++ b/templates/jaas/form-data.json
@@ -1,0 +1,40 @@
+{
+  "form": {
+    "/jaas": {
+      "templatePath": "/jaas/index.html",
+      "isModal": true,
+      "modalId": "jaas-modal",
+      "formData": {
+        "title": "Get in touch",
+        "formId": "5332",
+        "returnUrl": "https://canonical.com/jaas#contact-form-success",
+        "product": ""
+      },
+      "fieldsets": [
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number"
+            }
+          ]
+        },
+        {
+          "title": "Tell us more about your needs",
+          "id": "about-use-case",
+          "isRequired": false,
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "about-use-case"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/templates/jaas/index.html
+++ b/templates/jaas/index.html
@@ -1,0 +1,685 @@
+{% extends 'base_index.html' %}
+
+{% block title %}Manage large scale Juju deployments with Jaas{% endblock %}
+
+{% block meta_description %}
+  JAAS (Juju as a service) provides a single location to interact, manage and audit your Juju infrastructure using a dashboard or the Juju CLI commands.
+{% endblock %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1SMflo2V-EdAEDmYhShMjn0wOCIfsp_gEc-Nc5q3uWh4/edit
+{% endblock %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block content %}
+  <section class="p-section--hero u-no-padding--bottom">
+    <div class="grid-row--50-50 p-section--shallow">
+      <div class="grid-col">
+        <h1>Take control of your large-scale Juju deployments</h1>
+      </div>
+      <div class="grid-col">
+        <p>JAAS is Juju for enterprise.</p>
+        <div class="p-cta-block">
+          <a href="/contact-us"
+             class="p-button--positive js-invoke-modal"
+             aria-controls="jaas-modal">Contact us</a>
+        </div>
+      </div>
+    </div>
+    <div class="u-fixed-width">
+      <div class="p-image-container u-hide--medium u-hide--small">
+        {{ image(url="https://assets.ubuntu.com/v1/d7c20674-JAAS-arch-diagram.svg",
+                alt="",
+                height="933",
+                width="1848",
+                hi_def=True,
+                loading="auto",
+                attrs={ "class": "p-image-container__image" }) | safe
+        }}
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="is-fixed-width" />
+    <div class="grid-row">
+      <div class="grid-col-4 grid-col-medium-4 p-section--shallow">
+        <h2>Main JAAS components</h2>
+      </div>
+      <div class="grid-col-4 grid-col-medium-4">
+        <div class="p-section--shallow">
+          <div class="grid-row">
+            <div class="grid-col-2">
+              <h3 class="p-text--small-caps">Backend API server (JIMM)</h3>
+            </div>
+            <div class="grid-col-2">
+              <p>
+                JAAS has a backend API server (JIMM) that is responsible for managing all interactions with the downstream, Juju controllers.
+                <br />
+                Admins and users can interact with this service through the same Juju CLI and Terraform Provider for Juju.
+              </p>
+            </div>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="p-section--shallow">
+          <div class="grid-row">
+            <div class="grid-col-2">
+              <h3 class="p-text--small-caps">Dashboard</h3>
+            </div>
+            <div class="grid-col-2">
+              <p>A graphical user interface to simplify common administrative operations.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+    </div>
+    <div class="grid-row">
+      <div class="grid-col-2">
+        <div class="p-section--shallow">
+          <h2>Why use JAAS?</h2>
+        </div>
+      </div>
+      <div class="grid-col-6">
+        <div class="p-section--shallow">
+          <div class="grid-row">
+            <div class="grid-col-2">
+              <h3 class="p-heading--5">Have to manage multiple Juju controllers</h3>
+            </div>
+            <div class="grid-col-4">
+              <p>
+                JAAS simplifies the provisioning and lifecycle management of controllers and charms at scale, automating activities like model migrations and controller upgrades
+              </p>
+            </div>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="p-section--shallow">
+          <div class="grid-row">
+            <div class="grid-col-2">
+              <h3 class="p-heading--5">Need to meet tighter security and compliance requirements</h3>
+            </div>
+            <div class="grid-col-4">
+              <p>
+                JAAS offers additional security features like single sign on (SSO) on both the dashboard and the cli, permission management, fine grained juju controller activity auditing and soon an SSH proxy and service accounts for the Terraform provider
+              </p>
+            </div>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="p-section--shallow">
+          <div class="grid-row">
+            <div class="grid-col-2">
+              <h3 class="p-heading--5">Prefer to interact with your system with a web interface</h3>
+            </div>
+            <div class="grid-col-4">
+              <p>
+                The dashboard offer a simplified way for administrators to perform common administrative operations and monitor the state of the deployment
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+    </div>
+    <div class="p-section--shallow">
+      <div class="u-fixed-width">
+        <h2>
+          Enhanced control and visibility
+          <br />
+          for your Juju deployment
+        </h2>
+      </div>
+    </div>
+    <div class="grid-row--50-50">
+      <div class="grid-col">
+        <p style="max-width: 50rem;">
+          JAAS is your centralised enterprise control plane for Juju deployments.
+          <br />
+          With JAAS you can:
+        </p>
+        <div class="p-side-navigation homepage-tabs" style="margin-top: 0;">
+          <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small"
+              role="tablist"
+              data-tablist="jaas-features">
+            <li>
+              <button class="p-tabs__item"
+                      role="tab"
+                      aria-selected="true"
+                      aria-controls="view-models-and-controllers-details-tab"
+                      id="view-models-and-controllers-details">View models and controllers details</button>
+            </li>
+            <li>
+              <button class="p-tabs__item"
+                      role="tab"
+                      aria-selected="false"
+                      aria-controls="run-actions-tab"
+                      id="run-actions">Run actions</button>
+            </li>
+            <li>
+              <button class="p-tabs__item"
+                      role="tab"
+                      aria-selected="false"
+                      aria-controls="configure-applications-tab"
+                      id="configure-applications">Configure applications</button>
+            </li>
+            <li>
+              <button class="p-tabs__item"
+                      role="tab"
+                      aria-selected="false"
+                      aria-controls="onboard-controllers-and-manage-access-tab"
+                      id="onboard-controllers-and-manage-access">Onboard controllers and manage access</button>
+            </li>
+            <li>
+              <button class="p-tabs__item"
+                      role="tab"
+                      aria-selected="false"
+                      aria-controls="run-audits-and-reports-tab"
+                      id="run-audits-and-reports">Run audits and reports</button>
+            </li>
+            <li>
+              <button class="p-tabs__item"
+                      role="tab"
+                      aria-selected="false"
+                      aria-controls="search-and-filter-tab"
+                      id="search-and-filter">Search and filter</button>
+            </li>
+          </ul>
+          <form class="u-hide--large u-hide--medium">
+          <select name="tabSelect" data-tablist="jaas-features">
+            <option value="view-models-and-controllers-details-tab" selected="">View models and controllers details</option>
+            <option value="run-actions-tab">Run actions</option>
+            <option value="configure-applications-tab">Configure applications</option>
+            <option value="onboard-controllers-and-manage-access-tab">Onboard controllers and manage access</option>
+            <option value="run-audits-and-reports-tab">Run audits and reports</option>
+            <option value="search-and-filter-tab">Search and filter</option>
+          </select>
+        </form>
+        </div>
+      </div>
+      <div class="grid-col" data-tablist="jaas-features">
+        <div class="p-tabs__content"
+             role="tabpanel"
+             id="view-models-and-controllers-details-tab"
+             aria-labelledby="view-models-and-controllers-details">
+          {{ image(url="https://assets.ubuntu.com/v1/90922406-integrations.png",
+                    alt="",
+                    height="669",
+                    width="1031",
+                    hi_def=True,
+                    loading="auto") | safe
+          }}
+          <p style="max-width: 500rem;">
+            Drill down to view the details of everything that is deployed inside a model, such as applications, integrations, units, and more.
+          </p>
+        </div>
+        <div class="p-tabs__content"
+             role="tabpanel" id="run-actions-tab" aria-controls="run-actions">
+          {{ image(url="https://assets.ubuntu.com/v1/e70dab91-run-action.png",
+                    alt="",
+                    height="669",
+                    width="1031",
+                    hi_def=True,
+                    loading="auto",) | safe
+          }}
+          <p>Execute Juju action from the UI and view the resulting logs to confirm their status.</p>
+        </div>
+        <div class="p-tabs__content"
+             role="tabpanel" id="configure-applications-tab" aria-controls="configure-applications">
+          {{ image(url="https://assets.ubuntu.com/v1/1ac0ed08-configure-app.png",
+                    alt="",
+                    height="669",
+                    width="1031",
+                    hi_def=True,
+                    loading="auto",) | safe
+          }}
+          <p>Perform common administrative operations and apply machine configurations.</p>
+        </div>
+        <div class="p-tabs__content"
+             role="tabpanel" id="onboard-controllers-and-manage-access-tab" aria-controls="onboard-controllers-and-manage-access">
+          {{ image(url="https://assets.ubuntu.com/v1/d54720f1-jaas-controllers.png",
+                    alt="",
+                    height="669",
+                    width="1031",
+                    hi_def=True,
+                    loading="auto",) | safe
+          }}
+          <p>Onboard controllers and add, remove or manage user access to models and controllers.</p>
+        </div>
+        <div class="p-tabs__content"
+             role="tabpanel" id="run-audits-and-reports-tab" aria-controls="run-audits-and-reports">
+          {{ image(url="https://assets.ubuntu.com/v1/8d0f47a6-action-logs.png",
+                    alt="",
+                    height="669",
+                    width="1031",
+                    hi_def=True,
+                    loading="auto",) | safe
+          }}
+          <p>Access the logs from your deployment in a single, centralised location.</p>
+        </div>
+        <div class="p-tabs__content"
+             role="tabpanel" id="search-and-filter-tab" aria-controls="search-and-filter">
+          {{ image(url="https://assets.ubuntu.com/v1/f3ff0a1b-searchandfilter.jpg",
+                    alt="",
+                    height="669",
+                    width="1031",
+                    hi_def=True,
+                    loading="auto",) | safe
+          }}
+          <p style="max-width: 500rem;">
+            Perform complex searches/filters through your entire deployment and share the result through a unique URL.
+          </p>
+        </div>
+        <div class="p-section--shallow u-hide--small">
+          <hr class="p-rule--muted" />
+          <div class="js-tab-buttons" id="jaas-features">
+            <button class="p-button js-prev-tab" disabled>&lsaquo;&nbsp;Previous</button>
+            <button class="p-button js-next-tab">Next&nbsp;&rsaquo;</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section u-no-padding--bottom">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+    </div>
+    <div class="p-section--shallow">
+      <div class="u-fixed-width">
+        <h2>
+          Familiar experience and tighter
+          <br />
+          security controls
+        </h2>
+      </div>
+    </div>
+    <div class="p-section">
+      <div class="grid-row">
+        <div class="grid-col-6 grid-col-start-large-3">
+          <hr class="p-rule--muted" />
+          <div class="p-section--shallow">
+            <div class="grid-row">
+              <div class="grid-col-2">
+                <h3 class="p-heading--5">Centralised Terraform Provider</h3>
+              </div>
+              <div class="grid-col-4">
+                <p>
+                  JAAS can make use of the Juju Terraform provider to apply plans to all managed controllers. The provider supports Oauth client credentials authentication and its access is controlled by the authorisation system.
+                </p>
+              </div>
+            </div>
+          </div>
+          <hr class="p-rule--muted" />
+          <div class="p-section--shallow">
+            <div class="grid-row">
+              <div class="grid-col-2">
+                <h3 class="p-heading--5">
+                  SSH Proxy
+                  <br />
+                  (Coming soon)
+                </h3>
+              </div>
+              <div class="grid-col-4">
+                <p>
+                  Administrators can use JAAS to SSH into all units of managed controllers, reducing the need to grant access to vast areas of the network.
+                  <br />
+                  SSH access can be granted through a fine grained entitlement and session logs are kept in a tamper proof audit log.
+                </p>
+              </div>
+            </div>
+          </div>
+          <hr class="p-rule--muted" />
+          <div class="p-section--shallow">
+            <div class="grid-row">
+              <div class="grid-col-2">
+                <h3 class="p-heading--5">Single sign on (SSO)</h3>
+              </div>
+              <div class="grid-col-4">
+                <p>
+                  JAAS supports integration with external identity providers through OIDC, enforcing strong authentication on both the cli and the web dashboard
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="u-fixed-width">
+      <div class="p-image-container u-hide--medium u-hide--small">
+        {{ image(url="https://assets.ubuntu.com/v1/b6442458-JAAS%20illustration.svg",
+                alt="",
+                height="1028",
+                width="2462",
+                hi_def=True,
+                loading="auto",
+                attrs={ "class": "p-image-container__image", }) | safe
+        }}
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+    </div>
+    <div class="grid-row">
+      <div class="grid-col-4">
+        <div class="p-section--shallow">
+          <h2>
+            JAAS is available
+            <br />
+            through Ubuntu Pro
+          </h2>
+        </div>
+      </div>
+      <div class="grid-col-4">
+        <div class="p-section--shallow">
+          <p>
+            You can deploy JAAS on your infrastructure with an Ubuntu Pro subscription. Ubuntu Pro is a comprehensive subscription from Canonical which includes:
+          </p>
+          <hr class="p-rule--muted" />
+          <ul class="p-list--divided">
+            <li class="p-list__item has-bullet">JAAS charms and sample Terraform plan</li>
+            <li class="p-list__item has-bullet">Access to our world-class technical team and knowledge base</li>
+            <li class="p-list__item has-bullet">Security patching for all your software</li>
+            <li class="p-list__item has-bullet">Option of a dedicated Canonical support engineer on your premises</li>
+            <li class="p-list__item has-bullet">24/7 phone, portal and email support (optional)</li>
+          </ul>
+          <div class="p-cta-block">
+            <a href="/contact-us"
+               class="p-button--positive js-invoke-modal"
+               aria-controls="jaas-modal">Contact us to get started</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+    </div>
+    <div class="p-section--shallow">
+      <div class="u-fixed-width">
+        <h2>Canonical products are trusted by 10,000+ engineers at</h2>
+      </div>
+    </div>
+    <div class="u-fixed-width">
+      <div class="p-logo-section">
+        <div class="p-logo-section__items u-no-margin--bottom">
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/7040f392-Ubuntu-logo.png",
+                        alt="Ubuntu logo",
+                        width="218",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/a76d4ee3-deutsche-telekom.png",
+                        alt="Deutsche Telekom logo",
+                        width="257",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/0a6968e6-ibm-logo.png",
+                        alt="IBM logo",
+                        width="125",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/cc65269a-intel-new-logo.png",
+                        alt="Intel logo",
+                        width="133",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/ea63a7ba-microsoft-azure-2021.png",
+                        alt="Microsoft Azure logo",
+                        width="78",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/f3d556d7-cisco-logo.png",
+                        alt="Cisco logo",
+                        width="225",
+                        height="372",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/757f59f0-china-telecom-logo.png",
+                        alt="China Telecom logo",
+                        width="257",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/f044cea8-bt-logo.png",
+                        alt="BT logo",
+                        width="111",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/89365c81-nec-logo.png",
+                        alt="NEC logo",
+                        width="172",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/4b74a5f4-hp-logo.png",
+                        alt="Hewlett Packard logo",
+                        width="110",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/02d41af7-yahoo-jp-logo.png",
+                        alt="Yahoo! Japan logo",
+                        width="210",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/067bffc3-verizon-logo.png",
+                        alt="verizon logo",
+                        width="257",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/05d9f06b-bell-logo.png",
+                        alt="Bell logo",
+                        width="87",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/5482ad8a-swissquote-logo.png",
+                        alt="Swissquote logo",
+                        width="257",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/8848ee2f-panasonic-logo.png",
+                        alt="Panasonic logo",
+                        width="254",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/e0b84fa2-scania-logo.png",
+                        alt="Scania logo",
+                        width="255",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/d8060c1d-rabobank-logo.png",
+                        alt="Rabobank logo",
+                        width="257",
+                        height="259",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/e2fa6efb-tele2-logo.png",
+                        alt="tele2 logo",
+                        width="125",
+                        height="256",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+    </div>
+    <div class="grid-row">
+      <div class="grid-col-4">
+        <div class="p-section--shallow">
+          <h2>Learn more about Juju</h2>
+        </div>
+      </div>
+      <div class="grid-col-4">
+        <div class="grid-row">
+          <div class="grid-col-1">
+            <h3 class="p-heading--5">Connect with the community</h3>
+          </div>
+          <div class="grid-col-3">
+            <p>
+              <a href="https://matrix.to/#/#charmhub:ubuntu.com">Charmhub chat</a>
+            </p>
+            <hr class="p-rule--muted" />
+            <p>
+              <a href="https://discourse.charmhub.io/">Discourse forum</a>
+            </p>
+          </div>
+        </div>
+        <div class="u-fixed-width">
+          <hr class="p-rule--muted" />
+        </div>
+        <div class="grid-row">
+          <div class="grid-col-1">
+            <h3 class="p-heading--5">Contact us</h3>
+          </div>
+          <div class="grid-col-3">
+            <p>
+              <a href="/contact-us" class="js-invoke-modal" aria-controls="jaas-modal">Talk to a Canonical expert</a>
+            </p>
+          </div>
+        </div>
+        <div class="u-fixed-width">
+          <hr class="p-rule--muted" />
+        </div>
+        <div class="grid-row">
+          <div class="grid-col-1">
+            <h3 class="p-heading--5">Read more</h3>
+          </div>
+          <div class="grid-col-3">
+            <p>
+              <a href="https://juju.is/why-juju">How juju works</a>
+            </p>
+            <hr class="p-rule--muted" />
+            <p>
+              <a href="https://juju.is/docs/olm">Juju documentation</a>
+            </p>
+            <hr class="p-rule--muted" />
+            <p>
+              <a href="https://juju.is/docs/sdk">Charm SDK documentation</a>
+            </p>
+            <hr class="p-rule--muted" />
+            <p>
+              <a href="https://ubuntu.com/engage/kubernetes-operators-explained">What is a software operator?</a>
+            </p>
+            <hr class="p-rule--muted" />
+            <p>
+              <a href="https://ubuntu.com/engage/kubernetes-operators-explained-whitepaper">Software operators explained</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  {{ load_form("/jaas") | safe }}
+
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
+
+{% endblock content %}

--- a/templates/jaas/index.html
+++ b/templates/jaas/index.html
@@ -29,6 +29,33 @@
       <a href="/contact-us"
          class="p-button--positive js-invoke-modal"
          aria-controls="jaas-modal">Contact us</a>
+      <div class="u-align--cta">
+        <a class="github-button"
+           data-size="large"
+           href="https://github.com/canonical/jimm"
+           aria-label="Follow JIMM on GitHub"></a>
+        <noscript>
+          <a class="p-button" href="https://github.com/canonical/jimm">Follow @canonical on Github</a>
+        </noscript>
+        <a class="github-button"
+           data-size="large"
+           href="https://github.com/canonical/jimm"
+           data-icon="octicon-star"
+           data-show-count="true"
+           aria-label="Star canonical/jimm on GitHub"></a>
+        <noscript>
+          <a class="p-button" href="https://github.com/canonical/jimm">Star canonical/jimm on GitHub</a>
+        </noscript>
+        <a class="github-button"
+           data-size="large"
+           href="https://github.com/canonical/jimm/fork"
+           data-icon="octicon-repo-forked"
+           data-show-count="true"
+           aria-label="Fork canonical/jimm on GitHub"></a>
+        <noscript>
+          <a class="p-button" href="https://github.com/canonical/jimm">Fork canonical/jimm on GitHub</a>
+        </noscript>
+      </div>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container u-hide--medium u-hide--small">
@@ -692,5 +719,6 @@
   {{ load_form("/jaas") | safe }}
 
   <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
+  <script async defer src="https://buttons.github.io/buttons.js"></script>
 
 {% endblock content %}

--- a/templates/jaas/index.html
+++ b/templates/jaas/index.html
@@ -35,7 +35,7 @@
            href="https://github.com/canonical/jimm"
            aria-label="Follow JIMM on GitHub"></a>
         <noscript>
-          <a class="p-button" href="https://github.com/canonical/jimm">Follow @canonical on Github</a>
+          <a class="p-button" href="https://github.com/canonical/jimm">Follow @canonical/jimm on Github</a>
         </noscript>
         <a class="github-button"
            data-size="large"

--- a/templates/jaas/index.html
+++ b/templates/jaas/index.html
@@ -1,5 +1,7 @@
 {% extends 'base_index.html' %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
 {% block title %}Manage large scale Juju deployments with Jaas{% endblock %}
 
 {% block meta_description %}
@@ -15,21 +17,20 @@
 {% endblock body_class %}
 
 {% block content %}
-  <section class="p-section--hero u-no-padding--bottom">
-    <div class="grid-row--50-50 p-section--shallow">
-      <div class="grid-col">
-        <h1>Take control of your large-scale Juju deployments</h1>
-      </div>
-      <div class="grid-col">
-        <p>JAAS is Juju for enterprise.</p>
-        <div class="p-cta-block">
-          <a href="/contact-us"
-             class="p-button--positive js-invoke-modal"
-             aria-controls="jaas-modal">Contact us</a>
-        </div>
-      </div>
-    </div>
-    <div class="u-fixed-width">
+
+  {% call(slot) vf_hero(
+    title_text='Take control of your large-scale Juju deployments',
+    layout='50/50-full-width-image'
+    ) -%}
+    {%- if slot == 'description' -%}
+      <p>JAAS is Juju for enterprise.</p>
+    {%- endif -%}
+    {%- if slot == 'cta' -%}
+      <a href="/contact-us"
+         class="p-button--positive js-invoke-modal"
+         aria-controls="jaas-modal">Contact us</a>
+    {%- endif -%}
+    {%- if slot == 'image' -%}
       <div class="p-image-container u-hide--medium u-hide--small">
         {{ image(url="https://assets.ubuntu.com/v1/d7c20674-JAAS-arch-diagram.svg",
                 alt="",
@@ -40,8 +41,8 @@
                 attrs={ "class": "p-image-container__image" }) | safe
         }}
       </div>
-    </div>
-  </section>
+    {% endif -%}
+  {% endcall -%}
 
   <section class="p-section">
     <hr class="is-fixed-width" />
@@ -52,10 +53,10 @@
       <div class="grid-col-4 grid-col-medium-4">
         <div class="p-section--shallow">
           <div class="grid-row">
-            <div class="grid-col-2">
+            <div class="grid-col-2 grid-col-medium-2">
               <h3 class="p-text--small-caps">Backend API server (JIMM)</h3>
             </div>
-            <div class="grid-col-2">
+            <div class="grid-col-2 grid-col-medium-2">
               <p>
                 JAAS has a backend API server (JIMM) that is responsible for managing all interactions with the downstream, Juju controllers.
                 <br />
@@ -67,10 +68,10 @@
         <hr class="p-rule--muted" />
         <div class="p-section--shallow">
           <div class="grid-row">
-            <div class="grid-col-2">
+            <div class="grid-col-2 grid-col-medium-2">
               <h3 class="p-text--small-caps">Dashboard</h3>
             </div>
-            <div class="grid-col-2">
+            <div class="grid-col-2 grid-col-medium-2">
               <p>A graphical user interface to simplify common administrative operations.</p>
             </div>
           </div>
@@ -92,10 +93,10 @@
       <div class="grid-col-6">
         <div class="p-section--shallow">
           <div class="grid-row">
-            <div class="grid-col-2">
+            <div class="grid-col-2 grid-col-medium-2">
               <h3 class="p-heading--5">Have to manage multiple Juju controllers</h3>
             </div>
-            <div class="grid-col-4">
+            <div class="grid-col-4 grid-col-medium-2">
               <p>
                 JAAS simplifies the provisioning and lifecycle management of controllers and charms at scale, automating activities like model migrations and controller upgrades
               </p>
@@ -105,10 +106,10 @@
         <hr class="p-rule--muted" />
         <div class="p-section--shallow">
           <div class="grid-row">
-            <div class="grid-col-2">
+            <div class="grid-col-2 grid-col-medium-2">
               <h3 class="p-heading--5">Need to meet tighter security and compliance requirements</h3>
             </div>
-            <div class="grid-col-4">
+            <div class="grid-col-4 grid-col-medium-2">
               <p>
                 JAAS offers additional security features like single sign on (SSO) on both the dashboard and the cli, permission management, fine grained juju controller activity auditing and soon an SSH proxy and service accounts for the Terraform provider
               </p>
@@ -118,10 +119,10 @@
         <hr class="p-rule--muted" />
         <div class="p-section--shallow">
           <div class="grid-row">
-            <div class="grid-col-2">
+            <div class="grid-col-2 grid-col-medium-2">
               <h3 class="p-heading--5">Prefer to interact with your system with a web interface</h3>
             </div>
-            <div class="grid-col-4">
+            <div class="grid-col-4 grid-col-medium-2">
               <p>
                 The dashboard offer a simplified way for administrators to perform common administrative operations and monitor the state of the deployment
               </p>
@@ -147,7 +148,7 @@
     </div>
     <div class="grid-row--50-50">
       <div class="grid-col">
-        <p style="max-width: 50rem;">
+        <p>
           JAAS is your centralised enterprise control plane for Juju deployments.
           <br />
           With JAAS you can:
@@ -200,15 +201,15 @@
             </li>
           </ul>
           <form class="u-hide--large u-hide--medium">
-          <select name="tabSelect" data-tablist="jaas-features">
-            <option value="view-models-and-controllers-details-tab" selected="">View models and controllers details</option>
-            <option value="run-actions-tab">Run actions</option>
-            <option value="configure-applications-tab">Configure applications</option>
-            <option value="onboard-controllers-and-manage-access-tab">Onboard controllers and manage access</option>
-            <option value="run-audits-and-reports-tab">Run audits and reports</option>
-            <option value="search-and-filter-tab">Search and filter</option>
-          </select>
-        </form>
+            <select name="tabSelect" data-tablist="jaas-features">
+              <option value="view-models-and-controllers-details-tab" selected="">View models and controllers details</option>
+              <option value="run-actions-tab">Run actions</option>
+              <option value="configure-applications-tab">Configure applications</option>
+              <option value="onboard-controllers-and-manage-access-tab">Onboard controllers and manage access</option>
+              <option value="run-audits-and-reports-tab">Run audits and reports</option>
+              <option value="search-and-filter-tab">Search and filter</option>
+            </select>
+          </form>
         </div>
       </div>
       <div class="grid-col" data-tablist="jaas-features">
@@ -228,7 +229,9 @@
           </p>
         </div>
         <div class="p-tabs__content"
-             role="tabpanel" id="run-actions-tab" aria-controls="run-actions">
+             role="tabpanel"
+             id="run-actions-tab"
+             aria-controls="run-actions">
           {{ image(url="https://assets.ubuntu.com/v1/e70dab91-run-action.png",
                     alt="",
                     height="669",
@@ -239,7 +242,9 @@
           <p>Execute Juju action from the UI and view the resulting logs to confirm their status.</p>
         </div>
         <div class="p-tabs__content"
-             role="tabpanel" id="configure-applications-tab" aria-controls="configure-applications">
+             role="tabpanel"
+             id="configure-applications-tab"
+             aria-controls="configure-applications">
           {{ image(url="https://assets.ubuntu.com/v1/1ac0ed08-configure-app.png",
                     alt="",
                     height="669",
@@ -250,7 +255,9 @@
           <p>Perform common administrative operations and apply machine configurations.</p>
         </div>
         <div class="p-tabs__content"
-             role="tabpanel" id="onboard-controllers-and-manage-access-tab" aria-controls="onboard-controllers-and-manage-access">
+             role="tabpanel"
+             id="onboard-controllers-and-manage-access-tab"
+             aria-controls="onboard-controllers-and-manage-access">
           {{ image(url="https://assets.ubuntu.com/v1/d54720f1-jaas-controllers.png",
                     alt="",
                     height="669",
@@ -261,7 +268,9 @@
           <p>Onboard controllers and add, remove or manage user access to models and controllers.</p>
         </div>
         <div class="p-tabs__content"
-             role="tabpanel" id="run-audits-and-reports-tab" aria-controls="run-audits-and-reports">
+             role="tabpanel"
+             id="run-audits-and-reports-tab"
+             aria-controls="run-audits-and-reports">
           {{ image(url="https://assets.ubuntu.com/v1/8d0f47a6-action-logs.png",
                     alt="",
                     height="669",
@@ -272,7 +281,9 @@
           <p>Access the logs from your deployment in a single, centralised location.</p>
         </div>
         <div class="p-tabs__content"
-             role="tabpanel" id="search-and-filter-tab" aria-controls="search-and-filter">
+             role="tabpanel"
+             id="search-and-filter-tab"
+             aria-controls="search-and-filter">
           {{ image(url="https://assets.ubuntu.com/v1/f3ff0a1b-searchandfilter.jpg",
                     alt="",
                     height="669",
@@ -314,10 +325,10 @@
           <hr class="p-rule--muted" />
           <div class="p-section--shallow">
             <div class="grid-row">
-              <div class="grid-col-2">
+              <div class="grid-col-2 grid-col-medium-2">
                 <h3 class="p-heading--5">Centralised Terraform Provider</h3>
               </div>
-              <div class="grid-col-4">
+              <div class="grid-col-4 grid-col-medium-2">
                 <p>
                   JAAS can make use of the Juju Terraform provider to apply plans to all managed controllers. The provider supports Oauth client credentials authentication and its access is controlled by the authorisation system.
                 </p>
@@ -327,14 +338,14 @@
           <hr class="p-rule--muted" />
           <div class="p-section--shallow">
             <div class="grid-row">
-              <div class="grid-col-2">
+              <div class="grid-col-2 grid-col-medium-2">
                 <h3 class="p-heading--5">
                   SSH Proxy
                   <br />
                   (Coming soon)
                 </h3>
               </div>
-              <div class="grid-col-4">
+              <div class="grid-col-4 grid-col-medium-2">
                 <p>
                   Administrators can use JAAS to SSH into all units of managed controllers, reducing the need to grant access to vast areas of the network.
                   <br />
@@ -346,10 +357,10 @@
           <hr class="p-rule--muted" />
           <div class="p-section--shallow">
             <div class="grid-row">
-              <div class="grid-col-2">
+              <div class="grid-col-2 grid-col-medium-2">
                 <h3 class="p-heading--5">Single sign on (SSO)</h3>
               </div>
-              <div class="grid-col-4">
+              <div class="grid-col-4 grid-col-medium-2">
                 <p>
                   JAAS supports integration with external identity providers through OIDC, enforcing strong authentication on both the cli and the web dashboard
                 </p>
@@ -424,7 +435,7 @@
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/7040f392-Ubuntu-logo.png",
-                        alt="Ubuntu logo",
+                        alt="Ubuntu",
                         width="218",
                         height="256",
                         hi_def=True,
@@ -434,7 +445,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/a76d4ee3-deutsche-telekom.png",
-                        alt="Deutsche Telekom logo",
+                        alt="Deutsche Telekom",
                         width="257",
                         height="256",
                         hi_def=True,
@@ -444,7 +455,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/0a6968e6-ibm-logo.png",
-                        alt="IBM logo",
+                        alt="IBM",
                         width="125",
                         height="256",
                         hi_def=True,
@@ -454,7 +465,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/cc65269a-intel-new-logo.png",
-                        alt="Intel logo",
+                        alt="Intel",
                         width="133",
                         height="256",
                         hi_def=True,
@@ -464,7 +475,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/ea63a7ba-microsoft-azure-2021.png",
-                        alt="Microsoft Azure logo",
+                        alt="Microsoft Azure",
                         width="78",
                         height="256",
                         hi_def=True,
@@ -474,7 +485,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/f3d556d7-cisco-logo.png",
-                        alt="Cisco logo",
+                        alt="Cisco",
                         width="225",
                         height="372",
                         hi_def=True,
@@ -484,7 +495,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/757f59f0-china-telecom-logo.png",
-                        alt="China Telecom logo",
+                        alt="China Telecom",
                         width="257",
                         height="256",
                         hi_def=True,
@@ -494,7 +505,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/f044cea8-bt-logo.png",
-                        alt="BT logo",
+                        alt="BT",
                         width="111",
                         height="256",
                         hi_def=True,
@@ -504,7 +515,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/89365c81-nec-logo.png",
-                        alt="NEC logo",
+                        alt="NEC",
                         width="172",
                         height="256",
                         hi_def=True,
@@ -514,7 +525,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/4b74a5f4-hp-logo.png",
-                        alt="Hewlett Packard logo",
+                        alt="Hewlett Packard",
                         width="110",
                         height="256",
                         hi_def=True,
@@ -524,7 +535,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/02d41af7-yahoo-jp-logo.png",
-                        alt="Yahoo! Japan logo",
+                        alt="Yahoo! Japan",
                         width="210",
                         height="256",
                         hi_def=True,
@@ -534,7 +545,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/067bffc3-verizon-logo.png",
-                        alt="verizon logo",
+                        alt="verizon",
                         width="257",
                         height="256",
                         hi_def=True,
@@ -544,7 +555,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/05d9f06b-bell-logo.png",
-                        alt="Bell logo",
+                        alt="Bell",
                         width="87",
                         height="256",
                         hi_def=True,
@@ -554,7 +565,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/5482ad8a-swissquote-logo.png",
-                        alt="Swissquote logo",
+                        alt="Swissquote",
                         width="257",
                         height="256",
                         hi_def=True,
@@ -564,7 +575,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/8848ee2f-panasonic-logo.png",
-                        alt="Panasonic logo",
+                        alt="Panasonic",
                         width="254",
                         height="256",
                         hi_def=True,
@@ -574,7 +585,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/e0b84fa2-scania-logo.png",
-                        alt="Scania logo",
+                        alt="Scania",
                         width="255",
                         height="256",
                         hi_def=True,
@@ -584,7 +595,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/d8060c1d-rabobank-logo.png",
-                        alt="Rabobank logo",
+                        alt="Rabobank",
                         width="257",
                         height="259",
                         hi_def=True,
@@ -594,7 +605,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/e2fa6efb-tele2-logo.png",
-                        alt="tele2 logo",
+                        alt="tele2",
                         width="125",
                         height="256",
                         hi_def=True,
@@ -619,10 +630,10 @@
       </div>
       <div class="grid-col-4">
         <div class="grid-row">
-          <div class="grid-col-1">
+          <div class="grid-col-1 grid-col-medium-2">
             <h3 class="p-heading--5">Connect with the community</h3>
           </div>
-          <div class="grid-col-3">
+          <div class="grid-col-3 grid-col-medium-2">
             <p>
               <a href="https://matrix.to/#/#charmhub:ubuntu.com">Charmhub chat</a>
             </p>
@@ -636,10 +647,10 @@
           <hr class="p-rule--muted" />
         </div>
         <div class="grid-row">
-          <div class="grid-col-1">
+          <div class="grid-col-1 grid-col-medium-2">
             <h3 class="p-heading--5">Contact us</h3>
           </div>
-          <div class="grid-col-3">
+          <div class="grid-col-3 grid-col-medium-2">
             <p>
               <a href="/contact-us" class="js-invoke-modal" aria-controls="jaas-modal">Talk to a Canonical expert</a>
             </p>
@@ -649,10 +660,10 @@
           <hr class="p-rule--muted" />
         </div>
         <div class="grid-row">
-          <div class="grid-col-1">
+          <div class="grid-col-1 grid-col-medium-2">
             <h3 class="p-heading--5">Read more</h3>
           </div>
-          <div class="grid-col-3">
+          <div class="grid-col-3 grid-col-medium-2">
             <p>
               <a href="https://juju.is/why-juju">How juju works</a>
             </p>

--- a/templates/mir/index.html
+++ b/templates/mir/index.html
@@ -40,7 +40,7 @@
            href="https://github.com/canonical/mir"
            aria-label="Follow @canonical/mir on GitHub"></a>
         <noscript>
-          <a class="p-button" href="https://github.com/canonical/mir">Follow @canonical on Github</a>
+          <a class="p-button" href="https://github.com/canonical/mir">Follow @canonical/mir on Github</a>
         </noscript>
 
         <a class="github-button"

--- a/templates/mir/index.html
+++ b/templates/mir/index.html
@@ -34,7 +34,7 @@
     {%- if slot == 'cta' -%}
       <a href="https://assets.ubuntu.com/v1/bd787c8a-canonical-mir-datasheet-2018-12-20.pdf"
          class="p-button--positive">Get the Mir datasheet</a>
-      <div>
+      <div class="u-align--cta">
         <a class="github-button"
            data-size="large"
            href="https://github.com/canonical/mir"

--- a/templates/observability/what-is-observability.html
+++ b/templates/observability/what-is-observability.html
@@ -238,7 +238,7 @@
           The concept of observability originates in the field of modern control system theory, and its formulation has well withstood the test of time. And it was not a standalone concept either. Rather, observability had a twin concept, called controllability, which can be roughly defined as: "the property of a system to regulate itself and related systems to reliably produce the correct outputs given the provided inputs."
         </p>
         <p>
-          Nowadays, controllability is not a term many software engineers use daily, but its essence is embodied, for example, by operators <a href="https://jaas.ai/?_ga=2.74388370.1830430303.1624442919-1608689799.1623932549">implemented with Juju</a> or other frameworks, which steer the software they operate and the infrastructure underneath to provide seamless configuration management and achieve scalability, reliability and graceful degradation.
+          Nowadays, controllability is not a term many software engineers use daily, but its essence is embodied, for example, by operators <a href="/jaas">implemented with Juju</a> or other frameworks, which steer the software they operate and the infrastructure underneath to provide seamless configuration management and achieve scalability, reliability and graceful degradation.
         </p>
         <div class="p-cta-block">
           <a href="/blog/tag/model-driven-operations"

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1672,3 +1672,15 @@ def get_pricing_data():
     except FileNotFoundError:
         logger.error("Pricing data file not found")
         return {"error": "Pricing data not available"}, 500
+
+# Custom redirects for Jaas
+@app.route("/jaas/<charm_or_bundle_name>")
+@app.route("/jaas/<charm_or_bundle_name>/<series_or_version>")
+@app.route("/jaas/<charm_or_bundle_name>/<series_or_version>/<version>")
+def details_redirect(
+    charm_or_bundle_name,
+    series_or_version=None,
+    version=None,
+):
+    charmhub_url = "https://charmhub.io/" + charm_or_bundle_name
+    return flask.redirect(charmhub_url, code=301)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1673,6 +1673,7 @@ def get_pricing_data():
         logger.error("Pricing data file not found")
         return {"error": "Pricing data not available"}, 500
 
+
 # Custom redirects for Jaas
 @app.route("/jaas/<charm_or_bundle_name>")
 @app.route("/jaas/<charm_or_bundle_name>/<series_or_version>")


### PR DESCRIPTION
## Done

- Migrate the homepage, including updating to use current patterns:
  - grid-row
  - image template
  - tabbed-content.js
- Migrate the form to form builder
- Migrate the secondary nav
- Update the mega nav link
- Migrate redirects.yaml and permanent-redirects.yaml

Flyby:
- Update the form template to align field sets with the grid

## QA

- Open the [demo](https://canonical-com-1851.demos.haus/jaas)
- See it matches https://jaas.ai/
- Test on all screen sizes
- Test the form goes through to marketo

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-24178
