### PR TITLE
chore: Migrate /mlops/kubeflow/what-is-kubeflow

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -349,4 +349,4 @@ kubeflow:
     - title: What is Kubeflow
       path: /mlops/kubeflow/what-is-kubeflow
     - title: Docs
-      path: /mlops/kubeflow/docs
+      path: https://documentation.ubuntu.com/charmed-kubeflow/

--- a/templates/mlops/kubeflow/what-is-kubeflow.html
+++ b/templates/mlops/kubeflow/what-is-kubeflow.html
@@ -75,7 +75,7 @@
           <div class="p-logo-section__items">
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/7577d797-google-logo.svg",
-                            alt="Goofgle",
+                            alt="Google",
                             width="107",
                             height="144",
                             hi_def=True,

--- a/templates/mlops/kubeflow/what-is-kubeflow.html
+++ b/templates/mlops/kubeflow/what-is-kubeflow.html
@@ -1,0 +1,571 @@
+{% extends 'base_index.html' %}
+
+{% block title %}What is Kubeflow?{% endblock %}
+
+{% block meta_description %}
+  Charmed Kubeflow is an enterprise-ready, fully supported MLOps platform for any cloud. A complete, free, open source solution for sophisticated data science labs.
+{% endblock meta_description %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1m-96RlGkbzFa1KaGAxYFpY0ztIlsTuViCjXSAlErQlg
+{% endblock meta_copydoc %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block content %}
+
+  <div class="p-strip is-shallow u-no-padding--bottom">
+    <div class="u-fixed-width">
+      <div id="notification" class="p-notification">
+        <div class="p-notification__content">
+          <h5 class="p-notification__title">Apply to join our preview for Managed Kubeflow on Azure!</h5>
+          <p class="p-notification__message">
+            <a href="https://ubuntu.com/engage/managed-kubeflow-preview?utm_source=marketo&utm_medium=website&utm_campaign=701N100000VDqOkIAL"
+               target="_blank"
+               rel="noopener noreferrer">Learn more and sign up.</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <section class="p-section--hero">
+    <div class="grid-row">
+      <div class="grid-col-2 grid-col-medium-1 u-no-padding--bottom p-section">
+        {{ image(url="https://assets.ubuntu.com/v1/6d72759e-kubeflow-logo.png",
+                alt="Kubeflow",
+                width="852",
+                height="175",
+                hi_def=True,
+                loading="auto") | safe
+        }}
+      </div>
+      <div class="grid-col-6 grid-col-medium-3">
+        <div class="grid-row">
+          <div class="grid-col-4 p-section--shallow">
+            <h1 class="u-no-margin--bottom">What is Kubeflow?</h1>
+            <p class="p-heading--2">Kubeflow is the open source machine learning MLOps platform</p>
+          </div>
+          <div class="grid-col-2">
+            <p>
+              Kubeflow enables you to develop and deploy machine learning models at any scale. It is a cloud-native application that runs on any cloud.
+            </p>
+            <p>
+              Charmed Kubeflow is Canonical's distribution. It is secure and seamlessly integrated with other leading tools such as MLflow.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <a class="p-button--positive"
+           href="https://charmed-kubeflow.io/docs/install">Try out Charmed Kubeflow</a>
+        <a class="p-button" href="https://ubuntu.com/engage/mlops-toolkit">Read our MLOps toolkit</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+      <h2 class="p-section--shallow">Contributors to Kubeflow</h2>
+    </div>
+    <div class="row--25-75">
+      <div class="col">
+        <div class="p-logo-section">
+          <div class="p-logo-section__items">
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/7577d797-google-logo.svg",
+                            alt="Goofgle",
+                            width="107",
+                            height="144",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/6ece1a68-microsoft-logo.png",
+                            alt="Microsoft",
+                            width="420",
+                            height="384",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/756d9941-canonical-logo.png",
+                            alt="Canonical",
+                            width="364",
+                            height="384",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/1c72e761-cisco-logo.png",
+                            alt="Cisco",
+                            width="232",
+                            height="384",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/c8792945-ibm-logo.png",
+                            alt="IBM",
+                            width="141",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png",
+                            alt="Intel",
+                            width="149",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+      <h2 class="p-section--shallow">What's inside Kubeflow?</h2>
+    </div>
+    <div class="grid-row">
+      <div class="grid-col-start-large-3 grid-col-6">
+        <div class="p-logo-section p-section">
+          <div class="p-logo-section__items">
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/f7f624aa-jupyter-logo.png",
+                            alt="Jupyter",
+                            width="144",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/c497f959-tensor-flow-logo.png",
+                            alt="TensorFlow",
+                            width="278",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/2f4bd927-seldon-logo.png",
+                            alt="Seldon",
+                            width="281",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/6b0f7cdc-ambassador%20%20logo.png",
+                            alt="Ambassador",
+                            width="58",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/fe513e7b-pytorch-logo.png",
+                            alt="PyTorch",
+                            width="251",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/c112372b-istio%20logo.png",
+                            alt="Istio",
+                            width="255",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/e9ce15ff-mxnet%20logo.png",
+                            alt="MXNet",
+                            width="280",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/9c91dbfd-katib-logo.png",
+                            alt="Katib",
+                            width="97",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/8d5fee47-prometheus%20logo.png",
+                            alt="Prometheus",
+                            width="94",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/2c68ca73-onnx%20logo.png",
+                            alt="ONNX",
+                            width="261",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/091fa892-xgboost%20logo.png",
+                            alt="XGBoost",
+                            width="221",
+                            height="289",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/d335fd1c-scikit%20logo.png",
+                            alt="Scikit",
+                            width="261",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/c5ae87ca-pachyderm%20logo.png",
+                            alt="Pachyderm",
+                            width="97",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+          </div>
+        </div>
+        <hr class="p-rule--muted u-hide--small u-hide--medium" />
+        <div class="grid-row p-section--shallow">
+          <div class="grid-col-2 grid-col-medium-1 grid-col-start-medium-2 grid-col-order-medium-1">
+            <h3 class="p-heading--5">Kubeflow dashboard</h3>
+            <p>
+              <a href="https://www.kubeflow.org/docs/components/central-dash/overview/">Central dashboard</a> with <a href="https://www.kubeflow.org/docs/components/multi-tenancy/overview/">multi-user isolation</a> provides a platform for data scientists and engineers to leverage K8s to develop, deploy and monitor their models in production.
+            </p>
+          </div>
+          <div class="grid-col-2 grid-col-order-medium-2 grid-col-medium-1">
+            <h3 class="p-heading--5">JupyterLab and VSCode</h3>
+            <p>
+              With Kubeflow users can <a href="https://www.kubeflow.org/docs/components/notebooks/setup/">spin-up Jupyter notebook servers</a> but also VSCode directly from the dashboard, allocating the right storage, CPUs and GPUs.
+            </p>
+          </div>
+          <div class="grid-col-2 grid-col-order-medium-3 grid-col-medium-1">
+            <h3 class="p-heading--5">ML libraries & frameworks</h3>
+            <p>
+              Kubeflow is compatible with your choice of data science libraries and frameworks.
+              <a href="https://www.kubeflow.org/docs/components/training/tftraining/">TensorFlow</a>,
+              <a href="https://www.kubeflow.org/docs/components/training/pytorch/">PyTorch</a>,
+              <a href="https://pypi.org/project/mxnet/">MXNet</a>,
+              <a href="https://github.com/kubeflow/xgboost-operator">XGBoost</a>,
+              <a href="https://scikit-learn.org/stable/">scikit-learn</a> and more.
+            </p>
+          </div>
+        </div>
+
+        <hr class="p-rule--muted u-hide--small" />
+        <div class="grid-row">
+          <div class="grid-col-2 grid-col-medium-1 grid-col-start-medium-2 grid-col-order-medium-1">
+            <h3 class="p-heading--5">Kubeflow Pipelines</h3>
+            <p>
+              Automate your ML workflow into pipelines by containerizing steps as pipeline components and defining inputs, outputs, parameters and generated artifacts. <a href="https://ubuntu.com/blog/data-science-workflows-on-kubernetes-with-kubeflow-pipelines-part-1">Learn more&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="grid-col-2 grid-col-medium-1 grid-col-order-medium-2">
+            <h3 class="p-heading--5">Experiments, Runs and Recurring Runs</h3>
+            <p>
+              Experiments, groups of <a href="https://www.kubeflow.org/docs/pipelines/pipelines-quickstart/#run-an-ml-pipeline">Kubeflow Pipeline 'Runs'</a> and <a href="https://www.kubeflow.org/docs/components/pipelines/concepts/run/">Recurring Runs</a>, allow you to find the right parameters for your model, compare and replicate results.
+            </p>
+          </div>
+          <div class="grid-col-2 grid-col-medium-1 grid-col-order-medium-3">
+            <h3 class="p-heading--5">Hyperparameter tuning / AutoML</h3>
+            <p>
+              Kubeflow includes <a href="https://www.kubeflow.org/docs/components/katib/">Katib</a> for hyperparameter tuning. Katib runs pipelines with different hyperparameters (e.g. learning rate, # of hidden layers) optimising for the best ML model.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted u-hide--small" />
+        <div class="grid-row">
+          <div class="grid-col-2 grid-col-medium-1 grid-col-start-medium-2 grid-col-order-medium-1">
+            <h3 class="p-heading--5">KServe for inference serving</h3>
+            <p>
+              <a href="https://www.kubeflow.org/docs/components/serving/kfserving/">KServe</a> is a multi-framework model deployment tool with serverless inferencing, canary roll-outs, pre & post-processing and explainability. <a href="https://ubuntu.com/blog/what-is-kfserving">Learn more&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="grid-col-2 grid-col-medium-1 grid-col-order-medium-2">
+            <h3 class="p-heading--5">The integrations you need</h3>
+            <p>
+              Charmed Kubeflow integrates with <a href="https://github.com/mlopsworks/charms">MLFlow</a> for model registry, staging, and monitoring in production, <a href="https://github.com/SeldonIO/seldon-core">Seldon Core</a> for inference serving and <a href="https://spark.apache.org/">Apache Spark</a> for parallel data processing.
+            </p>
+          </div>
+          <div class="grid-col-2 grid-col-medium-1 grid-col-order-medium-3">
+            <h3 class="p-heading--5">More...</h3>
+            <p>Save, compare and share generated artifacts - models, images, plots.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="grid-row--50-50">
+      <hr class="p-rule" />
+      <div class="grid-col">
+        <h2>MLOps at any scale</h2>
+      </div>
+      <div class="grid-col">
+        <p>
+          Enterprise-ready Charmed Kubeflow, the fully supported MLOps platform for any cloud, is validated and certified on high-end AI hardware, such as NVIDIA DGX.
+        </p>
+        <p class="p-section--shallow">
+          A complete solution for sophisticated data science labs. Upgrades and security updates - all supported in the free, open source distribution.
+        </p>
+        <hr class="p-rule--muted" />
+        <a class="p-button--positive"
+           href="https://ubuntu.com/engage/run-ai-at-scale">Get the whitepaper</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="p-section--shallow">
+      <div class="grid-row--50-50">
+        <hr class="p-rule" />
+        <div class="grid-col">
+          <h2>Why MLOps?</h2>
+        </div>
+        <div class="grid-col p-section--shallow">
+          <p>
+            Bringing AI solutions to market can involve many steps: data pre-processing, training, model deployment or inference serving at scale... The list of tasks is complex and keeping them in a set of notebooks or scripts is hard to maintain, share and collaborate on, leading to inefficient processes.
+          </p>
+          <p class="p-section--shallow">
+            <a href="https://papers.nips.cc/paper/5656-hidden-technical-debt-in-machine-learning-systems.pdf">Google describes</a> that only about 20% of the effort and code required to bring AI systems to production is the development of ML code, while the remaining is operations. Standardizing ops in your ML workflows can hence greatly decrease time-to-market and costs for your AI solutions.
+          </p>
+          <hr class="p-rule--muted" />
+          <a href="https://ubuntu.com/blog/what-is-mlops">Read more about MLOps</a>
+        </div>
+      </div>
+    </div>
+    <div class="u-fixed-width">
+      <div class="u-align--center u-hide--small p-image-container">
+        {{ image(url="https://assets.ubuntu.com/v1/085604f2-u.c__ai__kubeflow.svg",
+                alt="",
+                width="1169",
+                height="375",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-image-container__image"},) | safe
+        }}
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="grid-row--50-50">
+      <hr class="p-rule" />
+      <div class="grid-col">
+        <h2>Who uses Kubeflow?</h2>
+      </div>
+      <div class="grid-col p-section">
+        <p>Thousands of companies have chosen Kubeflow for their AI/ML stack.</p>
+        <p>
+          From research institutions like CERN, to transport and logistics companies - Uber, Lyft, GoJek - to financial and media industries with Spotify, Bloomberg, Shopify and PayPal.
+        </p>
+        <p class="p-section--shallow">Forward-looking enterprises are using Kubeflow to empower their data scientists.</p>
+        <hr class="p-rule--muted" />
+        <a href="https://ubuntu.com/engage/ai-ml-casestudy-tasmania/">Read our case study with the University of Tasmania</a>
+      </div>
+    </div>
+    <div class="grid-row">
+      <div class="grid-col-start-large-3 grid-col-6">
+        <div class="p-logo-section">
+          <div class="p-logo-section__items">
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/ea6008a0-spotify-logo.png",
+                            alt="Spotify",
+                            width="272",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/b6b0b414-uber-logo.png",
+                            alt="Uber",
+                            width="133",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/63870c2f-paypal-logo.png",
+                            alt="PayPal",
+                            width="258",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/6117dd11-lyft-logo.png",
+                            alt="Lyft",
+                            width="289",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/c358b12a-cern-logo.png",
+                            alt="CERN",
+                            width="220",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/b0eca934-Bloomberg-Logo.png",
+                            alt="Bloomberg",
+                            width="289",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/a1996ad2-shopify-logo.png",
+                            alt="Shopify",
+                            width="268",
+                            height="288",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--shallow">
+    <div class="grid-row">
+      <hr class="p-rule" />
+      <div class="grid-col-4 u-no-margin--bottom">
+        <h2>Kubeflow resources</h2>
+      </div>
+      <div class="grid-col-4">
+        <ul class="p-list--divided">
+          <li class="p-list__item u-no-padding--top">
+            <div class="grid-row">
+              <div class="grid-col-2 grid-col-medium-2">
+                <p>
+                  <a href="https://charmed-kubeflow.io/docs">Charmed Kubeflow docs</a>
+                </p>
+              </div>
+              <div class="grid-col-2 grid-col-medium-2">
+                <p>Read more about Charmed MLflow's capabilities and follow our tutorials.</p>
+              </div>
+            </div>
+          </li>
+          <li class="p-list__item">
+            <div class="grid-row">
+              <div class="grid-col-2 grid-col-medium-2">
+                <p>
+                  <a href="https://ubuntu.com/engage/kubeflow-vs-mlflow">Kubeflow vs. MLflow</a>
+                </p>
+              </div>
+              <div class="grid-col-2 grid-col-medium-2">
+                <p>Understand the differences between the most famous open source solutions.</p>
+              </div>
+            </div>
+          </li>
+          <li class="p-list__item">
+            <div class="grid-row">
+              <div class="grid-col-2 grid-col-medium-2">
+                <p>
+                  <a href="https://ubuntu.com/engage/mlops-guide">Guide to MLOps</a>
+                </p>
+              </div>
+              <div class="grid-col-2 grid-col-medium-2">
+                <p>Learn how to take models to production using open source MLOps platforms.</p>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <div class="grid-row--50-50">
+      <hr class="p-rule" />
+      <div class="grid-col">
+        <h2>Get started today</h2>
+      </div>
+      <div class="grid-col">
+        <p>
+          Try-out Kubeflow on your Kubernetes environment. Or on MicroK8s &ndash; Zero-ops Kubernetes with high availability.
+        </p>
+        <p class="p-section--shallow">Deploy locally on your workstation, cloud VM or on-prem server.</p>
+        <hr class="p-rule--muted" />
+        <a class="p-button--positive"
+           href="https://charmed-kubeflow.io/docs/get-started-with-charmed-kubeflow">Try Kubeflow on MicroK8s</a>
+        <a class="p-button" href="https://charmed-kubeflow.io/#get-in-touch">Contact us now</a>
+      </div>
+    </div>
+  </section>
+
+{% endblock content %}


### PR DESCRIPTION
## Done

- Migrated page from the u.com codebase
- Updated deprecated Vanilla classes and switched to using new grid
- Refactored images in favor of the image template
- Added docs link

## QA

- View the site locally in your web browser at: https://canonical-com-1857.demos.haus/mlops/kubeflow/what-is-kubeflow and see that the content and design matches https://ubuntu.com/ai/what-is-kubeflow
- Please make sure to double check links against [doc](https://docs.google.com/document/d/1m-96RlGkbzFa1KaGAxYFpY0ztIlsTuViCjXSAlErQlg/edit?tab=t.0)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-23608
