### PR TITLE
fix: use separate session for discourse

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -109,6 +109,7 @@ charmhub_discourse_api = DiscourseAPI(
     get_topics_query_id=2,
 )
 search_session = get_requests_session()
+discourse_session = get_requests_session()
 
 app.register_blueprint(application, url_prefix="/careers/application")
 
@@ -1064,7 +1065,7 @@ dqlite_docs = Docs(
     parser=DocParser(
         api=DiscourseAPI(
             base_url="https://discourse.dqlite.io/",
-            session=search_session,
+            session=discourse_session,
         ),
         index_topic_id=34,
         url_prefix="/dqlite/docs",
@@ -1096,9 +1097,7 @@ maas_docs = Docs(
     parser=DocParser(
         api=DiscourseAPI(
             base_url="https://discourse.maas.io/",
-            session=search_session,
-            api_key=MAAS_DISCOURSE_API_KEY,
-            api_username=MAAS_DISCOURSE_API_USERNAME,
+            session=discourse_session,
             get_topics_query_id=2,
         ),
         index_topic_id=6662,


### PR DESCRIPTION
## Problem Statement

Requests to [canonical maas](https://canonical.com/maas/docs?randstr)  or [canonical dqlite](https://canonical.com/dqlite/docs?randstr) are returning 500 errors. Logs are showing 403 errors when accessing discourse, yet secrets have been supplied.

## Done

Created a separate requests session for discourse clients that do not need authentication. This prevents headers from being reused even for discourse API that don't require authentication.

## QA

- Open /maas/docs?randstr 
- Open /dqlite/docs?randstr
- Confirm both pages and navigation links are working
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

