### PR TITLE
style: hide duplicated hr rule on /spark/support page

### DIFF
--- a/templates/data/spark/support.html
+++ b/templates/data/spark/support.html
@@ -90,7 +90,7 @@
           }}
         </div>
       </div>
-      <hr class="p-rule--muted u-hide--medium" />
+      <hr class="p-rule--muted u-hide--medium u-hide--small" />
     </div>
     <div class="p-equal-height-row p-section--shallow">
       <div class="p-equal-height-row__col">


### PR DESCRIPTION
## Done
- Hid extra horizontal line on small screen

## QA

- Check out [demo link](https://canonical-com-1859.demos.haus/data/spark/support) and compare with https://canonical.com/data/spark/support to confirm issue was fixed

## Issue / Card

Fixes #1850 

## Screenshots
<img width="686" height="756" alt="image" src="https://github.com/user-attachments/assets/c6c8c023-a281-4774-88f7-f5e853f4dbb0" />

<img width="668" height="776" alt="image" src="https://github.com/user-attachments/assets/3fcb597a-a831-4f67-9655-87aaa3355bcf" />


[if relevant, include a screenshot]
