### PR TITLE
Fix missing cover image aspect ratios

### DIFF
--- a/templates/observability/what-is-observability.html
+++ b/templates/observability/what-is-observability.html
@@ -194,7 +194,7 @@
         </div>
       </div>
       <div class="p-section--shallow">
-        <div class="p-image-container is-cover is-highlighted">
+        <div class="p-image-container--3-2 is-cover is-highlighted">
           {{ image(url="https://assets.ubuntu.com/v1/9ab18658-telemetry.png",
                     alt="A layered diagram depicting substrates and prevalent telemetry types. The substrates, arranged vertically, include bare metal, virtualization, operating system, container orchestration, serverless (FaaS, CaaS), runtimes, applications, services, and end-user devices/IoT. Each layer represents a level of abstraction from infrastructure to application context. On the right, telemetry types such as metrics, logs, distributed traces, and profiles are shown, with examples of data visualizations. A note below emphasizes that telemetry context is crucial for correlating data with system topology and avoiding confusion between unrelated deployments",
                     width="2748",

--- a/templates/solutions/ai/index.html
+++ b/templates/solutions/ai/index.html
@@ -501,7 +501,7 @@
       </div>
       <div class="col">
         <div class="p-section--shallow">
-          <div class="p-image-container is-cover u-hide--small">
+          <div class="p-image-container--2-3 is-cover u-hide--small">
             {{ image(url="https://assets.ubuntu.com/v1/fc787875-security.png",
                         alt="",
                         width="1800",


### PR DESCRIPTION
## Done

Similar to https://github.com/canonical/ubuntu.com/pull/15431, some cases were found of cover images without their required aspect ratio classes. This would cause images to not render in Vanilla >= 4.26.1.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Navigate to the following pages and verify the cover images are rendered as expected:
  - [observability/what-is-observability](https://canonical-com-1860.demos.haus/observability/what-is-observability)
  - [solutions/ai](https://canonical-com-1860.demos.haus/solutions/ai)


## Issue / Card

Fixes https://chat.canonical.com/canonical/pl/7czayisdfid83xkc6758yomrkc

## Screenshots

Before

<img width="1466" height="274" alt="Screenshot from 2025-08-07 15-09-17" src="https://github.com/user-attachments/assets/2759cdc3-c613-4bfd-9a1a-525800aa5186" />

<img width="1392" height="769" alt="Screenshot from 2025-08-07 15-22-03" src="https://github.com/user-attachments/assets/66770d9e-9234-4f49-a3fa-2a2f3f4415f1" />



After

<img width="1466" height="1125" alt="image" src="https://github.com/user-attachments/assets/c71a51f7-d792-4a66-8875-8a8ef6153ed2" />

<img width="1392" height="1056" alt="image" src="https://github.com/user-attachments/assets/898325b3-3586-4ad2-8b1d-57387ae04366" />


