### PR TITLE
feat: update maas link in solutions/infrastructure

### DIFF
--- a/templates/solutions/infrastructure/index.html
+++ b/templates/solutions/infrastructure/index.html
@@ -519,7 +519,7 @@
             </div>
             <div class="col">
               <p>Super fast server provisioning.</p>
-              <a href="https://canonical.com/maas">Learn more&nbsp;&rsaquo;</a>
+              <a href="/maas">Learn more&nbsp;&rsaquo;</a>
             </div>
           </li>
         </ul>


### PR DESCRIPTION
## Done

Updated MAAS link to point to https://canonical.com/maas

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Go to http://0.0.0.0:8002/solutions/infrastructure
- Check the MAAS link points to https://canonical.com/maas


## Issue / Card

Fixes WD-24629