### PR TITLE
Redirects for Charmed MySQL doc links to RTD

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1419,3 +1419,6 @@ maas/deprecations/MD3: https://discourse.maas.io/t/6216
 maas/deprecations/MD4: https://discourse.maas.io/t/7440
 maas/deprecations/MD5: https://discourse.maas.io/t/10203
 maas/deprecations/MD6: https://discourse.maas.io/t/11245
+#Charmed MySQL and Charmed MySQL K8s docs
+data/docs/mysql/iaas/(?P<path>.*): https://canonical-charmed-mysql.readthedocs-hosted.com/{path}
+data/docs/mysql/k8s/(?P<path>.*): https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/{path}


### PR DESCRIPTION
## Done
added wildcard redirects for Charmed MySQL doc links

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- open http://0.0.0.0:8002/data/docs/mysql/iaas/reference/profiles
  - check that it goes to https://canonical-charmed-mysql.readthedocs-hosted.com/reference//
- open http://0.0.0.0:8002/data/docs/mysql/k8s/reference/
  - you will be redirected to an RTD login page (these docs aren't public yet I guess)
## Issue / Card

Fixes WD-24865