### PR TITLE
use image template on /data and /documentation pages

### DIFF
--- a/templates/data/mysql/managed.html
+++ b/templates/data/mysql/managed.html
@@ -25,7 +25,13 @@
     layout='25/75'
     ) -%}
     {%- if slot == 'signpost_image' -%}
-      <img src="https://assets.ubuntu.com/v1/a11267a9-mysql-logo.png" alt="" />
+      {{ image(url="https://assets.ubuntu.com/v1/a11267a9-mysql-logo.png",
+            alt="",
+            width="568",
+            height="162",
+            hi_def=True,
+            loading="auto") | safe
+      }}
     {%- endif -%}
     {%- if slot == 'description' -%}
       <p>
@@ -474,6 +480,6 @@
     </div>
   </section>
 
-  {{ load_form('/data/mysql') | safe }}
+  {{ load_form("/data/mysql") | safe }}
 
 {% endblock %}

--- a/templates/data/opensearch/managed.html
+++ b/templates/data/opensearch/managed.html
@@ -207,9 +207,14 @@
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
               <div class="p-image-container is-highlighted u-hide--small u-hide--medium">
-                <img width="320"
-                     src="https://assets.ubuntu.com/v1/7a451504-Rectangle%203.png"
-                     alt="" />
+                {{ image(url="https://assets.ubuntu.com/v1/7a451504-Rectangle%203.png",
+                                alt="",
+                                width="852",
+                                height="1278",
+                                hi_def=True,
+                                sizes="320px",
+                                loading="lazy") | safe
+                }}
               </div>
               <hr class="p-rule--highlight u-hide--medium u-hide--small p-rule--muted" />
               <h3 class="p-heading--5">1. Deployment</h3>
@@ -221,9 +226,14 @@
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
               <div class="p-image-container is-highlighted u-hide--small u-hide--medium">
-                <img width="320"
-                     src="https://assets.ubuntu.com/v1/1df0e940-Rectangle%204.png"
-                     alt="" />
+                {{ image(url="https://assets.ubuntu.com/v1/1df0e940-Rectangle%204.png",
+                                alt="",
+                                width="852",
+                                height="1278",
+                                sizes="320px",
+                                hi_def=True,
+                                loading="lazy") | safe
+                }}
               </div>
               <hr class="p-rule--highlight u-hide--medium u-hide--small p-rule--muted" />
               <h3 class="p-heading--5">2. Management</h3>
@@ -235,9 +245,14 @@
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
               <div class="p-image-container is-highlighted u-hide--small u-hide--medium">
-                <img width="320"
-                     src="https://assets.ubuntu.com/v1/6cd188e9-Rectangle%202.png"
-                     alt="" />
+                {{ image(url="https://assets.ubuntu.com/v1/6cd188e9-Rectangle%202.png",
+                                alt="",
+                                width="852",
+                                height="1278",
+                                hi_def=True,
+                                sizes="320px",
+                                loading="lazy") | safe
+                }}
               </div>
               <hr class="p-rule--highlight u-hide--medium u-hide--small p-rule--muted" />
               <h3 class="p-heading--5">2. Optional handover</h3>
@@ -262,12 +277,12 @@
           <div class="p-image-wrapper">
             <div class="p-image-container u-hide--small">
               {{ image(url="https://assets.ubuntu.com/v1/b252a9b1-generic-webinar-thumbnail.png",
-                          alt="",
-                          width="1800",
-                          height="1015",
-                          hi_def=True,
-                          attrs={"class": "p-image-container__image"},
-                          loading="lazy") | safe
+                            alt="",
+                            width="1800",
+                            height="1015",
+                            hi_def=True,
+                            attrs={"class": "p-image-container__image"},
+                            loading="lazy") | safe
               }}
             </div>
           </div>
@@ -339,9 +354,7 @@
         <div class="p-card--overlay u-no-padding--top" style="min-height: 600px">
           <div class="row">
             <div class="col-4 col-medium-2 col-small-3">
-              <h3 class="u-align-text--left u-no-margin--bottom">
-                Managed OpenSearch on public cloud instances
-              </h3>
+              <h3 class="u-align-text--left u-no-margin--bottom">Managed OpenSearch on public cloud instances</h3>
             </div>
             <div class="col-2 col-medium-1 col-small-1">
               <h3 class="u-align-text--right u-no-margin--bottom">$3099</h3>
@@ -369,9 +382,7 @@
         <div class="p-card--overlay u-no-padding--top" style="min-height: 600px">
           <div class="row">
             <div class="col-4 col-medium-2 col-small-3">
-              <h3 class="u-align-text--left u-no-margin--bottom">
-                Managed OpenSearch on OpenStack
-              </h3>
+              <h3 class="u-align-text--left u-no-margin--bottom">Managed OpenSearch on OpenStack</h3>
             </div>
             <div class="col-2 col-medium-1 col-small-1">
               <h3 class="u-align-text--right u-no-margin--bottom">$9470</h3>

--- a/templates/data/opensearch/managed.html
+++ b/templates/data/opensearch/managed.html
@@ -213,6 +213,7 @@
                                 height="1278",
                                 hi_def=True,
                                 sizes="320px",
+                                attrs={"class": "p-image-container__image"},
                                 loading="lazy") | safe
                 }}
               </div>
@@ -232,6 +233,7 @@
                                 height="1278",
                                 sizes="320px",
                                 hi_def=True,
+                                attrs={"class": "p-image-container__image"},
                                 loading="lazy") | safe
                 }}
               </div>
@@ -251,6 +253,7 @@
                                 height="1278",
                                 hi_def=True,
                                 sizes="320px",
+                                attrs={"class": "p-image-container__image"},
                                 loading="lazy") | safe
                 }}
               </div>

--- a/templates/data/postgresql/what-is-postgresql.html
+++ b/templates/data/postgresql/what-is-postgresql.html
@@ -159,9 +159,14 @@
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
           <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
-            <img class="p-image-container__image"
-                 src="https://assets.ubuntu.com/v1/87f1a153-geospatial-data.png"
-                 alt="" />
+            {{ image(url="https://assets.ubuntu.com/v1/87f1a153-geospatial-data.png",
+                        alt="",
+                        width="568",
+                        height="852",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class":"p-image-container__image"}) | safe
+            }}
           </div>
         </div>
         <div class="p-equal-height-row__item">
@@ -175,9 +180,14 @@
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
           <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
-            <img class="p-image-container__image"
-                 src="https://assets.ubuntu.com/v1/05d1de66-search.png"
-                 alt="" />
+            {{ image(url="https://assets.ubuntu.com/v1/05d1de66-search.png",
+                        alt="",
+                        width="568",
+                        height="852",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class":"p-image-container__image"}) | safe
+            }}
           </div>
         </div>
         <div class="p-equal-height-row__item">

--- a/templates/data/postgresql/what-is-postgresql.html
+++ b/templates/data/postgresql/what-is-postgresql.html
@@ -117,9 +117,14 @@
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
           <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
-            <img class="p-image-container__image"
-                 src="https://assets.ubuntu.com/v1/5a4a1fb3-analytics.png"
-                 alt="" />
+            {{ image(url="https://assets.ubuntu.com/v1/5a4a1fb3-analytics.png",
+                        alt="",
+                        width="568",
+                        height="852",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class":"p-image-container__image"}) | safe
+            }}
           </div>
         </div>
         <div class="p-equal-height-row__item">
@@ -133,9 +138,14 @@
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
           <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
-            <img class="p-image-container__image"
-                 src="https://assets.ubuntu.com/v1/f43e63db-banking.png"
-                 alt="" />
+            {{ image(url="https://assets.ubuntu.com/v1/f43e63db-banking.png",
+                        alt="",
+                        width="568",
+                        height="852",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class":"p-image-container__image"}) | safe
+            }}
           </div>
         </div>
         <div class="p-equal-height-row__item">
@@ -635,6 +645,6 @@
     </div>
   </section>
 
-  {{ load_form('/data/postgresql') | safe }}
+  {{ load_form("/data/postgresql") | safe }}
 
 {% endblock %}

--- a/templates/data/spark/support.html
+++ b/templates/data/spark/support.html
@@ -147,9 +147,14 @@
         <div class="p-equal-height-row p-section--shallow">
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item p-image-container is-highlighted u-hide--small">
-              <img src="https://assets.ubuntu.com/v1/f914a490-go%20further.png"
-                   alt=""
-                   class="p-image-container__image" />
+              {{ image(url="https://assets.ubuntu.com/v1/f914a490-go%20further.png",
+                            alt="",
+                            width="568",
+                            height="853",
+                            hi_def=True,
+                            attrs={"class": "p-image-container__image"},
+                            loading="lazy") | safe
+              }}
             </div>
             <hr class="p-rule--highlight u-hide--medium u-hide--small" />
             <h3 class="p-equal-height-row__item p-heading--5">Go further</h3>
@@ -159,9 +164,14 @@
           </div>
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item p-image-container is-highlighted u-hide--small">
-              <img src="https://assets.ubuntu.com/v1/e68ed270-backed%20by%20an%20sla.png"
-                   alt=""
-                   class="p-image-container__image" />
+              {{ image(url="https://assets.ubuntu.com/v1/e68ed270-backed%20by%20an%20sla.png",
+                            alt="",
+                            width="568",
+                            height="853",
+                            hi_def=True,
+                            attrs={"class": "p-image-container__image"},
+                            loading="lazy") | safe
+              }}
             </div>
             <hr class="p-rule--highlight u-hide--medium u-hide--small" />
             <h3 class="p-equal-height-row__item p-heading--5">Backed by an SLA</h3>
@@ -171,9 +181,14 @@
           </div>
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item p-image-container is-highlighted u-hide--small">
-              <img src="https://assets.ubuntu.com/v1/da8f6c14-firefighting%20support.png"
-                   alt=""
-                   class="p-image-container__image" />
+              {{ image(url="https://assets.ubuntu.com/v1/da8f6c14-firefighting%20support.png",
+                            alt="",
+                            width="568",
+                            height="853",
+                            hi_def=True,
+                            attrs={"class": "p-image-container__image"},
+                            loading="lazy") | safe
+              }}
 
             </div>
             <hr class="p-rule--highlight u-hide--medium u-hide--small" />

--- a/templates/data/spark/support.html
+++ b/templates/data/spark/support.html
@@ -300,7 +300,7 @@
     <div class="row">
       <div class="col-3 col-medium-2 col-small-2">
         <a href="/mlops/kubeflow">
-          <div class="p-image-container is-highlighted">
+          <div class="p-image-container--16-9 is-highlighted">
             {{ image(url="https://assets.ubuntu.com/v1/cd89477e-kubeflow-logo-container-vert-fill.png",
                         alt="Kubeflow",
                         width="349",

--- a/templates/documentation/beyond-canonical.html
+++ b/templates/documentation/beyond-canonical.html
@@ -31,10 +31,12 @@
                 <a class="p-side-navigation__link" href="#open-source-events">Open-source events</a>
               </li>
               <li class="p-side-navigation__item">
-                <a class="p-side-navigation__link" href="#supporting-open-source-projects">Supporting open-source projects</a>
+                <a class="p-side-navigation__link"
+                   href="#supporting-open-source-projects">Supporting open-source projects</a>
               </li>
               <li class="p-side-navigation__item">
-                <a class="p-side-navigation__link" href="#collaboration-with-practitioners">Collaboration with practitioners</a>
+                <a class="p-side-navigation__link"
+                   href="#collaboration-with-practitioners">Collaboration with practitioners</a>
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#scientific-research-community">Scientific research community</a>
@@ -82,11 +84,14 @@
                 We regularly attend events where the topic of documentation is firmly on the table. Recent examples of participation include <a href="https://2022.pyconuk.org/">PyCon UK 2022</a>, <a href="https://www.youtube.com/watch?v=R4O2WoFC-JQ">DjangoCon Europe 2022</a>, <a href="https://events.canonical.com/event/2/">Ubuntu Summit 2022</a>, <a href="https://www.python.org/events/python-events/1379/">PyCon Namibia 2023</a>.
               </p>
               <figure>
-                <img class="p-image"
-                     src="https://assets.ubuntu.com/v1/a1630e44-working-at-canonical.jpeg"
-                     alt="Workshop participants sitting around a table analyse user needs in documentation situations"
-                     width="600"
-                     height="400" />
+                {{ image(url="https://assets.ubuntu.com/v1/a1630e44-working-at-canonical.jpeg",
+                alt="Workshop participants sitting around a table analyse user needs in documentation situations",
+                                width="600",
+                                height="400",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class":"p-image"}) | safe
+                }}
                 <figcaption>Diátaxis workshop at the Ubuntu Summit, 2022</figcaption>
               </figure>
               <p>

--- a/templates/documentation/work-and-careers.html
+++ b/templates/documentation/work-and-careers.html
@@ -105,7 +105,13 @@
                 id="in-the-documentation-team">In the documentation team</h2>
             <div class="col-2 col-medium-1">
               <div class="p-image-wrapper">
-                <img src="https://assets.ubuntu.com/v1/f75f5612-tmihoc-photo.jpg" alt="" />
+                {{ image(url="https://assets.ubuntu.com/v1/f75f5612-tmihoc-photo.jpg",
+                                alt="",
+                                width="600",
+                                height="599",
+                                hi_def=True,
+                                loading="lazy") | safe
+                }}
               </div>
               <p class="p-heading--5 u-no-margin--bottom u-sv-1">Teodora Mihoc</p>
               <p class="p-muted-heading">Technical Author (Juju)</p>
@@ -127,8 +133,13 @@
             </div>
             <div class="col-2 col-start-large-4 col-medium-1 col-start-medium-3">
               <div class="p-image-wrapper">
-                <img src="https://assets.ubuntu.com/v1/7e32a5b7-Daniele-Procida.png"
-                     alt="" />
+                {{ image(url="https://assets.ubuntu.com/v1/7e32a5b7-Daniele-Procida.png",
+                                alt="",
+                                width="470",
+                                height="470",
+                                hi_def=True,
+                                loading="lazy") | safe
+                }}
               </div>
               <p class="p-heading--5 u-no-margin--bottom u-sv-1">Daniele Procida</p>
               <p class="p-muted-heading">Director of Engineering</p>


### PR DESCRIPTION
## Done
Update assets to use the image_template to benefit from the optimisation of the image template

## QA

- Check out the demo branch
  - Check https://canonical-com-1885.demos.haus/data/mysql/managed
  - https://canonical-com-1885.demos.haus/data/opensearch/managed
  - https://canonical-com-1885.demos.haus/data/postgresql/what-is-postgresql
  - https://canonical-com-1885.demos.haus/data/spark/support
  - https://canonical-com-1885.demos.haus/documentation/beyond-canonical
  - https://canonical-com-1885.demos.haus/documentation/work-and-careers

  and ensure images load properly and are not blurry

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-23856

## Screenshots

[if relevant, include a screenshot]
