### PR TITLE
feat(WD-25572): anbox-cloud - contact form - make comment field required

### DIFF
--- a/templates/anbox-cloud/form-data.json
+++ b/templates/anbox-cloud/form-data.json
@@ -14,7 +14,7 @@
         {
           "title": "Please briefly tell us about your use case",
           "id": "comments",
-          "isRequired": false,
+          "isRequired": true,
           "fields": [
             {
               "type": "long-text",


### PR DESCRIPTION
## Done

- Make comment field required in the contact form

## QA

- Go to: https://canonical-com-1889.demos.haus/anbox-cloud#get-in-touch
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [x] The comment field should be required

## Issue / Card

Fixes [WD-25572](https://warthogs.atlassian.net/browse/WD-25572)

## Screenshots

### Before
<img width="1440" height="339" alt="image" src="https://github.com/user-attachments/assets/557d7e5e-c3d8-4258-a5a6-cca5dd2bd912" />

### After
<img width="1440" height="339" alt="image" src="https://github.com/user-attachments/assets/7188784b-6a2a-4f65-ac5b-644f86dae661" />

[WD-25572]: https://warthogs.atlassian.net/browse/WD-25572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ