### PR TITLE
feat: Add meta image to /mlops/kubeflow

### DIFF
--- a/templates/mlops/kubeflow/index.html
+++ b/templates/mlops/kubeflow/index.html
@@ -13,6 +13,8 @@
   https://docs.google.com/document/d/1Wvhl0yYV_w0BJsyZbQFKg_QV6RjMLbmQU3x0rsD2F4Q
 {% endblock meta_copydoc %}
 
+{% block meta_image %}https://assets.ubuntu.com/v1/4964cb81-servers.jpg{% endblock %}
+
 {% block body_class %}
   is-paper
 {% endblock body_class %}


### PR DESCRIPTION
## Done

- Add meta image to /mlops/kubeflow

## QA

- Check the [demo](https://canonical-com-1893.demos.haus/mlops/kubeflow) meta image is the same as in the [copydoc](https://docs.google.com/document/d/1Wvhl0yYV_w0BJsyZbQFKg_QV6RjMLbmQU3x0rsD2F4Q)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-25539
