### PR TITLE
chore: Bump Vanilla to 4.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "sass": "1.89.2",
     "use-query-params": "^2.2.1",
     "uuid": "^11.1.0",
-    "vanilla-framework": "4.29.0",
+    "vanilla-framework": "4.30.0",
     "venobox": "2.1.8",
     "yup": "^1.6.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5210,10 +5210,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@4.29.0:
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.29.0.tgz#710ee48901d49f1df41abe51cd472a47754a6e07"
-  integrity sha512-406WW2C1hkmW187R43YW/jIyYRylUVK9qcV95NEzj8tSzX+iWoCR6KF61v6nHOIggNRHNs+FaqlDSlartWfE3g==
+vanilla-framework@4.30.0:
+  version "4.30.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.30.0.tgz#165195e32cbfee1506eccb6d550bf1241304a971"
+  integrity sha512-76bFHDNcmRboRD01RcM0CEDcU+gDd8rCMJe2SFF9MJcVeRG/5nla5nBBgT+30dc/ASQOrs3Fiz5kmAT/AQlhFw==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

- Bump Vanilla to 4.30.0

## QA

- Open the [demo](https://canonical-com-1897.demos.haus/)
- Have a click around and see nothing is broken

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-25989
