### PR TITLE
fix: Broken link in terms and services

### DIFF
--- a/templates/legal/terms-and-policies/index.md
+++ b/templates/legal/terms-and-policies/index.md
@@ -26,7 +26,7 @@ Your privacy is extremely important. Our privacy policy explains what data we co
 
 Terms and conditions are for when you purchase services from Canonical.
 
-[View service terms ›](/legal/ubuntu-advantage-service-terms)
+[View service terms ›](/legal/ubuntu-pro-service-terms)
 
 ### Intellectual property rights
 


### PR DESCRIPTION
## Done

- Update link from `/legal/ubuntu-advantage-service-terms` to `/legal/ubuntu-pro-service-terms`

## QA

- Go to https://canonical-com-1903.demos.haus/legal/terms-and-policies
- Find the link for 'View service terms ›`
- See it take you to https://canonical-com-1903.demos.haus/legal/ubuntu-pro-service-terms

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-26015
