### PR TITLE
Bugfix: added acquisition url field

### DIFF
--- a/templates/maas/contact-us.html
+++ b/templates/maas/contact-us.html
@@ -3,103 +3,117 @@
 {% block page_title %}Contact us{% endblock %}
 
 {% block meta_copydoc %}
-    https://docs.google.com/document/d/12zxzauq9GV6NYVTeKCCqtwMpflRGZewE5fdTg1SZoOQ/edit
+  https://docs.google.com/document/d/12zxzauq9GV6NYVTeKCCqtwMpflRGZewE5fdTg1SZoOQ/edit
 {% endblock meta_copydoc %}
 
 {% block content %}
-    <section class="p-strip--image is-dark p-takeover--no-overlays">
-        <div class="row">
-            <div class="col-8">
-                <h1 itemprop="description">Contact Canonical</h1>
-                <p class="p-heading--4">
-                    Are you interested in adopting MAAS for enterprise use or partner with Canonical? Just fill in the form below and a member of our team will be in touch within one working day.
-                </p>
-            </div>
-            <div class="p-card col-4 u-no-margin--bottom is-light">
-                <h3 class="p-card__title">Looking for a little professional support?</h3>
-                <p>If you are a small organisation, you can purchase packs of Ubuntu Pro in our shop.</p>
-                <p>
-                    <a href="https://buy.ubuntu.com"
-                       onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Click', 'eventLabel' : 'Visit the Ubuntu Pro shop' });">Visit the Ubuntu Pro shop</a>
-                </p>
-            </div>
-        </div>
-        \
-    </section>
+  <section class="p-strip--image is-dark p-takeover--no-overlays">
+    <div class="row">
+      <div class="col-8">
+        <h1 itemprop="description">Contact Canonical</h1>
+        <p class="p-heading--4">
+          Are you interested in adopting MAAS for enterprise use or partner with Canonical? Just fill in the form below and a member of our team will be in touch within one working day.
+        </p>
+      </div>
+      <div class="p-card col-4 u-no-margin--bottom is-light">
+        <h3 class="p-card__title">Looking for a little professional support?</h3>
+        <p>If you are a small organisation, you can purchase packs of Ubuntu Pro in our shop.</p>
+        <p>
+          <a href="https://buy.ubuntu.com"
+             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Click', 'eventLabel' : 'Visit the Ubuntu Pro shop' });">Visit the Ubuntu Pro shop</a>
+        </p>
+      </div>
+    </div>
+    \
+  </section>
 
-    <section class="p-strip--light is-deep">
-        <div class="row">
-            <div class="col-8">
-                <!-- MARKETO FORM -->
-                <script src="https://assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
-                <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+  <section class="p-strip--light is-deep">
+    <div class="row">
+      <div class="col-8">
+        <!-- MARKETO FORM -->
+        <script src="https://assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
+        <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
 
-                <form action="https://ubuntu.com/marketo/submit"
-                      method="post"
-                      id="mktoForm_1337">
-                    <ul class="p-list">
-                        <li>
-                            <label for="firstName" class="is-required">First name:</label>
-                            <input required id="firstName" name="firstName" maxlength="255" type="text" />
-                        </li>
+        <form action="https://ubuntu.com/marketo/submit"
+              method="post"
+              id="mktoForm_1337">
+          <ul class="p-list">
+            <li>
+              <label for="firstName" class="is-required">First name:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text" />
+            </li>
 
-                        <li>
-                            <label for="lastName" class="is-required">Last name:</label>
-                            <input required id="lastName" name="lastName" maxlength="255" type="text" />
-                        </li>
+            <li>
+              <label for="lastName" class="is-required">Last name:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text" />
+            </li>
 
-                        <li>
-                            <label for="company" class="is-required">Company:</label>
-                            <input required id="company" name="company" maxlength="255" type="text" />
-                        </li>
+            <li>
+              <label for="company" class="is-required">Company:</label>
+              <input required id="company" name="company" maxlength="255" type="text" />
+            </li>
 
-                        <li>
-                            <label for="email" class="is-required">Work email:</label>
-                            <input required id="email" name="email" maxlength="255" type="email" />
-                        </li>
+            <li>
+              <label for="email" class="is-required">Work email:</label>
+              <input required id="email" name="email" maxlength="255" type="email" />
+            </li>
 
-                        <li>
-                            <label for="phone" class="is-required">Phone number:</label>
-                            <input required id="phone" name="phone" maxlength="255" type="tel" />
-                        </li>
-                        {% include "shared/forms/_country.html" %}
-                        <li>
-                            <label for="Comments_from_lead__c" class="is-required">What would you like to talk to us about?</label>
-                            <textarea required
-                                      id="Comments_from_lead__c"
-                                      name="Comments_from_lead__c"
-                                      rows="5"
-                                      maxlength="2000"></textarea>
-                        </li>
-                        <li>
-                            <input id="canonicalUpdatesOptIn"
-                                   name="canonicalUpdatesOptIn"
-                                   type="checkbox"
-                                   value="yes" />
-                            <label for="canonicalUpdatesOptIn">
-                                I agree to receive information about Canonical&rsquo;s products and services.
-                            </label>
-                        </li>
-                        <li class="u-sv3">
-                            In submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy/contact"
+            <li>
+              <label for="phone" class="is-required">Phone number:</label>
+              <input required id="phone" name="phone" maxlength="255" type="tel" />
+            </li>
+            {% include "shared/forms/_country.html" %}
+            <li>
+              <label for="Comments_from_lead__c" class="is-required">What would you like to talk to us about?</label>
+              <textarea required
+                        id="Comments_from_lead__c"
+                        name="Comments_from_lead__c"
+                        rows="5"
+                        maxlength="2000"></textarea>
+            </li>
+            <li>
+              <input id="canonicalUpdatesOptIn"
+                     name="canonicalUpdatesOptIn"
+                     type="checkbox"
+                     value="yes" />
+              <label for="canonicalUpdatesOptIn">
+                I agree to receive information about Canonical&rsquo;s products and services.
+              </label>
+            </li>
+            <li class="u-sv3">
+              In submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy/contact"
     target="_blank">Canonical&rsquo;s Privacy Notice</a> and <a aria-label="Read the Canonical privacy policy"
     target="_blank"
     href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.
-                        </li>
-                        <li>
-                            <button type="submit"
-                                    class="p-button--positive"
-                                    onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal link', 'eventAction' : 'Click', 'eventLabel' : 'Submit contact us' });">
-                                Submit
-                            </button>
-                        </li>
-                        <input type="hidden" name="formid" value="1337" />
-                        <input type="hidden" name="returnURL" value="/maas#success" />
-                    </ul>
-                </form>
-                <script src="https://assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
-                <!-- /MARKETO FORM -->
-            </div>
-        </div>
-    </section>
+            </li>
+            <li>
+              <button type="submit"
+                      class="p-button--positive"
+                      onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal link', 'eventAction' : 'Click', 'eventLabel' : 'Submit contact us' });">
+                Submit
+              </button>
+            </li>
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="formid"
+                   value="1337" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="returnURL"
+                   value="/maas#success" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="acquisition_url"
+                   id="acquisition_url"
+                   value="{{ request.url }}" />
+          </ul>
+        </form>
+        <script src="https://assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
+        <!-- /MARKETO FORM -->
+      </div>
+    </div>
+  </section>
 {% endblock %}


### PR DESCRIPTION
## Done
- Added field for acquisition url to send correct url

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Visit [demo](https://canonical-com-1905.demos.haus/maas/contact-us) and fill the form, see the correct acquisition url goes into network payload

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-26047

