### PR TITLE
[WD-26050] remove a section from /mlops page

### DIFF
--- a/templates/mlops/index.html
+++ b/templates/mlops/index.html
@@ -152,18 +152,6 @@
         <div class="p-section--shallow">
           <hr class="p-rule--muted" />
           <div class="p-section--shallow">
-            <h3 class="p-heading--2">Open source MLOps in the public cloud</h3>
-          </div>
-          <p>
-            Get started with machine learning in the public cloud. Use the Charmed Kubeflow appliance on AWS to experiment with MLOps quickly and scale up with Canonical's support.
-          </p>
-          <p>
-            <a href="https://aws.amazon.com/marketplace/pp/prodview-ssgryrrrydtds?sr=0-1&ref_=beagle&applicationId=AWSMPContessa">Get started with Kubeflow Appliance&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-        <div class="p-section--shallow">
-          <hr class="p-rule--muted" />
-          <div class="p-section--shallow">
             <h3 class="p-heading--2">
               Get your team up-to-date
               <br class="u-hide--small" />


### PR DESCRIPTION
## Done

- Removing a section in accordance to [this comment](https://docs.google.com/document/d/1k3-ZBUmzaiel-iTvsznJfMeV8ggkzgkSzpjMJIBd0d8/edit?disco=AAABps7phaM) from the copy doc

## QA

- Open https://canonical-com-1906.demos.haus/mlops
- Scroll down to "MLOPS SERVICES" section
- Check that the "Open source MLOps in the public cloud" part has been removed

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-26050
