### PR TITLE
[WD-25054] feat: added secondary navigation on /legal bubble

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -74,6 +74,24 @@ kafka:
     - title: Docs
       path: /data/docs/kafka/iaas
 
+legal:
+  title: Legal
+  path: /legal
+
+  children:
+    - title: Overview
+      path: /legal
+    - title: Terms and policies
+      path: /legal/terms-and-policies
+    - title: Data privacy
+      path: /legal/data-privacy
+    - title: Trademarks
+      path: /legal/trademarks
+    - title: Ubuntu Pro
+      path: /legal/ubuntu-pro
+    - title: Contributors
+      path: /legal/contributors
+
 lxd:
   title: LXD
   path: /lxd


### PR DESCRIPTION
## Done

- Added secondary navigation

## QA

- View the site locally in your web browser at: https://canonical-com-1908.demos.haus/legal
- Verify the presence of secondary navigation
- Click on nav items and make sure they all work as expected

## Issue / Card

Fixes #[WD-25054](https://warthogs.atlassian.net/browse/WD-25054)

[WD-25054]: https://warthogs.atlassian.net/browse/WD-25054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ