### PR TITLE
Bugfix: added updated link to privacy policy

### DIFF
--- a/templates/data/_form-data-kafka.html
+++ b/templates/data/_form-data-kafka.html
@@ -50,7 +50,7 @@
                       <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                     </label>
                   </li>
-                  <li class="p-list__item">In submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</li>
+                  <li class="p-list__item">By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
                   {# These are honey pot fields to catch bots #}
                   <li class="u-off-screen">
                     <label class="website" for="website">Website:</label>

--- a/templates/data/_form-data-mongodb.html
+++ b/templates/data/_form-data-mongodb.html
@@ -34,7 +34,7 @@
                   <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
-                <p>By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.</p>
+                <p>By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</p>
               </div>
               {# These are honey pot fields to catch bots #}
               <div class="u-off-screen">

--- a/templates/data/_form-data-opensearch.html
+++ b/templates/data/_form-data-opensearch.html
@@ -69,8 +69,7 @@
                 <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
               </label>
               <p>
-                By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy"
-    target="_blank">Privacy Policy</a>.
+                By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
               </p>
             </div>
             {# These are honey pot fields to catch bots #}

--- a/templates/data/_form-data-relational-dbs.html
+++ b/templates/data/_form-data-relational-dbs.html
@@ -69,8 +69,7 @@
                 <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
               </label>
               <p>
-                By submitting this form, I confirm that I have read and agree to Canonical's
-                <a href="/legal/terms-and-policies/privacy-policy" target="_blank">Privacy Policy</a>.
+                By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
               </p>
             </div>
             {# These are honey pot fields to catch bots #}

--- a/templates/data/_form-data-spark.html
+++ b/templates/data/_form-data-spark.html
@@ -66,8 +66,7 @@
                 <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
               </label>
               <p>
-                By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy"
-    target="_blank">Privacy Policy</a>.
+                By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
               </p>
             </div>
             {# These are honey pot fields to catch bots #}

--- a/templates/data/_form-data-valkey.html
+++ b/templates/data/_form-data-valkey.html
@@ -65,8 +65,7 @@
                 <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
               </label>
               <p>
-                By submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy"
-    target="_blank">Privacy Policy</a>.
+                By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
               </p>
             </div>
             {# These are honey pot fields to catch bots #}

--- a/templates/legal/terms-and-policies/snap-store-terms.md
+++ b/templates/legal/terms-and-policies/snap-store-terms.md
@@ -91,7 +91,7 @@ Additional Snap Store services may require payment of fees, such as access to a 
 
 ## 13\. Personal data
 
-Our [Privacy Notice](/legal/data-privacy/snap-store) and [Privacy Policy](/legal/terms-and-policies/privacy-policy) explain how we treat your personal data and protect your privacy.
+Our [Privacy Notice](/legal/data-privacy/snap-store) and [Privacy Policy](/legal/data-privacy) explain how we treat your personal data and protect your privacy.
 
 ## 14\. Limitation of liability
 

--- a/templates/legal/ubuntu-pro/personal/index.md
+++ b/templates/legal/ubuntu-pro/personal/index.md
@@ -66,7 +66,7 @@ Use of Canonical intellectual property is subject to [Canonical's intellectual p
 
 So that we can provide the Service to you, you will be required to provide information about yourself such as your name and email address. Any such information you provide to Canonical must always be accurate, correct and up to date and in compliance with these Terms of Service.
 
-Our [Single Sign On Privacy Notice](/legal/data-privacy/sso) and [Privacy Policy](/legal/terms-and-policies/privacy-policy) explain how we treat your personal data and protect your privacy when using these Services. In addition, if you use the Service for more than the entitled number of Ubuntu systems Canonical may contact you directly, using the SSO account details provided, to discuss ongoing maintenance and support requirements.
+Our [Single Sign On Privacy Notice](/legal/data-privacy/sso) and [Privacy Policy](/legal/data-policy) explain how we treat your personal data and protect your privacy when using these Services. In addition, if you use the Service for more than the entitled number of Ubuntu systems Canonical may contact you directly, using the SSO account details provided, to discuss ongoing maintenance and support requirements.
 
 We may also collect certain non-personally-identifiable information, which is located on your computer. The information collected may include statistics relating to how often data is transferred, and performance metrics in relation to software and configuration. You agree this information may be retained and used by Canonical.
 

--- a/templates/legal/ubuntu-pro/personal/index.md
+++ b/templates/legal/ubuntu-pro/personal/index.md
@@ -66,7 +66,7 @@ Use of Canonical intellectual property is subject to [Canonical's intellectual p
 
 So that we can provide the Service to you, you will be required to provide information about yourself such as your name and email address. Any such information you provide to Canonical must always be accurate, correct and up to date and in compliance with these Terms of Service.
 
-Our [Single Sign On Privacy Notice](/legal/data-privacy/sso) and [Privacy Policy](/legal/data-policy) explain how we treat your personal data and protect your privacy when using these Services. In addition, if you use the Service for more than the entitled number of Ubuntu systems Canonical may contact you directly, using the SSO account details provided, to discuss ongoing maintenance and support requirements.
+Our [Single Sign On Privacy Notice](/legal/data-privacy/sso) and [Privacy Policy](/legal/data-privacy) explain how we treat your personal data and protect your privacy when using these Services. In addition, if you use the Service for more than the entitled number of Ubuntu systems Canonical may contact you directly, using the SSO account details provided, to discuss ongoing maintenance and support requirements.
 
 We may also collect certain non-personally-identifiable information, which is located on your computer. The information collected may include statistics relating to how often data is transferred, and performance metrics in relation to software and configuration. You agree this information may be retained and used by Canonical.
 

--- a/templates/maas/contact-us.html
+++ b/templates/maas/contact-us.html
@@ -81,10 +81,7 @@
               </label>
             </li>
             <li class="u-sv3">
-              In submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy/contact"
-    target="_blank">Canonical&rsquo;s Privacy Notice</a> and <a aria-label="Read the Canonical privacy policy"
-    target="_blank"
-    href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.
+              By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
             </li>
             <li>
               <button type="submit"


### PR DESCRIPTION
## Done

- added updated link to privacy policy

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Visit the  forms on [demo ](https://canonical-com-1910.demos.haus/) and see they point to correct privacy link.
- https://canonical-com-1910.demos.haus/data/kafka
- https://canonical-com-1910.demos.haus/data/mongodb
- https://canonical-com-1910.demos.haus/data/opensearch
- https://canonical-com-1910.demos.haus/data/spark
- https://canonical-com-1910.demos.haus/mass
- Also look for changes in md files.

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-26098

## Screenshots

[if relevant, include a screenshot]
