### PR TITLE
Update withdrawal reasons

### DIFF
--- a/webapp/application.py
+++ b/webapp/application.py
@@ -25,8 +25,16 @@ from webapp.requests_session import get_requests_session
 logger = logging.getLogger(__name__)
 
 withdrawal_reasons = {
-    "27987": "I've accepted another position",
-    "27992": "I've decided to stay with my current employer",
+    "97001": "Accepted another offer – compensation",
+    "97002": "Accepted another offer – role fit",
+    "97004": (
+        "I chose to remain with my current company "
+        "as the timing/offer was a better fit"
+    ),
+    "97003": (
+        "I chose to remain with my current company due to "
+        "a new opportunity/promotion"
+    ),
     "35818": "The position isn't a good fit",
     "36714": "I cannot complete the assessment",
     "33": "Other",


### PR DESCRIPTION
## Rationale

TS have updated the withdrawal reasons in GH. As such we need to update the reasons shown to candidates in the withdrawal flow on the Candidate Dash, along with the GH reason IDs they map to.

## Done

- update withdrawal reasons mapping for candidate dash

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View test candidate Bruno Fernandes' candidate dash locally in your web browser:  http://localhost:8002/careers/application/gAAAAABl2Dcq_kzb-fhHaxzIeu5P8A-wItXtC9nPndSvP3MjHrxwjC0REX-MX53dQq3Tea-3AUGuYNNEtAwPJHcVMhLOgGJRhQ==
- Run through the withdrawal process:
  - Ensure the new options show up in the withdrawal form
  - Select one, enter email (the email for this candidate is `nathan.clairmonte@canonical.com`), select "Send Email"
  - Since the site is in debug mode, you won't receive an email but you should see the debug email there in the webpage
  - Click on the "Please click here to confirm your application withdrawal" link to confirm withdrawal
  - Page will refresh, you should see the debug emails sent to HL and candidate there in the page
  - Since greenhouse API class is in debug mode, application rejection will not actually occur. Instead, inspect logs to find the `SKIP reject_application 345462494 2529900 97004`
  - Ensure that the last value, the rejection reason ID, matches that of the option you selected from the dropdown.

## Issue / Card

[TSP-1417](https://warthogs.atlassian.net/browse/TSP-1417)


[TSP-1417]: https://warthogs.atlassian.net/browse/TSP-1417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ