### PR TITLE
Feat: Added redirect for blog tag

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1440,3 +1440,7 @@ jaas/blog: https://juju.is/blog
 jaas/u/(?P<username>.*)/(?P<charm_or_bundle_name>.*): https://charmhub.io/{username}-{charm_or_bundle_name}
 jaas/u/(?P<username>.*)/(?P<charm_or_bundle_name>.*)/(?P<series_or_version>.*): https://charmhub.io/{username}-{charm_or_bundle_name}
 jaas/u/(?P<username>.*)/(?P<charm_or_bundle_name>.*)/(?P<series_or_version>.*)/(?P<version>.*): https://charmhub.io/{username}-{charm_or_bundle_name}
+
+
+# Blog redirects
+blog/tag/charmed-aether-sd-core: /solutions/telco 


### PR DESCRIPTION
## Done

- Added redirect for blog tag charmed-aether-sd-core

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Verify that https://canonical-com-1919.demos.haus/blog/tag/charmed-aether-sd-core redirects to  https://canonical-com-1919.demos.haus/solutions/telco 

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-25992

