### PR TITLE
Feat: Updated navigation for /mlops

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -111,14 +111,15 @@ mlops:
   path: /mlops
 
   children:
-    - title: Feast
-      path: /mlops/feast
-    - title: MLFlow
-      path: /mlops/mlflow
-    - title: MLOps workshop
-      path: /mlops/mlops-workshop
     - title: Kubeflow
       path: /mlops/kubeflow
+    - title: MLFlow
+      path: /mlops/mlflow
+    - title: Feast
+      path: /mlops/feast
+    - title: MLOps workshop
+      path: /mlops/mlops-workshop
+
 
 mongodb:
   title: MongoDB


### PR DESCRIPTION
## Done

-  Updated navigation for /mlops

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- See [Demo](https://canonical-com-1922.demos.haus/mlops) and check if it matches
<img width="878" height="855" alt="Screenshot 2025-08-27 at 10 44 15" src="https://github.com/user-attachments/assets/fbf48e49-3e00-47ae-b3be-677cbe8242d1" />


## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-26149

## Screenshots

[if relevant, include a screenshot]
