### PR TITLE
fix: clipped blog card on homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1209,7 +1209,7 @@
         </div>
         <hr class="p-rule--muted u-hide--large" />
         <div class="col-9 col-medium-6">
-          <div class="scroll-section__contentArea">
+          <div class="scroll-section__contentArea" style="min-height: 25rem;">
             <div class="scroll-section__content active" aria-hidden="false">
               <div class="row" data-js="latest-news">
                 <div class="col-9">


### PR DESCRIPTION
## Done
add min-height to scroll-section blog card to prevent layout shift

## QA

- Check out the homepage on the [demo](https://canonical-com-1923.demos.haus/)
- Scroll to the bottom
- Ensure the blog cards are not clipped
- Compare that to the homepage on [production](https://canonical.com)

## Issue / Card

Fixes #

## Screenshots
Before
<img width="3082" height="902" alt="image" src="https://github.com/user-attachments/assets/7b31a3e8-cab1-41d7-b8da-d76dfd9bb918" />
After
<img width="3008" height="1152" alt="image" src="https://github.com/user-attachments/assets/825405cb-7f30-4a0d-8408-97d9b7d4c0de" />

[if relevant, include a screenshot]
