### PR TITLE
fix: ubuntu pro link

### DIFF
--- a/templates/legal/ubuntu-pro/index.md
+++ b/templates/legal/ubuntu-pro/index.md
@@ -7,9 +7,9 @@ context:
 
 # Ubuntu Pro
 
-[Ubuntu Pro](/pro) is Canonical's service package for Ubuntu. It offers tiered levels of support for desktop, server and cloud deployments. In this section, you can see our service description, but don't forget that there will still be some details in your customer agreement that are specific to your deployment.
+[Ubuntu Pro](https://ubuntu.com/pro) is Canonical's service package for Ubuntu. It offers tiered levels of support for desktop, server and cloud deployments. In this section, you can see our service description, but don't forget that there will still be some details in your customer agreement that are specific to your deployment.
 
-If you're interested in support for an Ubuntu deployment or you're a reseller and you want to offer it to your customers, you can [learn more about Ubuntu Pro here](/pro).
+If you're interested in support for an Ubuntu deployment or you're a reseller and you want to offer it to your customers, you can [learn more about Ubuntu Pro here](https://ubuntu.com/pro).
 
 ### Ubuntu Pro service description
 


### PR DESCRIPTION
## Done

- Fixed ubuntu pro URL

## QA

- View the site locally in your web browser at: https://canonical-com-1934.demos.haus/legal/ubuntu-pro
- Click the `Ubuntu Pro` links see that they submit, check that [this issue](https://github.com/canonical/canonical.com/issues/1928) is fixed 
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes [WD-26366](https://warthogs.atlassian.net/browse/WD-26366)


[WD-26366]: https://warthogs.atlassian.net/browse/WD-26366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ