### PR TITLE
fix: Remove /openstack/resources as it is returning 504

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -212,8 +212,6 @@ openstack:
       path: /openstack/compare
     - title: Support
       path: /openstack/support
-    - title: Resources
-      path: /openstack/resources
     - title: Docs
       path: https://canonical-openstack.readthedocs-hosted.com/en/latest/
 


### PR DESCRIPTION
## Done

- Remove /openstack/resources from the secondary navigation as it is returning 504

## QA

- Open the demo
- See that 'Resources' is not in the secondary navigation

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
