### PR TITLE
reduce directory timeout to 5sec

### DIFF
--- a/webapp/application.py
+++ b/webapp/application.py
@@ -110,7 +110,7 @@ def _get_employee_directory_data(employee_id: str):
         headers={"Authorization": directory_api_token},
         use_json=True,
         verify=False,
-        timeout=10,
+        timeout=5,
     )
     client = Client(transport=transport)
     filter_term = r"{id: $id}"


### PR DESCRIPTION
## Done

- directory timeout reduced to 5 sec

## Why

- directory timeout value is the same as gateways (10s)
- gateway timeout is triggered when directory is not responding
- candidate page should still load if directory is not working.

