### PR TITLE
fix: add missing path to docs redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -25,8 +25,8 @@ careers/sustainability/?: "/careers/company-culture/sustainability"
 careers/ethics/?: "/careers/company-culture"
 data/docs/postgresql/iaas(?P<path>.*)/?: "https://canonical-charmed-postgresql.readthedocs-hosted.com/14/{path}"
 data/docs/postgresql/k8s(?P<path>.*)/?: "https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/14/{path}"
-data/docs/kafka/iaas(?P<path>.*)/?: https://documentation.ubuntu.com/charmed-kafka
-data/docs/kafka/k8s(?P<path>.*)/?: https://documentation.ubuntu.com/charmed-kafka-k8s
+data/docs/kafka/iaas(?P<path>.*)/?: "https://documentation.ubuntu.com/charmed-kafka/3/{path}"
+data/docs/kafka/k8s(?P<path>.*)/?: "https://documentation.ubuntu.com/charmed-kafka-k8s/3/{path}"
 partners/apps-and-snaps/?: "/partners"
 partners/kubernetes/?: "/partners"
 partners/devices-and-iot/?: "/partners/iot-device"


### PR DESCRIPTION
## Done

- Add missing path wildcard to docs redirect

## QA

- Go to https://canonical-com-1945.demos.haus/data/docs/kafka/iaas/h-cluster-migration
- See that it redirects to https://documentation.ubuntu.com/charmed-kafka/3/how-to/cluster/migrate/
- Go to https://canonical-com-1945.demos.haus/data/docs/kafka/k8s/h-deploy
- See that it redirects to https://documentation.ubuntu.com/charmed-kafka-k8s/3/how-to/deploy/

## Issue / Card

Fixes [WD-26762](https://warthogs.atlassian.net/browse/WD-26762)

## Screenshots

[if relevant, include a screenshot]


[WD-26762]: https://warthogs.atlassian.net/browse/WD-26762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ