### PR TITLE
[WD-26911] fix: failing newsletter form

### DIFF
--- a/templates/openstack/resources.html
+++ b/templates/openstack/resources.html
@@ -682,8 +682,8 @@
   {% call(slot) vf_newsletter_signup(
     layout="50-50",
     title_text="Sign up for our monthly OpenStack newsletter",
-    form_id="mktoForm_7615",
-    return_url="https://ubuntu.com/#contact-form-success",
+    form_id="7615",
+    return_url="https://canonical.com/openstack/resources#contact-form-success",
     input_label='Your email address',
     checkbox_id='canonicalUpdatesOptIn',
     checkbox_label='I agree to receive information about Canonical\'s products and services.') %}


### PR DESCRIPTION
## Done

- Fixed a failing newsletter form

## QA

- View the site locally in your web browser at: https://canonical-com-1946.demos.haus/openstack/resources
- Click on "Sign up for newsletter" button
- Fill the form
- Submit and verify the form goes through sucessfully

## Issue / Card

Fixes #[WD-26911](https://warthogs.atlassian.net/browse/WD-26911)

[WD-26911]: https://warthogs.atlassian.net/browse/WD-26911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ