### PR TITLE
[WD-26916] fix: Expand and highlight currently opened docs navigation item

### DIFF
--- a/templates/docs/shared/_docs.html
+++ b/templates/docs/shared/_docs.html
@@ -26,15 +26,7 @@
         {% if expandable %}
           {% if element.children %}
             <button class="p-side-navigation__expand"
-                    aria-expanded="{% if element.is_active or element.has_active_child %}"
-                    "
-                    true
-                    "
-                    {% else %}
-                    "
-                    false
-                    "
-                    {% endif %}
+                    aria-expanded="{% if element.is_active or element.has_active_child %}true{% else %}false{% endif %}"
                     aria-label="show submenu for {{ element.navlink_text }}"></button>
           {% endif %}
           {{ create_navigation(element.children, expandable, element.is_active or element.has_active_child) }}


### PR DESCRIPTION
## Done

- Fixed currently opened doc link not expanded and highlighted in side nav

## QA

- View the site in your web browser at: https://canonical-com-1951.demos.haus/maas/docs/how-to-back-up-maas
- Verify the current page is expanded and highlighted in the left sidebar
- Select different links and make sure they're highlighted too

## Issue / Card

Fixes #[WD-26916](https://warthogs.atlassian.net/browse/WD-26916)


[WD-26916]: https://warthogs.atlassian.net/browse/WD-26916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ