### PR TITLE
Update logic for bubble nav to match exact child path

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -306,6 +306,10 @@ data-and-ai:
   path: /solutions/data-and-ai
 
   children:
+    - title: Overview
+      path: /solutions/data-and-ai
+    - title: Data warehouse
+      path: /data/warehouse
     - title: Data lakehouse
       path: /data/lakehouse
     - title: Data streaming

--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -306,10 +306,6 @@ data-and-ai:
   path: /solutions/data-and-ai
 
   children:
-    - title: Overview
-      path: /solutions/data-and-ai
-    - title: Data warehouse
-      path: /data/warehouse
     - title: Data lakehouse
       path: /data/lakehouse
     - title: Data streaming

--- a/webapp/navigation.py
+++ b/webapp/navigation.py
@@ -40,23 +40,26 @@ def get_current_page_bubble(path):
     for page_bubble_name, page_bubble in page_bubbles.items():
         bubble_path = page_bubble.get("path", "")
 
-        # 1) Exact match on the bubble path (e.g. /solutions/ai should match the 'ai' bubble)
+        # 1) Exact match on the bubble path
+        # (e.g. /solutions/ai should match the 'ai' bubble)
         if bubble_path == normalized_path:
             exact_bubble_match = page_bubble
             break
 
-        # 2) Exact match on any child path (for cases like /data/warehouse, /data/streaming
+        # 2) Exact match on any child path
+        # (for cases like /data/warehouse, /data/streaming
         #    that should select the 'data-and-ai' bubble)
         for child in page_bubble.get("children", []) or []:
             child_path = child.get("path")
-            child_paths = child.get("paths", [])
 
-            if child_path == normalized_path or path in child_paths or normalized_path in child_paths:
+            if child_path == normalized_path:
                 exact_child_match = page_bubble
-                # We found a suitable child match; no need to check more children for this bubble
+                # We found a suitable child match;
+                # no need to check more children for this bubble
                 break
 
-        # 3) Longest prefix match as a fallback (keeps general behavior like /data -> 'data' bubble)
+        # 3) Longest prefix match as a fallback
+        # (keeps general behavior like /data -> 'data' bubble)
         if normalized_path.startswith(bubble_path):
             fallback_match = page_bubble
 
@@ -73,7 +76,10 @@ def get_current_page_bubble(path):
         children = current_page_bubble.get("children", [])
         if children:
             for page in children:
-                if page.get("path") == normalized_path or page.get("path") == path:
+                if (
+                    page.get("path") == normalized_path
+                    or page.get("path") == path
+                ):
                     page["active"] = True
 
     return {"page_bubble": current_page_bubble}
@@ -111,6 +117,6 @@ def split_list(array, parts):
 
     k, m = divmod(len(array), parts)
     return [
-        array[i * k + min(i, m): (i + 1) * k + min(i + 1, m)]
+        array[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)]
         for i in range(parts)
     ]

--- a/webapp/navigation.py
+++ b/webapp/navigation.py
@@ -29,20 +29,52 @@ def get_current_page_bubble(path):
 
     page_bubbles = copy.deepcopy(secondary_navigation_data)
 
+    # Priority order for selecting the bubble:
+    # 1) Exact match on a bubble's own path
+    # 2) Exact match on any child path
+    # 3) fallback match on a bubble's path
+    exact_bubble_match = None
+    exact_child_match = None
+    fallback_match = None
+
     for page_bubble_name, page_bubble in page_bubbles.items():
-        if normalized_path.startswith(page_bubble["path"]):
-            current_page_bubble = page_bubble
-            parent = page_bubble.get("parent", None)
+        bubble_path = page_bubble.get("path", "")
 
-            if parent:
-                current_page_bubble["parent_title"] = parent[0]["title"]
-                current_page_bubble["parent_path"] = parent[1]["path"]
+        # 1) Exact match on the bubble path (e.g. /solutions/ai should match the 'ai' bubble)
+        if bubble_path == normalized_path:
+            exact_bubble_match = page_bubble
+            break
 
-            children = page_bubble.get("children", [])
-            if children:
-                for page in children:
-                    if page["path"] == path:
-                        page["active"] = True
+        # 2) Exact match on any child path (for cases like /data/warehouse, /data/streaming
+        #    that should select the 'data-and-ai' bubble)
+        for child in page_bubble.get("children", []) or []:
+            child_path = child.get("path")
+            child_paths = child.get("paths", [])
+
+            if child_path == normalized_path or path in child_paths or normalized_path in child_paths:
+                exact_child_match = page_bubble
+                # We found a suitable child match; no need to check more children for this bubble
+                break
+
+        # 3) Longest prefix match as a fallback (keeps general behavior like /data -> 'data' bubble)
+        if normalized_path.startswith(bubble_path):
+            fallback_match = page_bubble
+
+    chosen_bubble = exact_bubble_match or exact_child_match or fallback_match
+
+    if chosen_bubble:
+        current_page_bubble = chosen_bubble
+        parent = chosen_bubble.get("parent", None)
+
+        if parent:
+            current_page_bubble["parent_title"] = parent[0]["title"]
+            current_page_bubble["parent_path"] = parent[1]["path"]
+
+        children = current_page_bubble.get("children", [])
+        if children:
+            for page in children:
+                if page.get("path") == normalized_path or page.get("path") == path:
+                    page["active"] = True
 
     return {"page_bubble": current_page_bubble}
 
@@ -79,6 +111,6 @@ def split_list(array, parts):
 
     k, m = divmod(len(array), parts)
     return [
-        array[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)]
+        array[i * k + min(i, m): (i + 1) * k + min(i + 1, m)]
         for i in range(parts)
     ]


### PR DESCRIPTION
The secondary navigation resolver matched by prefix first, causing generic parent bubbles (e.g., "/data") to override more specific mappings. Pages that are explicit children of another bubble could be misclassified. This happened because:
1. The algorithm processed bubbles in order and stopped at the first prefix match
2. `/data/lakehouse` starts with `/data`, so it matched the 'data' bubble first
3. It never checked the 'data-and-ai' bubble where these paths are explicitly defined as children
 
## Done
Update get_current_page_bubble to:
- First check for exact child path matches across all bubbles using the normalized path.
- Then fall back to prefix matching if no exact child match is found.

Outcome: 
- /data/lakehouse, /data/streaming → Data & AI bubble
- /solutions/ai → AI bubble

## QA

- Go to https://canonical-com-1955.demos.haus/solutions/data-and-ai
- Click "Data streaming" and ensure it remains in the `Data and AI` bubble
- Click "Data warehouse" and ensure it remains in the `Data and AI` bubble
- Click "AI solutions" and ensure it takes you to the `AI` bubble
- and compare that with prod https://canonical.com/solutions/data-and-ai
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
