### PR TITLE
fix(projects): remove aether project [WD-26978]

### DIFF
--- a/templates/projects/index.html
+++ b/templates/projects/index.html
@@ -213,50 +213,40 @@
       {%- endif -%}
 
       {%- if slot == 'list_item_title_13' -%}
-        <a class="p-heading--5" href="https://aetherproject.org">Aether project</a>
-      {%- endif -%}
-
-      {%- if slot == 'list_item_description_13' -%}
-        <p>
-          The Aether project helps organizations to set up private local mobile 5G networks. Powered by cloud-native technology, these networks are customizable, and allow users to connect devices securely and reliably. 
-        </p>
-      {%- endif -%}
-
-      {%- if slot == 'list_item_title_14' -%}
         <a class="p-heading--5" href="https://opensearch.org">OpenSearch</a>
       {%- endif -%}
 
-      {%- if slot == 'list_item_description_14' -%}
+      {%- if slot == 'list_item_description_13' -%}
         <p>
           Generating useful insights from massive data sets can be difficult and slow. OpenSearch is a powerful tool that helps you search, analyze, and visualize huge amounts of data in real time. It is also used for data observability, data ingestion, Security Event and Information Management (SIEM), vector databases and more.
         </p>
       {%- endif -%}
 
-      {%- if slot == 'list_item_title_15' -%}
+      {%- if slot == 'list_item_title_14' -%}
         <a class="p-heading--5" href="https://valkey.io">Valkey</a>
       {%- endif -%}
 
-      {%- if slot == 'list_item_description_15' -%}
+      {%- if slot == 'list_item_description_14' -%}
         <p>
           Valkey is a low-latency in-memory store. It is typically used as a cache to improve application response times but can also be used to perform real-time analytics or as a lightweight message queueing system. 
         </p>
       {%- endif -%}
 
-      {%- if slot == 'list_item_title_16' -%}
+      {%- if slot == 'list_item_title_15' -%}
         <a class="p-heading--5" href="https://sylvaproject.org">Sylva project</a>
       {%- endif -%}
 
-      {%- if slot == 'list_item_description_16' -%}
+      {%- if slot == 'list_item_description_15' -%}
         <p>
           Sylva was born from the need for a Telco-friendly infrastructure platform. Europe's main carriers and network providers are working together on creating scalable, cloud-native infrastructure that can be deployed on any compliant platform.
         </p>
       {%- endif -%}
 
-      {%- if slot == 'list_item_title_17' -%}
+      {%- if slot == 'list_item_title_16' -%}
         <a class="p-heading--5" href="https://www.gnome.org">GNOME</a>
       {%- endif -%}
 
-      {%- if slot == 'list_item_description_17' -%}
+      {%- if slot == 'list_item_description_16' -%}
         <p>
           For nearly three decades, GNOME has been developing a free, independent, and beautiful open source desktop environment. GNOME provides the user experience for the main Linux distributions, and has expanded to essential apps, an app development platform and runtime environment, and more.
         </p>


### PR DESCRIPTION
## Done

- Removed "Aether project" from [/projects](https://canonical-com-1957.demos.haus/projects) ([Copy doc](https://docs.google.com/document/d/1GTnsk_Fk-ZHJQi--6X2TuaURwUCwnxZQjKdWDFBsaS0/edit?tab=t.0) - [Jira](https://warthogs.atlassian.net/browse/WD-26978))

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Go to [/projects](https://canonical-com-1957.demos.haus/projects)
- Check that "Aether project" is not included anymore in the section about "open source projects we support"

## Issue / Card

Fixes [WD-26978](https://warthogs.atlassian.net/browse/WD-26978)

[WD-26978]: https://warthogs.atlassian.net/browse/WD-26978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ