### PR TITLE
retry candidate dashboard requests

### DIFF
--- a/webapp/application.py
+++ b/webapp/application.py
@@ -20,7 +20,7 @@ from webapp.job_regions import regions
 from webapp.utils.cipher import Cipher, InvalidToken
 from webapp.google_calendar import CalendarAPI
 from webapp.utils.constants import ONE_WEEK_IN_MINUTES, SECOND_LOOK_REQ_ID
-from webapp.requests_session import get_requests_session
+from webapp.requests_session import get_requests_session_with_retries
 
 logger = logging.getLogger(__name__)
 
@@ -439,7 +439,7 @@ def application_access_denied():
 
 @application.route("/<string:token>")
 def handle_application_index(token):
-    with get_requests_session() as session:
+    with get_requests_session_with_retries() as session:
         harvest = Harvest.from_session(session)
         return application_index(harvest, token)
 
@@ -473,7 +473,7 @@ def application_index(harvest, token):
 
 @application.route("/get-report/<string:token>", methods=["POST"])
 def handle_application_report(token):
-    with get_requests_session() as session:
+    with get_requests_session_with_retries() as session:
         harvest = Harvest.from_session(session)
         return application_report(harvest, token)
 
@@ -503,7 +503,7 @@ def application_report(harvest, token):
 
 @application.route("/withdraw/<string:token>")
 def handle_application_withdrawal(token):
-    with get_requests_session() as session:
+    with get_requests_session_with_retries() as session:
         harvest = Harvest.from_session(session)
         return application_withdrawal(harvest, token)
 
@@ -669,7 +669,7 @@ def application_withdrawal(harvest, token):
 
 @application.route("/<string:token>", methods=["POST"])
 def handle_request_withdrawal(token):
-    with get_requests_session() as session:
+    with get_requests_session_with_retries() as session:
         harvest = Harvest.from_session(session)
         return request_withdrawal(harvest, token)
 

--- a/webapp/requests_session.py
+++ b/webapp/requests_session.py
@@ -1,4 +1,5 @@
 import requests
+from requests.adapters import HTTPAdapter, Retry
 import talisker.requests
 
 
@@ -6,3 +7,21 @@ def get_requests_session():
     session = requests.Session()
     talisker.requests.configure(session)
     return session
+
+
+def get_requests_session_with_retries():
+    session = get_requests_session()
+    retry_strategy = Retry(
+        total=5,
+        backoff_factor=1,
+        backoff_max=5,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET", "POST", "PATCH", "PUT"],
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+


### PR DESCRIPTION
## Done

- add retries to greenhouse endpoints in candidate dashboard

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- check test candidate page