### PR TITLE
Add livechat domains to CSP policy

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -86,6 +86,7 @@ CSP = {
         "api.livechatinc.com",
         "cdn.livechatinc.com",
         "secure.livechatinc.com",
+        "web.facebook.com",
     ],
     "frame-src": [
         "'self'",
@@ -112,6 +113,7 @@ CSP = {
     ],
     "child-src": [
         "'self'",
+        "blob:",
         "youtube.com",
         "google.com",
         "fonts.google.com",


### PR DESCRIPTION
## Done
Add necessary livechat domains to Content Security Policy to support livechat functionality

[List of work items including drive-bys]

## QA

- Check out [/data](https://canonical-com-1967.demos.haus/data)
- Open the dev console, ensure there are no errors.
- Compare that with https://canonical.com/data
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes # [WD-27332](https://warthogs.atlassian.net/browse/WD-27332)

## Screenshots
### Current
<img width="519" height="330" alt="image" src="https://github.com/user-attachments/assets/040384a9-d700-452f-b834-c5edda4f190b" />


[if relevant, include a screenshot]


[WD-27332]: https://warthogs.atlassian.net/browse/WD-27332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ