### PR TITLE
WD-27608: `/data/spark/what-is-spark` copy updates

### DIFF
--- a/templates/data/spark/what-is-spark.html
+++ b/templates/data/spark/what-is-spark.html
@@ -298,7 +298,7 @@
         <p>
           Spark is a distributed system developed in Java, designed for computers running Ubuntu and other Linux distributions.
         </p>
-        <p>You can use Canonical's Charmed Spark solution to deploy a fully supported Spark solution on Kubernetes.</p>
+        <p>You can use Charmed Apache Spark to deploy a fully supported Spark solution on Kubernetes.</p>
         <div class="p-cta-block">
           <a class="p-button--positive" href="/data/docs/spark/k8s">Try Charmed Spark</a>
         </div>
@@ -311,7 +311,7 @@
       <div class="row--50-50">
         <hr class="p-rule" />
         <div class="col">
-          <h2>Canonical's Charmed Spark</h2>
+          <h2>Charmed Apache Spark</h2>
         </div>
         <div class="col">
           <p>
@@ -329,7 +329,7 @@
           </div>
           <div class="col-6 col-medium-3">
             <p class="p-heading--5">Included in Ubuntu Pro + Support</p>
-            <p>When you purchase an Ubuntu Pro + Support  plan, you also get support for the full Charmed Spark solution.</p>
+            <p>When you purchase an Ubuntu Pro + Support  plan, you also get support for the full Charmed Apache Spark solution.</p>
             <hr class="p-rule--muted u-no-margin--bottom" />
             <ul class="p-list--divided u-no-margin--bottom">
               <li class="p-list__item is-ticked">Up to 10 years of Spark support per release track</li>


### PR DESCRIPTION
## Done

Updated three changes regarding Apache Spark, see copy doc: https://docs.google.com/document/d/1pyX-BOXmIZY6_8imIft1SAp1-S0i8bGYWEo5zoVEgQw/edit?tab=t.0

## QA

- See live demo: https://canonical-com-1973.demos.haus/data/spark/what-is-spark

## Issue / Card

https://warthogs.atlassian.net/browse/WD-27608?actionerId=63bbef0b04b5f5c7b5ecd3cf&sourceType=assign

## Screenshots

<img width="1391" height="638" alt="image" src="https://github.com/user-attachments/assets/ee06474d-8990-47cb-b3db-54ad70364546" />
