### PR TITLE
WD-28108: /data/spark/support MLFlow image resize - Dev Update

### DIFF
--- a/templates/data/spark/support.html
+++ b/templates/data/spark/support.html
@@ -332,7 +332,7 @@
       </div>
       <div class="col-3 col-medium-2 col-small-2">
         <a href="/mlops/mlflow">
-          <div class="p-image-container is-highlighted">
+          <div class="p-image-container--16-9 is-highlighted">
             {{ image(url="https://assets.ubuntu.com/v1/104192d9-mlflow-logo-container-vert-fill.png",
                         alt="MLflow",
                         width="222",


### PR DESCRIPTION
## Done

Added `p-image-container--16-9` class to the MLFlow div container to resize the image to the correct dimensions, and to match with other assets in the same section.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/data/spark/support
- Scroll to the bottom section where the images grid are displayed as shown in the screenshots below

## Issue / Card

Fixes # [Dev - Update canonical.com/data/spark/support](https://warthogs.atlassian.net/browse/WD-28108)

## Screenshots

**Before**
<img width="1463" height="785" alt="Screenshot from 2025-10-02 21-06-36" src="https://github.com/user-attachments/assets/452fa868-57b3-4c13-826e-86bc3ac0f25f" />
 
**After**
<img width="1463" height="785" alt="Screenshot from 2025-10-02 21-05-59" src="https://github.com/user-attachments/assets/c02b93e2-a1c5-427a-a7c0-b0a156944828" />
