### PR TITLE
feat: rename MongoDB and add chips

### DIFF
--- a/templates/data/mysql/index.html
+++ b/templates/data/mysql/index.html
@@ -212,7 +212,7 @@
           </ul>
           <hr class="p-rule--muted" />
           <p>
-            <a href="https://charmhub.io/mysql">Get started with Charmed MySQL&nbsp;&rsaquo;</a>
+            <a href="https://canonical-charmed-mysql.readthedocs-hosted.com">Get started with Charmed MySQL&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>
@@ -489,7 +489,7 @@
         <div class="row">
           <div class="col-3 col-medium-2">
             <h3 class="p-heading--5">
-              Documentation for <a href="https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/">K8s</a> and <a href="https://canonical-charmed-mysql.readthedocs-hosted.com/">VMs</a>
+              Documentation for <a href="https://canonical-charmed-mysql-k8s.readthedocs-hosted.com">K8s</a> and <a href="https://canonical-charmed-mysql.readthedocs-hosted.com">VMs</a>
             </h3>
           </div>
           <div class="col-6 col-medium-4 p-section--shallow">

--- a/templates/data/relational-databases.html
+++ b/templates/data/relational-databases.html
@@ -311,7 +311,7 @@ meta_copydoc %}
         <div class="row">
           <div class="col-2">
             <h3 class="p-heading--5 u-no-margin--bottom">
-              <a href="https://charmhub.io/mysql">MySQL</a>
+              <a href="https://canonical-charmed-mysql.readthedocs-hosted.com">MySQL</a>
             </h3>
           </div>
           <div class="col-4">

--- a/templates/juju/charmhub-community.html
+++ b/templates/juju/charmhub-community.html
@@ -164,7 +164,7 @@
             <p>Open-source relational database management system</p>
           </div>
           <div class="grid-col-2">
-            <a href="https://charmhub.io/mysql" aria-label="MySQL">
+            <a href="https://canonical-charmed-mysql.readthedocs-hosted.com" aria-label="MySQL">
               {{ image(url="https://assets.ubuntu.com/v1/64c18861-mysql_logo.png",
                             alt="",
                             height="339",
@@ -177,7 +177,7 @@
               }}
             </a>
             <p class="p-heading--5 u-no-margin--bottom">
-              <a href="https://charmhub.io/mysql">MySQL</a>
+              <a href="https://canonical-charmed-mysql.readthedocs-hosted.com">MySQL</a>
             </p>
             <p>Open-source relational database management system</p>
           </div>

--- a/templates/juju/docs/index.html
+++ b/templates/juju/docs/index.html
@@ -248,7 +248,7 @@
                         </h5>
                       </div>
                       <div class="col-2 col-medium-1" style="display: flex; align-items: center">
-                        <a href="https://charmhub.io/mysql-k8s">
+                        <a href="https://canonical-charmed-mysql-k8s.readthedocs-hosted.com">
                           {{ image(url="https://assets.ubuntu.com/v1/ae2e0c53-mysql_logo.svg",
                                                     alt="MySQL",
                                                     width="70",
@@ -259,7 +259,7 @@
                         </a>
                         <h5 class="u-no-margin--bottom u-no-padding--top"
                             style="margin-left: 15px">
-                          <a href="https://charmhub.io/mysql-k8s">MySQL</a>
+                          <a href="https://canonical-charmed-mysql-k8s.readthedocs-hosted.com">MySQL</a>
                         </h5>
                       </div>
                       <div class="col-2 col-medium-1" style="display: flex; align-items: center">

--- a/templates/juju/index.html
+++ b/templates/juju/index.html
@@ -485,7 +485,7 @@
             <div class="grid-col-2 grid-col-medium-2">
               <div class="p-heading-icon u-no-margin">
                 <div class="p-heading-icon__header">
-                  <a href="https://charmhub.io/mysql">
+                  <a href="https://canonical-charmed-mysql.readthedocs-hosted.com">
                     {{ image(url="https://assets.ubuntu.com/v1/39deb703-updated_mysql.png",
                                         alt="MySQL",
                                         width="120",
@@ -515,7 +515,7 @@
               </div>
               <hr class="p-rule--muted" />
               <p>
-                <a href="https://charmhub.io/mysql">MySQL on charmhub &nbsp;&rsaquo;</a>
+                <a href="https://canonical-charmed-mysql.readthedocs-hosted.com">MySQL on charmhub &nbsp;&rsaquo;</a>
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Done

- Rename `Charmed MongoDB` to `MongoDB` on /juju
- Add `K8s` chips on /juju
- Update docs links for VMs and K8s on /data/mysql
- Both changes were requested in #1979 and #1978

## QA

- Go to https://canonical-com-1987.demos.haus/juju
- See that `Charmed MongoDB` is renamed to `MongoDB`
- Check that `K8s` chips is added as an offering for `MongoDB`
- Go to https://canonical-com-1987.demos.haus/data/mysql
- Check updated links:
  - Documentation for VMs should point to [this](https://canonical-charmed-mysql.readthedocs-hosted.com/) ReadTheDocs page.
  - Documentation for K8s should point to [this](https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/) ReadTheDocs page.

## Issue / Card

Fixes [WD-28104](https://warthogs.atlassian.net/browse/WD-28104) and [WD-28105](https://warthogs.atlassian.net/browse/WD-28105)

## Screenshots

[if relevant, include a screenshot]


[WD-28104]: https://warthogs.atlassian.net/browse/WD-28104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-28105]: https://warthogs.atlassian.net/browse/WD-28105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ