### PR TITLE
docs: add spark k8s docs redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -27,6 +27,7 @@ data/docs/postgresql/iaas(?P<path>.*)/?: "https://canonical-charmed-postgresql.r
 data/docs/postgresql/k8s(?P<path>.*)/?: "https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/14/{path}"
 data/docs/kafka/iaas(?P<path>.*)/?: "https://documentation.ubuntu.com/charmed-kafka/3/{path}"
 data/docs/kafka/k8s(?P<path>.*)/?: "https://documentation.ubuntu.com/charmed-kafka-k8s/3/{path}"
+data/docs/spark/k8s(?P<path>.*)/?: "https://canonical-charmed-spark.readthedocs-hosted.com/main/{path}"
 partners/apps-and-snaps/?: "/partners"
 partners/kubernetes/?: "/partners"
 partners/devices-and-iot/?: "/partners/iot-device"


### PR DESCRIPTION
## Done

Setup redirects for spark docs

## QA

- Check out these URLs and ensure that they redirect to the right docs on readthedocs
  - https://canonical-com-1988.demos.haus/data/docs/spark/k8s/t-overview
  - https://canonical-com-1988.demos.haus/data/docs/spark/k8s/h-run-on-k8s-pod
  - https://canonical-com-1988.demos.haus/data/docs/spark/k8s/r-rev-2
  - https://canonical-com-1988.demos.haus/data/docs/spark/k8s/h-use-spark-client-from-python
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-27525

## Screenshots

[if relevant, include a screenshot]
