### PR TITLE
ci: set marketo test as CRON job and report failures

### DIFF
--- a/.github/workflows/forms-test.yaml
+++ b/.github/workflows/forms-test.yaml
@@ -7,8 +7,6 @@ on:
       - "templates/**"
   schedule:
     - cron: "20 7 * * *"
-env:
-  SECRET_KEY: insecure_test_key
 
 jobs:
   test-marketo-form-generator:


### PR DESCRIPTION
## Done

- Run `test-marketo` as a CRON job and on every merged PR on main
- Report failures to webge channel on MM
- Note: remove action to trigger job on individual PRs and form failure trigger

## QA

- See that [`test-marketo`](https://github.com/canonical/canonical.com/actions/runs/18492179860/job/52688159697?pr=2003) runs Marketo tests
- See that failure is raised and reported to the webge channel

## Issue / Card

Fixes [WD-29934](https://warthogs.atlassian.net/browse/WD-29934)

## Screenshots

[if relevant, include a screenshot]


[WD-29934]: https://warthogs.atlassian.net/browse/WD-29934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ