### PR TITLE
fix(WD-29337): add canonical academy link to navbar

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -107,9 +107,9 @@ products:
           - title: Certified hardware
             description: Ubuntu hardware you can trust
             url: https://ubuntu.com/certified
-          # - title: Canonical Academy
-          #   description: Real-world, industry relevant exams.
-          #   url: /academy
+          - title: Canonical Academy
+            description: Real-world, industry relevant exams.
+            url: /academy
       section_footer:
         copy: We're here to help with any questions and more information.
         cta_title: Contact us


### PR DESCRIPTION
## Done

- Add Canonical Academy link to navbar

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes [WD-29337](https://warthogs.atlassian.net/browse/WD-29337)

[WD-29337]: https://warthogs.atlassian.net/browse/WD-29337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ