### PR TITLE
ci: add missing SECRET_KEY

### DIFF
--- a/.github/workflows/forms-test.yaml
+++ b/.github/workflows/forms-test.yaml
@@ -7,6 +7,8 @@ on:
       - "templates/**"
   schedule:
     - cron: "20 7 * * *"
+env:
+  SECRET_KEY: insecure_test_key # used to configure our Flask base app
 
 jobs:
   test-marketo-form-generator:


### PR DESCRIPTION
## Done

- add `SECRET_KEY` to fix [failing action](https://github.com/canonical/canonical.com/actions/runs/18553759432/job/52886295919)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
