### PR TITLE
copy: refresh /maas/contact-us

### DIFF
--- a/templates/maas/contact-us.html
+++ b/templates/maas/contact-us.html
@@ -7,26 +7,5 @@
 {% endblock meta_copydoc %}
 
 {% block content %}
-  <section class="p-strip--image is-dark p-takeover--no-overlays">
-    <div class="row">
-      <div class="col-8">
-        <h1 itemprop="description">Contact Canonical</h1>
-        <p class="p-heading--4">
-          Are you interested in adopting MAAS for enterprise use or partner with Canonical? Just fill in the form below and a member of our team will be in touch within one working day.
-        </p>
-      </div>
-      <div class="p-card col-4 u-no-margin--bottom is-light">
-        <h3 class="p-card__title">Looking for a little professional support?</h3>
-        <p>If you are a small organisation, you can purchase packs of Ubuntu Pro in our shop.</p>
-        <p>
-          <a href="https://buy.ubuntu.com"
-             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Click', 'eventLabel' : 'Visit the Ubuntu Pro shop' });">Visit the Ubuntu Pro shop</a>
-        </p>
-      </div>
-    </div>
-    \
-  </section>
-
   {{ load_form("/maas/contact-us") | safe }}
-
 {% endblock %}

--- a/templates/maas/form-data.json
+++ b/templates/maas/form-data.json
@@ -1,9 +1,12 @@
 {
   "form": {
-    "/maas/contact-us": {
-      "templatePath": "/maas/contact-us.html",
-      "isModal": false,
+    "/maas": {
+      "templatePath": "/maas/index.html",
+      "isModal": true,
+      "modalId": "maas-contact-form",
       "formData": {
+        "title": "Contact Canonical",
+        "introText": "Are you interested in adopting MAAS for enterprise use or partner with Canonical? Just fill in the form below and a member of our team will be in touch within one working day.",
         "formId": "1337",
         "returnUrl": "/maas#contact-form-success",
         "product": "maas"
@@ -13,12 +16,79 @@
           "title": "How should we get in touch?",
           "id": "about-you",
           "noCommentsFromLead": true,
+          "fields": [{ "type": "tel", "id": "phone", "label": "Phone number" }]
+        },
+        {
+          "title": "Tell us about your project",
+          "id": "project-details",
+          "noCommentsFromLead": true,
           "fields": [
             {
-              "type": "tel",
-              "id": "phone",
-              "label": "Phone number",
-              "isRequired": false
+              "type": "long-text",
+              "id": "project-description",
+              "label": "Project Description"
+            }
+          ]
+        },
+        {
+          "title": "What is the approximate size of your deployment?",
+          "id": "deployment-size",
+          "inputType": "radio",
+          "fields": [
+            {
+              "type": "radio",
+              "id": "small",
+              "value": "Small (1-50 nodes)",
+              "label": "Small (1-50 nodes)"
+            },
+            {
+              "type": "radio",
+              "id": "medium",
+              "value": "Medium (51-250 nodes)",
+              "label": "Medium (51-250 nodes)"
+            },
+            {
+              "type": "radio",
+              "id": "large",
+              "value": "Large (251-1000 nodes)",
+              "label": "Large (251-1000 nodes)"
+            },
+            {
+              "type": "radio",
+              "id": "enterprise",
+              "value": "Enterprise (1000+ nodes)",
+              "label": "Enterprise (1000+ nodes)"
+            }
+          ]
+        },
+        {
+          "title": "What is your primary use case for MAAS?",
+          "id": "primary-use-case",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "private-cloud",
+              "value": "Private Cloud with OpenStack",
+              "label": "Private Cloud with OpenStack"
+            },
+            {
+              "type": "checkbox",
+              "id": "server-automation",
+              "value": "Server Automation",
+              "label": "Server Automation"
+            },
+            {
+              "type": "checkbox",
+              "id": "bare-metal-kubernetes",
+              "value": "Bare Metal Kubernetes",
+              "label": "Bare Metal Kubernetes"
+            },
+            {
+              "type": "checkbox",
+              "id": "other",
+              "value": "Other",
+              "label": "Other"
             }
           ]
         },
@@ -27,12 +97,108 @@
           "id": "comments",
           "required": true,
           "noCommentsFromLead": false,
+          "fields": [{ "type": "long-text", "id": "comments" }]
+        }
+      ]
+    },
+    "/maas/contact-us": {
+      "templatePath": "/maas/contact-us.html",
+      "isModal": false,
+      "modalId": "maas-contact-form-static",
+      "formData": {
+        "title": "Contact Canonical",
+        "introText": "Are you interested in adopting MAAS for enterprise use or partner with Canonical? Just fill in the form below and a member of our team will be in touch within one working day.",
+        "formId": "1337",
+        "returnUrl": "/maas/contact-us#contact-form-success",
+        "product": "maas"
+      },
+      "fieldsets": [
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [{ "type": "tel", "id": "phone", "label": "Phone number" }]
+        },
+        {
+          "title": "Tell us about your project",
+          "id": "project-details",
+          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",
-              "id": "comments"
+              "id": "project-description",
+              "label": "Project Description"
             }
           ]
+        },
+        {
+          "title": "What is the approximate size of your deployment?",
+          "id": "deployment-size",
+          "inputType": "radio",
+          "fields": [
+            {
+              "type": "radio",
+              "id": "small",
+              "value": "Small (1-50 nodes)",
+              "label": "Small (1-50 nodes)"
+            },
+            {
+              "type": "radio",
+              "id": "medium",
+              "value": "Medium (51-250 nodes)",
+              "label": "Medium (51-250 nodes)"
+            },
+            {
+              "type": "radio",
+              "id": "large",
+              "value": "Large (251-1000 nodes)",
+              "label": "Large (251-1000 nodes)"
+            },
+            {
+              "type": "radio",
+              "id": "enterprise",
+              "value": "Enterprise (1000+ nodes)",
+              "label": "Enterprise (1000+ nodes)"
+            }
+          ]
+        },
+        {
+          "title": "What is your primary use case for MAAS?",
+          "id": "primary-use-case",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "private-cloud",
+              "value": "Private Cloud with OpenStack",
+              "label": "Private Cloud with OpenStack"
+            },
+            {
+              "type": "checkbox",
+              "id": "server-automation",
+              "value": "Server Automation",
+              "label": "Server Automation"
+            },
+            {
+              "type": "checkbox",
+              "id": "bare-metal-kubernetes",
+              "value": "Bare Metal Kubernetes",
+              "label": "Bare Metal Kubernetes"
+            },
+            {
+              "type": "checkbox",
+              "id": "other",
+              "value": "Other",
+              "label": "Other"
+            }
+          ]
+        },
+        {
+          "title": "What would you like to talk to us about?",
+          "id": "comments",
+          "required": true,
+          "noCommentsFromLead": false,
+          "fields": [{ "type": "long-text", "id": "comments" }]
         }
       ]
     }

--- a/templates/maas/index.html
+++ b/templates/maas/index.html
@@ -33,7 +33,9 @@
     {%- endif -%}
     {%- if slot == 'cta' -%}
       <a href="/maas/docs/maas-in-thirty-minutes" class="p-button--positive">Try MAAS</a>
-      <a href="/maas/contact-us" class="p-button">Get in touch</a>
+      <a href="/maas/contact-us"
+         class="p-button js-invoke-modal"
+         aria-controls="maas-contact-form">Get in touch</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="u-embedded-media">
@@ -425,7 +427,7 @@
     },
     ]
     },
-    ],)
+    ],) 
   }}
 
   {% with tag_id="1304" %}
@@ -513,7 +515,7 @@
     },
     ]
     },
-    ],)
+    ],) 
   }}
 
   {{ vf_basic_section(title={"text": "Enterprise support for MAAS"},
@@ -553,7 +555,7 @@
     }
     }
     }
-    ])
+    ]) 
   }}
 
   {% call(slot) vf_pricing_block(
@@ -617,7 +619,7 @@
     'list_item_content_html': 'Phone and ticket support'
     }
     ],
-    'cta_html': '<a href="/maas/contact-us">Contact us&nbsp;&rsaquo;</a>'
+    'cta_html': '<a href="/maas/contact-us" class="js-invoke-modal" aria-controls="maas-contact-form">Contact us&nbsp;&rsaquo;</a>'
     },
 
     {
@@ -647,7 +649,7 @@
     'list_item_content_html': 'Phone and ticket support: Office hours'
     }
     ],
-    'cta_html': '<a href="/maas/contact-us">Contact us&nbsp;&rsaquo;</a>'
+    'cta_html': '<a href="/maas/contact-us" class="js-invoke-modal" aria-controls="maas-contact-form">Contact us&nbsp;&rsaquo;</a>'
     },
     {
     'tier_name_text': 'Advanced',
@@ -676,7 +678,7 @@
     'list_item_content_html': 'Phone and ticket support:<br /> 24 hours a day, everyday'
     }
     ],
-    'cta_html': '<a href="/maas/contact-us">Contact us&nbsp;&rsaquo;</a>'
+    'cta_html': '<a href="/maas/contact-us" class="js-invoke-modal" aria-controls="maas-contact-form">Contact us&nbsp;&rsaquo;</a>'
     }
     ]
     ) -%}
@@ -694,7 +696,8 @@
     layout='100',
     ) -%}
     {%- if slot == 'cta' -%}
-      Deploying MAAS at scale? <a href="/maas/contact-us">Talk to our team</a>
+      Deploying MAAS at scale? <a href="/maas/contact-us" class="js-invoke-modal" aria-controls="maas-contact-form">Talk to our team</a>
     {%- endif -%}
   {% endcall -%}
+  {{ load_form("/maas") | safe }}
 {% endblock %}


### PR DESCRIPTION
## Done
- make contact us form open in modal if javascript is enabled
- update optional fields in contact form

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- View the site in the demo site: https://canonical-com-2021.demos.haus/maas
  - Check that the modal is opened when javascript is enabled, and the redirect when javascript is disabled
  - Check the form fields match the copy doc
## Issue / Card
[Jira ticket WD-30134](https://warthogs.atlassian.net/browse/WD-30134)
[Copy doc](https://docs.google.com/document/d/12zxzauq9GV6NYVTeKCCqtwMpflRGZewE5fdTg1SZoOQ/edit?tab=t.0)
Fixes #
- "Contact us" modal not opening when javascript is enabled
## Screenshots
<img width="896" height="955" alt="image" src="https://github.com/user-attachments/assets/7fe12b1e-2a4d-4354-92bd-d06cbd917009" />
<img width="873" height="952" alt="image" src="https://github.com/user-attachments/assets/3841e743-77ac-4d1d-9479-319e6545b03f" />

