### PR TITLE
fix: missing project detail fields on maas contact forms

### DIFF
--- a/templates/maas/form-data.json
+++ b/templates/maas/form-data.json
@@ -21,7 +21,6 @@
         {
           "title": "Tell us about your project",
           "id": "project-details",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",
@@ -122,7 +121,6 @@
         {
           "title": "Tell us about your project",
           "id": "project-details",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",


### PR DESCRIPTION
## Done

- Fix missing "Tell us about your project" in payload submission
- Remove unexpected `project-details` field from marketo payload, append it to the comments from lead attribute
- Fixed failing `test-marketo` [action](https://github.com/canonical/canonical.com/actions/runs/18773937013/job/53564139882)

## QA

- Go to https://canonical-com-2025.demos.haus/maas/contact-us and https://canonical-com-2025.demos.haus/maas#get-in-touch
- Submit form
- Go to payload and check that `Comments_from_lead__c` includes "Tell us about your project" 
- Alternatively, check out this branch locally and run `test-marketo`. Check that all tests pass
  - You can retrieve marketo secrets from bitwarden or reach out to me

## Issue / Card

Fixes [WD-30456](https://warthogs.atlassian.net/browse/WD-30456)

## Screenshots

[if relevant, include a screenshot]


[WD-30456]: https://warthogs.atlassian.net/browse/WD-30456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ