### PR TITLE
Adds a link to Elementary website

### DIFF
--- a/templates/case-study/elementary-ai-machine-vision.html
+++ b/templates/case-study/elementary-ai-machine-vision.html
@@ -16,7 +16,10 @@
 {% endblock %}
 
 {% block meta_company_name %}Elementary{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1QLuokyOYWJpji6jfNyMMOUJsMEHsOp64giBqm3A2eDU/edit?tab=t.0{% endblock %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1QLuokyOYWJpji6jfNyMMOUJsMEHsOp64giBqm3A2eDU/edit?tab=t.0
+{% endblock %}
 
 {% block inner_content %}
   {%- call(slot) vf_hero(
@@ -43,6 +46,8 @@
     {%- endif -%}
     {%- if slot == 'list_item_content_3' -%}
       Pioneers of VisionStream, an AI model that catches up to 99.99% of defects.
+      <br />
+      Find out more on <a href="https://www.elementaryml.com/">Elementary’s website</a>.
     {%- endif -%}
   {%- endcall -%}
 
@@ -91,7 +96,7 @@
   <section class="p-section">
     <div class="grid-row">
       <div class="grid-col-start-large-3 grid-col-6">
-        <hr class="p-rule--muted">
+        <hr class="p-rule--muted" />
         <p>
           To scale their business, Elementary wanted to eliminate manual configurations, while enabling automated provisioning for their channel partners and integrators. This required an alternative infrastructure: a securely designed, low-touch system for IoT at scale, that would simplify provisioning, enable over-the-air (OTA) updates, support long-term device lifecycles, and allow partners to provision and recover devices independently.
         </p>
@@ -137,7 +142,7 @@
   <section class="p-section">
     <div class="grid-row">
       <div class="grid-col-start-large-3 grid-col-6">
-        <hr class="p-rule--muted">
+        <hr class="p-rule--muted" />
         <p>
           Ubuntu Core is Canonical’s OS for IoT and embedded devices, built with a fully containerized, snap-based architecture. It provides the atomic, OTA updates that Elementary was seeking. By moving to Ubuntu Core, Elementary’s customers can manage their own devices, relieving the burden of support from Elementary.
         </p>
@@ -173,7 +178,7 @@
   <section class="p-section">
     <div class="grid-row">
       <div class="grid-col-start-large-3 grid-col-6">
-        <hr class="p-rule--muted">
+        <hr class="p-rule--muted" />
         <p>
           Security, a key concern for manufacturers, is a particular strength of Ubuntu Core. Though a critical part of Elementary’s value proposition, the cloud connectivity of their machine vision software widens the possible attack surface compared to traditional server-based architecture. As a result, customers can be cautious about cloud connectivity. To alleviate their concerns, Ubuntu Core offers features which provide greater security for sensitive data. Secure boot allows only trusted software to run during the boot process, preventing malware from compromising the system before the operating system loads. Full-disk encryption prevents unauthorized access in case a device is lost or stolen. Sandboxed snaps restrict an application’s access to system resources, limiting damage in case of compromise. Elementary can meet diverse compliance frameworks without added engineering effort.
         </p>
@@ -221,7 +226,7 @@
   <section class="p-section">
     <div class="grid-row">
       <div class="grid-col-start-large-3 grid-col-6">
-        <hr class="p-rule--muted">
+        <hr class="p-rule--muted" />
         <p>
           Canonical’s solution has laid a strong foundation for more innovation, AI-powered features, and further expansion. With Canonical’s platform, Elementary is rolling out self-learning AI that can detect defects within 30 seconds of deployment – up to 100x faster than traditional workflows – alongside new analytics and their new AI vision inspection product, VisionLink, which integrates AI with existing machine vision systems.
         </p>
@@ -241,6 +246,4 @@
   {%- endcall -%}
 {% endblock %}
 
-{% block cta_content %}
-  {{ cta(title="Contact us", link="/contact-us", has_modal=true) }}
-{% endblock %}
+{% block cta_content %}{{ cta(title="Contact us", link="/contact-us", has_modal=true) }}{% endblock %}


### PR DESCRIPTION
## Done

Adds a link to find out more about Elementary.
[Copy doc](https://docs.google.com/document/d/1QLuokyOYWJpji6jfNyMMOUJsMEHsOp64giBqm3A2eDU/edit?tab=t.0)

Drive-by: djlint formatting in other parts of the page

## QA

- Visit https://canonical-com-2027.demos.haus/case-study/elementary-ai-machine-vision
- Check the last bullet of About section against [copy doc](https://docs.google.com/document/d/1QLuokyOYWJpji6jfNyMMOUJsMEHsOp64giBqm3A2eDU/edit?tab=t.0)
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes [WD-30457](https://github.com/canonical/canonical.com/tree/WD-30457-elementary-link)

## Screenshots

<img width="965" height="347" alt="image" src="https://github.com/user-attachments/assets/cae841e4-d0e5-4cde-b60e-fb072b501309" />


[WD-30457]: https://warthogs.atlassian.net/browse/WD-30457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ