### PR TITLE
fix: incorrect contact fields

### DIFF
--- a/templates/solutions/form-data.json
+++ b/templates/solutions/form-data.json
@@ -15,6 +15,7 @@
                 {
                     "title": "Fill in this form and we'll get in touch as soon as possible.",
                     "id": "about-you",
+                    "noCommentsFromLead": true,
                     "fields": [
                         {
                             "type": "tel",
@@ -27,7 +28,6 @@
                 {
                     "title": "What would you like to talk with us about?",
                     "isRequired": false,
-                    "noCommentsFromLead": false,
                     "id": "comments",
                     "fields": [
                         {


### PR DESCRIPTION
## Done

- Fix incorrect payload for contact fields
- Remove contact fields from `Comments_from_lead__c`

## QA

- Go to https://canonical-com-2028.demos.haus/solutions#get-in-touch
- If demo doesn't work, check out this PR locally and run project on `dotrun`
- Fill up form and submit
- Check payload `Comments_from_lead__c` and see that it only has fields from comments

## Issue / Card

Fixes [WD-30517](https://warthogs.atlassian.net/browse/WD-30517)

## Screenshots

[if relevant, include a screenshot]


[WD-30517]: https://warthogs.atlassian.net/browse/WD-30517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ