### PR TITLE
fix(WD-30462): Fix global nav's dropdown item description color

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -97,6 +97,28 @@ $navigation-heading-color: #fff9;
     }
   }
 
+  .p-navigation__content-panel {
+    background-color: $navigation-background;
+    padding-top: 2rem;
+
+    .p-navigation__main-links {
+      margin-left: -0.5rem;
+    }
+
+    .p-navigation__dropdown-item {
+      padding: 0.25rem 0.5rem;
+
+      small {
+        color: #aaa;
+      }
+    }
+
+    li:first-of-type .p-navigation__dropdown-item,
+    li:not(:last-of-type) .p-navigation__dropdown-item {
+      border-bottom: $dropdown-border;
+    }
+  }
+
   .p-navigation__content-panel--full-width {
     .p-navigation__dropdown-item small,
     .p-navigation__dropdown-item small:visited {
@@ -147,28 +169,6 @@ $navigation-heading-color: #fff9;
     }
   }
 
-  .p-navigation__content-panel {
-    background-color: $navigation-background;
-    padding-top: 2rem;
-
-    .p-navigation__main-links {
-      margin-left: -0.5rem;
-    }
-
-    .p-navigation__dropdown-item {
-      padding: 0.25rem 0.5rem;
-
-      small {
-        color: #aaa;
-      }
-    }
-
-    li:first-of-type .p-navigation__dropdown-item,
-    li:not(:last-of-type) .p-navigation__dropdown-item {
-      border-bottom: $dropdown-border;
-    }
-  }
-
   .p-navigation__preview-link--container {
     row-gap: 2rem;
   }
@@ -192,13 +192,16 @@ $navigation-heading-color: #fff9;
     justify-content: space-between;
   }
 
-  .p-navigation--sliding .p-navigation__dropdown.is-full-width .p-navigation__dropdown-content--full-width {
+  .p-navigation--sliding
+    .p-navigation__dropdown.is-full-width
+    .p-navigation__dropdown-content--full-width {
     @include vf-animation(all, brisk, out);
   }
 
   .p-navigation--reduced,
   .p-navigation--sliding {
-    .p-navigation__dropdown.is-full-width .p-navigation__dropdown-content--full-width {
+    .p-navigation__dropdown.is-full-width
+      .p-navigation__dropdown-content--full-width {
       background-color: $navigation-background;
     }
   }
@@ -244,7 +247,9 @@ $navigation-heading-color: #fff9;
   }
 
   // remove the border from the final tab item
-  .p-navigation__tab-panel .p-side-navigation__item:last-of-type .p-side-navigation__link {
+  .p-navigation__tab-panel
+    .p-side-navigation__item:last-of-type
+    .p-side-navigation__link {
     border-bottom: none;
   }
 }


### PR DESCRIPTION
## Done

Fixed descriptions color

## QA

- Check out the [demo](https://canonical-com-2030.demos.haus/)
- Click "Products" on the top nav
- Verify the description color is muted

## Issue / Card

Fixes #[WD-30462](https://warthogs.atlassian.net/browse/WD-30462)

## Screenshots

Before:

<img width="1476" height="490" alt="image" src="https://github.com/user-attachments/assets/908aa69a-6aaf-450b-9578-b49b77e20619" />


After:

<img width="1476" height="490" alt="image" src="https://github.com/user-attachments/assets/21cb9531-4485-445a-8d4b-c31dd62485ea" />



[WD-30462]: https://warthogs.atlassian.net/browse/WD-30462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ