### PR TITLE
chore: updated jira sync key to 31040

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -22,4 +22,4 @@ settings:
   sync_comments: true
 
   # (Optional) (Default: None) Parent Epic key to link the issue to
-  epic_key: "WD-22403"
+  epic_key: "WD-31040"


### PR DESCRIPTION
## Done

- Updated Jira key to point to the new github issues EPIC

Fixes [#31041](https://warthogs.atlassian.net/browse/WD-31041)
