### PR TITLE
feat(legal): WD-30656 - add Canonical GCP link to legal terms and policies page

### DIFF
--- a/templates/legal/terms-and-policies/index.md
+++ b/templates/legal/terms-and-policies/index.md
@@ -34,6 +34,12 @@ Our intellectual property rights policy lets you use, modify and redistribute Ub
 
 [View intellectual property policy ›](/legal/intellectual-property-policy)
 
+### Canonical General Conditions of Purchase
+
+Terms and conditions are for when we purchase services from you.
+
+[View Canonical general conditions of purchase>](/legal/general-conditions-of-purchase)
+
 ### Online accounts
 
 Ubuntu online accounts are provided by Canonical. This legal notice applies to your use of Ubuntu online accounts and incorporates the terms of our legal notice and our privacy policy.
@@ -138,6 +144,6 @@ The terms governing use of Canonical's support portal.
 
 ### AI Support Knowbot Terms of Use
 
-The terms governing the use of Canonical's AI Support Knowbot. 
+The terms governing the use of Canonical's AI Support Knowbot.
 
 [View Support Knowbot terms ›](https://assets.ubuntu.com/v1/291cefc5-ai_support_knowbot_terms_v1.pdf)


### PR DESCRIPTION
## Done

- Add "Canonical General Conditions of Purchase" section to the legal terms and policies page.

## QA

- Check out the page on the [demo](https://canonical-com-2050.demos.haus/legal/terms-and-policies#canonical-general-conditions-of-purchase) and see the Canonical General Conditions of Purchase section has been added to the legal terms and polices page.
- Make the content of the section aligns with the proposed changes in the [copy doc](https://docs.google.com/document/d/1p3ZWroZ3nkw8XJJdPvPxSlWGYcLZLT8UbUVuppBcyHk/edit?tab=t.0).

## Issue / Card

- [WD-30656](https://warthogs.atlassian.net/browse/WD-30656)


[WD-30656]: https://warthogs.atlassian.net/browse/WD-30656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ