### PR TITLE
update /maas/how-it-works

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -756,6 +756,7 @@ maas/install: "/maas/docs/how-to-install-maas"
 maas/index(.html)?: "/maas/"
 maas/tour: "/maas/features"
 maas/(?P<path>.+)/index(.html)?: "/maas/{path}"
+maas/how-it-works: "/maas/how-maas-works"
 # Docs redirects
 maas/docs/(devel|2.6|stable|en|devel/en|stable/en|2.6/en): /maas/docs
 maas/docs/(devel|2.6|stable|en|devel/en|stable/en|2.6/en)/(?P<path>.*): /maas/docs/{path}

--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -383,8 +383,8 @@ maas:
   children:
     - title: Overview
       path: /maas
-    - title: How it works
-      path: /maas/how-it-works
+    - title: How MAAS works
+      path: /maas/how-maas-works
     - title: Install
       path: /maas/docs/how-to-get-maas-up-and-running
     - title: Docs

--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -266,7 +266,7 @@ meta_copydoc %}
               deployment to dynamically create virtual machines on it.
             </p>
             <p>
-              Read about <a href="/maas/how-it-works">how MAAS works</a> or <a href="/maas/tutorials/build-a-maas-and-lxd-environment-in-30-minutes-with-multipass-on-ubuntu">MAAS
+              Read about <a href="/maas/how-maas-works">how MAAS works</a> or <a href="/maas/tutorials/build-a-maas-and-lxd-environment-in-30-minutes-with-multipass-on-ubuntu">MAAS
               works</a> and <a href="/maas/tutorials/build-a-maas-and-lxd-environment-in-30-minutes-with-multipass-on-ubuntu">try
               MAAS and LXD</a>&nbsp;&rsaquo;
             </p>

--- a/templates/maas/features.html
+++ b/templates/maas/features.html
@@ -513,7 +513,7 @@ source and free to use, with commercial support available from Canonical.
     layout='100',
   ) -%}
     {%- if slot == 'cta' -%}
-      <a href="/maas/how-it-works" aria-label="Link to the how it works page on maas dot i o">Read how it
+      <a href="/maas/how-maas-works" aria-label="Link to the how MAAS works page on maas dot i o">Read how it
         works&nbsp;&rsaquo;</a>
     {%- endif -%}
   {% endcall -%}

--- a/templates/maas/how-maas-works.html
+++ b/templates/maas/how-maas-works.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}How it works{% endblock %}
+{% block title %}How MAAS works{% endblock %}
 
 {% block meta_copydoc %}
     https://docs.google.com/document/d/16tkFyk2W-AkoJYeE9qoFjwzHBlH4diazN9tlqRsV3XA/edit
@@ -10,7 +10,7 @@
     <section class="p-strip--image is-dark p-takeover--no-overlays">
         <div class="row u-equal-height u-vertically-center">
             <div class="col-6">
-                <h1>How it works</h1>
+                <h1>How MAAS works</h1>
                 <p>
                     MAAS has a tiered architecture with a central postgres database backing a &lsquo;Region Controller (regiond)&rsquo; that deals with operator requests. Distributed Rack Controllers (rackd) provide high-bandwidth services to multiple racks. The controller itself is stateless and horizontally scalable, presenting only a REST API.
                 </p>

--- a/templates/maas/index.html
+++ b/templates/maas/index.html
@@ -345,7 +345,7 @@
     ) | safe
 
     ,
-    "description_html": "<p>Streamline the entire <a href='/maas/how-it-works'>lifecycle management</a> of your server fleet, from initial provisioning to eventual re-purposing. This automation ensures consistency, reduces human error, and significantly speeds up operations. Combine it with <a href='https://ubuntu.com/landscape'>Landscape</a> to automate security patching, application auditing, access management and compliance tasks across Ubuntu machines.</p>",
+    "description_html": "<p>Streamline the entire <a href='/maas/how-maas-works'>lifecycle management</a> of your server fleet, from initial provisioning to eventual re-purposing. This automation ensures consistency, reduces human error, and significantly speeds up operations. Combine it with <a href='https://ubuntu.com/landscape'>Landscape</a> to automate security patching, application auditing, access management and compliance tasks across Ubuntu machines.</p>",
     "cta_html": "<a href='https://pages.ubuntu.com/eBook-MAAS.html'>Get our free eBook on server provisioning&nbsp;&rsaquo;</a>"
     },
     ]

--- a/templates/maas/tutorials.html
+++ b/templates/maas/tutorials.html
@@ -32,7 +32,7 @@
   <div class="row">
     <div class="col-12">
       <p class="p-heading--three">Want to understand the core concepts and get a high-level overview of MAAS and its architecture?</p>
-      <p class="u-no-margin--bottom"><a href="/maas/how-it-works" aria-label="Link to the how it works page on maas dot i o">Read how it works&nbsp;&rsaquo;</a></p>
+      <p class="u-no-margin--bottom"><a href="/maas/how-maas-works" aria-label="Link to the how MAAS works page on maas dot i o">Read how it works&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
- Updates /maas/how-it-works to `/maas/how-maas-works` according to the [copy doc](https://docs.google.com/document/d/16tkFyk2W-AkoJYeE9qoFjwzHBlH4diazN9tlqRsV3XA/edit?tab=t.0#heading=h.twzeocg9szb2)
- Updates meganav to reflect these changes
- Adds a redirect in case any other sites still use the old url

## QA

- Go to https://canonical-com-2056.demos.haus/maas/how-maas-works
- Make sure url, meganav, tab name and title of the page has changed to "How MAAS works"
- Go to https://canonical-com-2056.demos.haus/maas/how-it-works and make sure you are redirected to `how-maas-works`

## Issue / Card

Fixes [WD-31170](https://warthogs.atlassian.net/browse/WD-31170)


[WD-31170]: https://warthogs.atlassian.net/browse/WD-31170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ