### PR TITLE
remove "Networking" link in eng. jobs

### DIFF
--- a/templates/careers/includes/_fast-track-jobs.html
+++ b/templates/careers/includes/_fast-track-jobs.html
@@ -141,15 +141,6 @@
       <div class="row">
 
         <div class="col-3">
-          <a href="/careers/5163397">Networking</a>
-
-          <p class="u-no-padding--top">
-            <small>Data centres, SDN/NFV tech</small>
-          </p>
-
-        </div>
-
-        <div class="col-3">
           <a href="/careers/5143011">DevRel</a>
 
           <p class="u-no-padding--top">
@@ -157,10 +148,6 @@
           </p>
 
         </div>
-
-      </div>
-
-      <div class="row">
 
         <div class="col-3">
           <a href="/careers/5833620">Rust</a>
@@ -170,6 +157,10 @@
           </p>
 
         </div>
+      
+      </div>
+
+      <div class="row">
 
         <div class="col-3">
           <a href="/careers/5792361">Performance and Correctness</a>


### PR DESCRIPTION
## Done

- Removed the "Networking" link in /careers/engineering which was giving 404

## QA

- visit https://canonical-com-2057.demos.haus/careers/engineering
- check if there is no Networking link
- check links arrangement 

