### PR TITLE
Bump canonicalwebteam.discourse version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.blog==6.7.0
 canonicalwebteam.http==1.0.4
 canonicalwebteam.image-template==1.9.0
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.discourse==6.3.0
+canonicalwebteam.discourse==7.1.0
 canonicalwebteam.search==2.1.2
 canonicalwebteam.form-generator==2.0.1
 canonicalwebteam.directory-parser==1.2.10


### PR DESCRIPTION
## Done
- Bump DIscourse module version
- Fix list of tags on /case-study so that the list of tags that appear are only related to `case study`
- Fix filtering on engage pages: When you select a tag and apply filter, it fetches posts related to that tag. The filtering does not work well as some posts with that tag do not appear.

## QA

- Check out [/case-study](https://canonical-com-2059.demos.haus/case-study)
- Select Anjuna from the tags and apply filter (https://canonical-com-2059.demos.haus/case-study?tag=anjuna)
- Check that posts appear
- Select security from the tags and apply fitler
- Check that posts appear

Compare that to production
- Check out [/case-study](https://canonical.com/case-study)
- Apply `anjuna` tag filter (https://canonical.com/case-study?tag=anjuna)
- See that no posts appear
- Select `english` from the language filter while having `anjuna` tag applies and see that posts appear (https://canonical.com/case-study?tag=anjuna&language=en)

## Issue / Card

Fixes #
https://warthogs.atlassian.net/browse/WD-31245
https://warthogs.atlassian.net/browse/WD-21422

## Screenshots
### Before
<img width="1730" height="878" alt="image" src="https://github.com/user-attachments/assets/b3b2f412-8170-4a08-9353-efec4bcef8c8" />


### After
<img width="1656" height="1460" alt="image" src="https://github.com/user-attachments/assets/2e473c02-d4b6-459f-8000-d74e5df06ab4" />


[if relevant, include a screenshot]
