### PR TITLE
feat: Implement cross-domain cookie sharing

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -114,6 +114,11 @@ env:
       key: secret
       name: sitemaps
 
+  - name: COOKIE_SERVICE_API_KEY
+    secretKeyRef:
+      key: cookies-api-key
+      name: cookies-canonical-com-credentials
+
 extraHosts:
   - domain: blog.canonical.com
   - domain: design.canonical.com

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test-marketo": "python3 -m unittest tests.test_marketo"
   },
   "dependencies": {
-    "@canonical/cookie-policy": "^3.7.3",
+    "@canonical/cookie-policy": "3.8.0",
     "@canonical/discourse-rad-parser": "1.0.2",
     "@canonical/global-nav": "3.8.0",
     "@canonical/latest-news": "2.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ canonicalwebteam.discourse==7.1.0
 canonicalwebteam.search==2.1.2
 canonicalwebteam.form-generator==2.1.0
 canonicalwebteam.directory-parser==1.2.10
+canonicalwebteam.cookie-service==1.0.0
+Flask-Caching==2.1.0
 bleach==5.0.1
 markdown==3.8.2
 python-slugify==8.0.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,10 +288,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@^3.7.3":
-  version "3.7.4"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.7.4.tgz#612419cb0610f0ca86c6b04df48d48c3b9fc221e"
-  integrity sha512-sDiGXhh1X6SeHy9RgXZm56P+zwGqkTJbqiQg34tkSI8oHPZ/6zWycEoUSR9DX3EaUrKdJtl69rDgM54SyOe5FQ==
+"@canonical/cookie-policy@3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.8.0.tgz#8f20b5d6d0c2e5553bbe05d1513f7f1af7d0836c"
+  integrity sha512-njUYf10gFmuXr47Aj5jayuFbyq08IkBdr/W6qtvHjZvJ8Dt4ru9ehMacWa4mostfQoXVARusIucOARSgnMoArg==
 
 "@canonical/discourse-rad-parser@1.0.2":
   version "1.0.2"


### PR DESCRIPTION
## Done

- Implements [cookie service flask extension](https://github.com/canonical/canonicalwebteam.cookie-service) for integration with cookies.canonical.com
- Bumps cookie-policy npm package to 3.8.1
- Implement basic flask-caching to store health status of cookies.canonical.com

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
