### PR TITLE
revert setting initialReferrer and initialUrl

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -252,38 +252,6 @@
             }
           </script>
 
-          <!-- set canonical.initialReferrer, canonical.initialUrl -->
-          <script>
-            (function() {
-              const initialReferrerKey = "canonical.initialReferrer";
-              const initialUrlKey = "canonical.initialUrl";
-
-              function stripReferrer(url) {
-                if (!url) {
-                  return "";
-                }
-                try {
-                  const parsed = new URL(url, window.location.href);
-                  return parsed.origin || "";
-                } catch (error) {
-                  return "";
-                }
-              }
-
-              try {
-                if (!sessionStorage.getItem(initialReferrerKey)) {
-                  const refDomain = stripReferrer(document.referrer);
-                  if (refDomain) {
-                    sessionStorage.setItem(initialReferrerKey, refDomain);
-                  }
-                }
-
-                if (!sessionStorage.getItem(initialUrlKey)) {
-                  sessionStorage.setItem(initialUrlKey, window.location.href);
-                }
-              } catch {}
-            })();
-          </script>
 
         </body>
 


### PR DESCRIPTION
## Done

- revert recent change to set session variables `canonical.initialReferrer` and `canonical.initialUrl`. This should be done after user consent. The previous pull request: https://github.com/canonical/canonical.com/pull/2094

