### PR TITLE
WD-31736- Added sitemaps for product docs to sitemap index

### DIFF
--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -19,12 +19,6 @@
     <loc>https://canonical.com/data/docs/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/data/docs/mongodb/iaas/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://canonical.com/data/docs/mongodb/k8s/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
     <loc>https://canonical.com/data/docs/opensearch/iaas/sitemap.xml</loc>
   </sitemap>
   <sitemap>


### PR DESCRIPTION
## Done

- Added sitemaps for product docs to sitemap index

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check if you can see the updated [sitemap.xml](https://canonical-com-2099.demos.haus/sitemap.xml) in the demo with the added sitemaps for product docs.

## Issue / Card

Fixes #

https://warthogs.atlassian.net/browse/WD-31736
