### PR TITLE
fix(/microk8s/compare): Broken brighttalk link

### DIFF
--- a/templates/microk8s/compare.html
+++ b/templates/microk8s/compare.html
@@ -256,7 +256,7 @@ layout='50/50'
               intro to MicroK8s</a>
           </li>
           <li class="p-list__item">
-            <a href="https://www.brighttalk.com/webcast/6793/488796/kubernetes-at-the-edge-easy-as-pi">K8s at the edge:
+            <a href="https://www.brighttalk.com/webcast/6793/488796">K8s at the edge:
               easy as "Pi"
             </a>
           </li>


### PR DESCRIPTION
## Done

- Fixed broken brighttalk link
- Fixed broken corbelsolutions partners link

## QA

- Go to https://canonical-com-2100.demos.haus/microk8s/compare
- Find 'K8s at the edge: easy as "Pi"'
- Check the link works

- Go to https://canonical-com-2100.demos.haus/partners/find-a-partner?search=corbel
- Click the 'Corbel Solutions' link
- See it takes you to their homepage

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-31762
