### PR TITLE
fix(WD-31354): Updated copytext for canonical partners program

### DIFF
--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -58,7 +58,7 @@
             </p>
           </div>
           <div class="col-6">
-            <p>Ubuntu on clouds is optimised, tested and certified by Canonical for performance and security</p>
+            <p>Ubuntu on clouds is optimized, tested and certified by Canonical for performance and security</p>
           </div>
         </div>
         <hr class="p-rule" />
@@ -69,7 +69,7 @@
             </p>
           </div>
           <div class="col-6">
-            <p>Certified hardware for efficient data centres, from the large-scale core to distributed edge</p>
+            <p>Certified hardware for efficient data centers, from the large-scale core to distributed edge</p>
           </div>
         </div>
         <hr class="p-rule" />


### PR DESCRIPTION
## Done

- Changed title and body text

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Navigate to `/partners`.
- Make sure the page matches [this copytext doc](https://docs.google.com/document/d/1q6dkqQ0zcshrfOmdJA_bAip73EaMSEyXAn8bAD7GqNw/edit?tab=t.0).

## Issue / Card

Fixes # [WD-31354](https://warthogs.atlassian.net/browse/WD-31354)



[WD-31354]: https://warthogs.atlassian.net/browse/WD-31354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ