### PR TITLE
remove extra comma from `/partners/silicon`

### DIFF
--- a/templates/partners/silicon/index.html
+++ b/templates/partners/silicon/index.html
@@ -296,7 +296,7 @@
                     strong partnerships with the community and ecosystem.
                 </p>
                 <p>
-                    To drive this vision, Canonical has established a dedicated RISC-V program, and, we welcome
+                    To drive this vision, Canonical has established a dedicated RISC-V program, and we welcome
                     partners and contributors to collaborate with us.
                 </p>
                 <div class="p-cta-block">


### PR DESCRIPTION
## Done

In https://github.com/canonical/canonical.com/pull/2096 there is an extra comma after an "and" resulting in a sentence reading "Canonical has established a dedicated RISC-V program, and, we welcome..." - this is a typo and was originally present in the [Figma](https://www.figma.com/design/S6KvNUt0agl0bcbp6wjhnB/ubuntu.com-partners---Sites?node-id=3256-2905&m=dev)

I have manually added the comma to the [copydoc](https://docs.google.com/document/d/1nyiz4I1GqBiXe_SKpDzho3yv20LKyYpyhHh0fvvUrOI/edit?tab=t.0) to keep it in sync with the live page, and made a suggested deletion to remove the comma.

## QA

- Go to [`/partners/silicon`](https://canonical-com-2115.demos.haus/partners/silicon).
- Scroll to "Ubuntu on RISC-V".
- Ensure there is no extra comma after the "and" in the "Canonical has established..." sentence

## Issue / Card

No ticket; I noticed this myself and confirmed it with the page owner.

## Screenshots

Before
<img width="386" height="181" alt="Screenshot_2025-12-04_19-07-42" src="https://github.com/user-attachments/assets/9011bea1-e8fe-43bd-bd0c-9c78d6561e0c" />

After
<img width="641" height="179" alt="Screenshot_2025-12-04_19-07-12" src="https://github.com/user-attachments/assets/b0e42a42-2190-4da8-845b-d655422e3ab5" />

