### PR TITLE
ci: configure TICS workflow

### DIFF
--- a/.github/workflows/tics_coverage.yaml
+++ b/.github/workflows/tics_coverage.yaml
@@ -1,9 +1,7 @@
 name: TICS Analysis and Coverage
-# on:
-#   schedule:
-#     - cron: "0 22 * * 5"
-on: 
-  pull_request:
+on:
+  schedule:
+    - cron: "0 22 * * 5"
   workflow_dispatch:
     inputs:
       detach:


### PR DESCRIPTION
Note: uncomment PR action trigger before merging

## Done

- Added TIOBE config file: `tiobe_config.txt`
- Added GH workflow to update TICS coverage: `tics_coverage.yaml`
  - The workflow runs coverage tests for python and js files on `build-coverage`. The coverage report is then uploaded as an artifact
  - The `TICS` action downloads the GH artifact and publishes it on [TICS Viewer](https://canonical.tiobe.com/tiobeweb/TICS/TqiDashboard.html#axes=Date(1765518993),Project(canonical.com),Sub()&metric=tqi&sort=T(0,best))

## QA
- See `TICS Analysis and coverage` action passes, specifically `TICS (22.x)`
- Check on [TICS Viewer](https://canonical.tiobe.com/tiobeweb/TICS/TqiDashboard.html#axes=Date(1765518993),Project(canonical.com),Sub()&metric=tqi&sort=T(0,best)) that the "Measured on" date is updated
- Check that TQI score has increased from the screenshot before workflow integration

## Issue / Card

Fixes [WD-30653](https://warthogs.atlassian.net/browse/WD-30653) and [WD-30654](https://warthogs.atlassian.net/browse/WD-30654)

## Screenshots
<img width="637" height="571" alt="Screenshot 2025-12-12 at 3 18 38 PM" src="https://github.com/user-attachments/assets/90150464-3d1c-4eb1-ba54-eec7b46161ff" />



[WD-30653]: https://warthogs.atlassian.net/browse/WD-30653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-30654]: https://warthogs.atlassian.net/browse/WD-30654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ