### PR TITLE
Update the careers FAQ with Why many roles

### DIFF
--- a/templates/careers/application/faq.html
+++ b/templates/careers/application/faq.html
@@ -203,6 +203,14 @@
           <ul class="p-accordion__list">
             <li class="p-accordion__group">
               <div role="heading" aria-level="3" class="p-accordion__heading">
+                <button type="button" class="p-accordion__tab" id="application-management-tab0" aria-controls="application-management-tab0-section" aria-expanded="false"><span class="u-default-max-width">Why do Canonical have so many roles advertised?</span></button>
+              </div>
+              <section class="p-accordion__panel" id="application-management-tab0-section" aria-hidden="true" aria-labelledby="application-management-tab0">
+                <p>As a distributed, remote first organization we benefit from being able to make our opportunities available to people across the globe regardless of physical location. Therefore we ensure our roles are available to view in all relevant locations. We are also growing, so our job adverts often represent multiple seats available, or can be evergreen tracks for entry into our disciplines. Our job adverts seek to attract applications for live, open and available positions.</p>
+              </section>
+            </li>
+            <li class="p-accordion__group">
+              <div role="heading" aria-level="3" class="p-accordion__heading">
                 <button type="button" class="p-accordion__tab" id="application-management-tab1" aria-controls="application-management-tab1-section" aria-expanded="false"><span class="u-default-max-width">Is use of AI permitted during the hiring process?</span></button>
               </div>
               <section class="p-accordion__panel" id="application-management-tab1-section" aria-hidden="true" aria-labelledby="application-management-tab1">
@@ -279,13 +287,13 @@
               </div>
               <section class="p-accordion__panel" id="application-management-tab10-section" aria-hidden="true" aria-labelledby="application-management-tab10">
                 <p>
-                   There has been a notable rise in recruitment fraud over recent years. This fraud centers around the aim of stealing personal information or money from applicants in return for fake job offers or contractual agreements to carry out services for a company. The fraudsters use professional approaches, often disguised by sophisticated communication including the use of logos, very similar domain names for communication and real job titles. 
+                   There has been a notable rise in recruitment fraud over recent years. This fraud centers around the aim of stealing personal information or money from applicants in return for fake job offers or contractual agreements to carry out services for a company. The fraudsters use professional approaches, often disguised by sophisticated communication including the use of logos, very similar domain names for communication and real job titles.
                 </p>
                 <p>
                   Whilst we take all reasonable efforts to maintain security, it is sadly impossible to keep ahead of internet fraud. Be vigilant when sharing your personal information and make sure that you only share your information through legitimate sources.
                 </p>
                 <p>
-                  Once you are selected to move forward into our hiring process you will be able to review your progress on your secure personalized candidate dashboard, which we will share with you as soon as you enter our hiring process. We recommend you bookmark this page so that you can review where you are in our process at any given time. 
+                  Once you are selected to move forward into our hiring process you will be able to review your progress on your secure personalized candidate dashboard, which we will share with you as soon as you enter our hiring process. We recommend you bookmark this page so that you can review where you are in our process at any given time.
                 </p>
                 <p>
                   Our communication to you may come from a variety of different sources, sometimes from external platform providers and suppliers that we use. However, please be aware that during our hiring process, Canonical will never ask for you for:


### PR DESCRIPTION
## Done

Add the "Why do Canonical have so many roles advertised?" section on the careers FAQ.

## QA

- Check the demo
- Go to /careers/application/faq
- Check the new section content matches the [copy doc](https://docs.google.com/document/d/12_O_QtPqfv9p7kaDFdiP8Xq-kY5xa1XB-C-CRbXjDew/edit?tab=t.0)

