### PR TITLE
Update chiseled to american spelling WD-31976

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -484,7 +484,7 @@ products:
           - title: Snap Store
             description: App store for Linux
             url: https://snapcraft.io
-          - title: Chiselled Ubuntu
+          - title: Chiseled Ubuntu
             description: Ultra-small containerization
             url: https://ubuntu.com/containers/chiselled
           - title: Juju


### PR DESCRIPTION
## Done
- Change `chiselled` to `chiseled`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the spelling in the mega nav is correct

## Issue / Card

[WD-31976](https://warthogs.atlassian.net/browse/WD-31976)


[WD-31976]: https://warthogs.atlassian.net/browse/WD-31976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ