### PR TITLE
Change Ubuntu Pro description URLs in redirects.yaml

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -650,9 +650,9 @@ mir/doc/md__r_e_a_d_m_e.*: https://github.com/canonical/mir/blob/main/README.md
 mir/doc/.*: https://canonical-mir.readthedocs-hosted.com/stable/
 mir/tutorials: /mir/docs/tutorials/
 mir/tutorials/.*: /mir/docs/tutorials/
-legal/ubuntu-pro-description/?: "https://assets.ubuntu.com/v1/c46fb596-Ubuntu%20Pro%20description%20(unified).pdf"
-legal/ubuntu-pro-description/ja?: "https://assets.ubuntu.com/v1/c46fb596-Ubuntu%20Pro%20description%20(unified).pdf"
-legal/ubuntu-pro-description/jp?: "https://assets.ubuntu.com/v1/c46fb596-Ubuntu%20Pro%20description%20(unified).pdf"
+legal/ubuntu-pro-description/?: "https://assets.ubuntu.com/v1/461325c3-ubuntu_pro_description_unified.pdf"
+legal/ubuntu-pro-description/ja?: "https://assets.ubuntu.com/v1/461325c3-ubuntu_pro_description_unified.pdf"
+legal/ubuntu-pro-description/jp?: "https://assets.ubuntu.com/v1/461325c3-ubuntu_pro_description_unified.pdf"
 
 # Multipass documentation
 multipass/docs?: "https://documentation.ubuntu.com/multipass/en/latest"


### PR DESCRIPTION
## Done

Change Ubuntu Pro description URLs in redirects.yaml

## QA

Check the different `legal/ubuntu-pro-description` paths redirect to https://assets.ubuntu.com/v1/461325c3-ubuntu_pro_description_unified.pdf`