### PR TITLE
fix(WD-31282): add career progression

### DIFF
--- a/templates/careers/company-culture/progression.html
+++ b/templates/careers/company-culture/progression.html
@@ -339,10 +339,10 @@
       </div>
     </section>
 
-    <section class="p-strip--careers-progression is-dark">
+    <section class="p-strip--careers-progression is-dark u-hide--small">
       <div class="row" data-animation="u-animation--slide-from-bottom">
         <h2 class="u-sv3">Leveling framework</h2>
-        {{ image(url="https://assets.ubuntu.com/v1/8c7d2b68-diagram.jpg", alt="", width="3696", height="1540", hi_def=True, loading="lazy" ) | safe }}
+        {{ image(url="https://assets.ubuntu.com/v1/8c7d2b68-diagram.jpg", alt="A diagram illustrating career paths starting from graduate level. It branches into three leadership tracks: depth for technical specialists, drive for staff and principals, and plan for management roles like director and VP", width="3696", height="1540", hi_def=True, loading="lazy" ) | safe }}
       </div>
     </section>
 


### PR DESCRIPTION
## Done

- Add career progression section in `/careers/company-culture/progression`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes [WD-31282](https://warthogs.atlassian.net/browse/WD-31282)

[WD-31282]: https://warthogs.atlassian.net/browse/WD-31282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ