### PR TITLE
fix: exclude prerelease and draft juju versions

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,7 +1,9 @@
 import logging
+import responses
+import unittest
 
 from vcr_unittest import VCRTestCase
-from webapp.app import app
+from webapp.app import app, get_latest_versions
 
 
 logging.getLogger("talisker.context").disabled = True
@@ -153,3 +155,92 @@ class TestRoutes(VCRTestCase):
         """
 
         self.assertEqual(self.client.get("/not-found-url").status_code, 404)
+
+
+class TestJujuVersion(unittest.TestCase):
+    def setUp(self):
+        """
+        Set up Flask app for testing
+        """
+        app.testing = True
+        self.client = app.test_client()
+        # The /juju/latest.json response is cached, so the cache is cleared to
+        # prevent leakage between tests.
+        get_latest_versions.cache_clear()
+        return super().setUp()
+
+    @responses.activate
+    def test_latest_release(self):
+        """
+        Check that the latest Juju and Juju Dashboard release versions are
+        returned as JSON.
+        """
+        responses.get(
+            "https://api.github.com/repos/canonical/"
+            "juju-dashboard/releases/latest",
+            json={
+                "tag_name": "v1.2.3",
+            },
+        )
+        responses.get(
+            "https://api.github.com/repos/juju/juju/releases",
+            json=[
+                {
+                    "tag_name": "v4.5.6",
+                    "draft": False,
+                    "prerelease": False,
+                },
+                {
+                    "tag_name": "v4.5.5",
+                    "draft": False,
+                    "prerelease": False,
+                },
+                {
+                    "tag_name": "v3.4.5",
+                    "draft": False,
+                    "prerelease": False,
+                },
+            ],
+        )
+        self.assertEqual(
+            self.client.get("/juju/latest.json").json,
+            {"dashboard": "v1.2.3", "juju": ["3.4.5", "4.5.6"]},
+        )
+
+    @responses.activate
+    def test_latest_prerelease(self):
+        """
+        Check that drafts and pre-releases are ignored from the Juju and
+        version response.
+        """
+        responses.get(
+            "https://api.github.com/repos/canonical/"
+            "juju-dashboard/releases/latest",
+            json={
+                "tag_name": "v1.2.3",
+            },
+        )
+        responses.get(
+            "https://api.github.com/repos/juju/juju/releases",
+            json=[
+                {
+                    "tag_name": "v5.6.7",
+                    "draft": True,
+                    "prerelease": False,
+                },
+                {
+                    "tag_name": "v4.5.6",
+                    "draft": False,
+                    "prerelease": True,
+                },
+                {
+                    "tag_name": "v3.4.5",
+                    "draft": False,
+                    "prerelease": False,
+                },
+            ],
+        )
+        self.assertEqual(
+            self.client.get("/juju/latest.json").json,
+            {"dashboard": "v1.2.3", "juju": ["3.4.5"]},
+        )

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -395,6 +395,8 @@ def get_latest_versions():
         juju_json_response = juju_response.json()
         juju_versions = []
         for release in juju_json_response:
+            if release["draft"] or release["prerelease"]:
+                continue
             # get semver
             version = semver.VersionInfo.parse(
                 release["tag_name"].replace("juju-", "").lstrip("v")


### PR DESCRIPTION
## Done

- Exclude prerelease and draft release from the latest juju version json.

## QA

- Open [/juju/latest.json](https://canonical-com-2160.demos.haus/juju/latest.json).
- Check that there are Juju Dashboard and Juju releases instead of `{ "error": "4.0-rc1 is not valid SemVer string" }`

## Issue / Card

https://warthogs.atlassian.net/browse/WD-32596
