### PR TITLE
replace sentry DSN

### DIFF
--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -91,7 +91,7 @@ config:
     sentry-dsn:
       type: string
       description: "Sentry DSN for error tracking"
-      default: "https://aedc7a57f0bc4d22bf7c0b6d63c3e1bb@sentry.is.canonical.com//14"
+      default: "https://c6217b27586626e049f00f21a2def0c6@o4510662863749120.ingest.de.sentry.io/4510673678499920"
     service-account-email:
       type: string
       description: "Google service account"

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -7,7 +7,7 @@ env:
     value: https://cla.staging.canonical.com
 
   - name: SENTRY_DSN
-    value: https://aedc7a57f0bc4d22bf7c0b6d63c3e1bb@sentry.is.canonical.com//14
+    value: https://c6217b27586626e049f00f21a2def0c6@o4510662863749120.ingest.de.sentry.io/4510673678499920
 
   - name: GREENHOUSE_API_KEY
     secretKeyRef:
@@ -145,7 +145,7 @@ production:
             name: greenhouse-credentials
 
         - name: SENTRY_DSN
-          value: https://aedc7a57f0bc4d22bf7c0b6d63c3e1bb@sentry.is.canonical.com//14
+          value: https://c6217b27586626e049f00f21a2def0c6@o4510662863749120.ingest.de.sentry.io/4510673678499920
 
         - name: SERVICE_ACCOUNT_EMAIL
           secretKeyRef:
@@ -194,7 +194,7 @@ staging:
             name: greenhouse-credentials
 
         - name: SENTRY_DSN
-          value: https://aedc7a57f0bc4d22bf7c0b6d63c3e1bb@sentry.is.canonical.com//14
+          value: https://c6217b27586626e049f00f21a2def0c6@o4510662863749120.ingest.de.sentry.io/4510673678499920
 
         - name: DIRECTORY_API_TOKEN
           secretKeyRef:

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -59,7 +59,7 @@ CSP = {
         "ubuntu.com",
         "analytics.google.com",
         "www.googletagmanager.com",
-        "sentry.is.canonical.com",
+        "o4510662863749120.ingest.de.sentry.io",
         "www.google-analytics.com",
         "*.crazyegg.com",
         "*.g.doubleclick.net",


### PR DESCRIPTION
## Done

Now that we have a [new server for Sentry](https://canonical-ax.sentry.io/insights/projects/canonical-com/?project=4510673678499920), DSN connection string has been updated

