### PR TITLE
chore(WD-32804): bump latest-news package with upstream fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@canonical/cookie-policy": "3.8.3",
     "@canonical/discourse-rad-parser": "1.0.2",
     "@canonical/global-nav": "3.8.0",
-    "@canonical/latest-news": "2.1.0",
+    "@canonical/latest-news": "2.2.1",
     "@canonical/react-components": "^0.60.0",
     "@fullhuman/postcss-purgecss": "6.0.0",
     "@lottiefiles/dotlottie-web": "^0.44.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,10 +305,10 @@
   dependencies:
     vanilla-framework "4.35.0"
 
-"@canonical/latest-news@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/@canonical/latest-news/-/latest-news-2.1.0.tgz"
-  integrity sha512-L8YDIVsgZlm6j24lnMmRsLfzUAgK+GRy83TblCXI6D8wntrfhAz0F6no58uW3E5vjvq0XEOUXYryqjvR+JTzTg==
+"@canonical/latest-news@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@canonical/latest-news/-/latest-news-2.2.1.tgz#ec2764c348980f5b25120307c05b987c8d7aab6f"
+  integrity sha512-r7L/GkmqFUa2p+I8cYjHKLKrtIQEtSKo/As8WYnbssCcc6CWFf/zFiBX9vhbKxU63Cma7x5BFOo6CBlvlUrvxQ==
 
 "@canonical/react-components@^0.60.0":
   version "0.60.0"
@@ -928,9 +928,9 @@
     fast-glob "^3.2.11"
     image-size "^1.0.0"
 
-"@percy/cli@^1.31.5":
+"@percy/cli@1.31.5":
   version "1.31.5"
-  resolved "https://registry.npmjs.org/@percy/cli/-/cli-1.31.5.tgz"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.31.5.tgz#b923d4cd3b30eaf09aa52c52c38781bdd22768db"
   integrity sha512-4Mhb7hWfwxrD6pAbkSvWzR226rIX1xPsSP1bJE/bJUiDy7SZcfQqwG65fP78BhnDT6ehPvlmhot8B33v8AeWOw==
   dependencies:
     "@percy/cli-app" "1.31.5"


### PR DESCRIPTION
## Done

- Bumped latest-news package version with upstream fixes to address a11y issue on article links

## QA

- Check out the [demo](https://canonical-com-2175.demos.haus/)
- Scroll to the end
- Verify the latest news articles show up as expected

## Issue / Card

Fixes [WD-32804](https://warthogs.atlassian.net/browse/WD-32804)


[WD-32804]: https://warthogs.atlassian.net/browse/WD-32804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ