### PR TITLE
add enterprise store to meganav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -499,6 +499,9 @@ products:
           - title: Mir
             description: Display server library
             url: /mir
+          - title: Enterprise Store
+            description: Proxy for software management
+            url: https://ubuntu.com/enterprise-store
 
       secondary_links:
         title: Quick links


### PR DESCRIPTION
Add the enterprise store to the meganav as requested in the [copydoc](https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?disco=AAAByZ3juQA)

This is a follow up from https://github.com/canonical/ubuntu.com/pull/15904

## QA

- Open demo
- In the nav, check that `Products > Developer tools > Enterprise Store` exists   