### PR TITLE
fix(WD-32835): blog group returns 500

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -2023,3 +2023,4 @@ jaas/u/(?P<username>.*)/(?P<charm_or_bundle_name>.*)/(?P<series_or_version>.*)/(
 
 # Blog redirects
 blog/tag/charmed-aether-sd-core: /solutions/telco
+blog/group/(?P<group>[^/]+)/?: /blog/archives?group={group}


### PR DESCRIPTION
## Done

- Added a redirect from `/blog/group/<group-name>` to `/blog/archives?group=<group-name`

## QA

- Check out the [demo](https://canonical-com-2180.demos.haus/blog/group/canonical-announcements)
- Verify it loads up fine

## Issue / Card

Fixes [WD-32835](https://warthogs.atlassian.net/browse/WD-32835)


[WD-32835]: https://warthogs.atlassian.net/browse/WD-32835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ