### PR TITLE
enhancements for new Sentry integration

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -126,6 +126,9 @@ production:
     - name: CANONICAL_CLA_API_URL
       value: https://cla.canonical.com
 
+    - name: FLASK_ENV
+      value: "production"
+
   routes:
     - paths: [/blog]
       name: canonical-com-blog
@@ -193,6 +196,9 @@ staging:
             key: application-crypto-key
             name: greenhouse-credentials
 
+        - name: FLASK_ENV
+          value: "staging"
+
         - name: SENTRY_DSN
           value: https://c6217b27586626e049f00f21a2def0c6@o4510662863749120.ingest.de.sentry.io/4510673678499920
 
@@ -236,3 +242,6 @@ demo:
 
     - name: GREENHOUSE_DEBUG
       value: "true"
+
+    - name: FLASK_ENV
+      value: "demo"


### PR DESCRIPTION
## Done

- Add new "FLASK_ENV" environment variable for defining which environment the application is working on
- Pass that value to Sentry for seeing in which environment an error has happened
- Add Flask integration to Sentry for passing richer context 
- Use `get_flask_env` for getting env var values for support on both PS5 and PS6
- Have the testing `/sentry-debug` route for all environments, except "production"

## QA

- Open the testing route that throws an error: https://canonical-com-2181.demos.haus/sentry-debug
- Check that the error appeared in [Sentry](https://canonical-ax.sentry.io/insights/projects/canonical-com/?project=4510673678499920), with correct value for environment: `demo`
