### PR TITLE
chore(WD-32911): Add legal/ubuntu-advantage-service-terms to legal/ubuntu-pro-service-terms redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -653,6 +653,7 @@ mir/tutorials/.*: /mir/docs/tutorials/
 legal/ubuntu-pro-description/?: "https://assets.ubuntu.com/v1/f56994fc-ubuntu_pro_description_unified.pdf"
 legal/ubuntu-pro-description/ja?: "https://assets.ubuntu.com/v1/f56994fc-ubuntu_pro_description_unified.pdf"
 legal/ubuntu-pro-description/jp?: "https://assets.ubuntu.com/v1/f56994fc-ubuntu_pro_description_unified.pdf"
+legal/ubuntu-advantage-service-terms(?P<page>.*)/?: "/legal/ubuntu-pro-service-terms{page}"
 
 # Multipass documentation
 multipass/docs?: "https://documentation.ubuntu.com/multipass/en/latest"


### PR DESCRIPTION
## Done

- Added a redirect

## QA

- Visit [demo](https://canonical-com-2183.demos.haus/legal/ubuntu-advantage-service-terms)
- Verify it redirects to https://canonical-com-2183.demos.haus/legal/ubuntu-pro-service-terms

## Issue / Card

Fixes #2182 [WD-32911](https://warthogs.atlassian.net/browse/WD-32911)


[WD-32911]: https://warthogs.atlassian.net/browse/WD-32911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ