### PR TITLE
[WD-33088] Remove vmware migration link from infra solutions page

### DIFF
--- a/templates/solutions/infrastructure/index.html
+++ b/templates/solutions/infrastructure/index.html
@@ -138,8 +138,6 @@
           <p class="p-section--shallow">
             With open source tools, Canonical puts clouds within reach for everyone. Unlike proprietary solutions, there are no license fees. You pay only for the support and maintenance you need.
           </p>
-          <hr class="p-rule" />
-          <a href="https://ubuntu.com/engage/vmware-migration-scenarios">How to migrate from proprietary solutions like VMware to open source&nbsp;&rsaquo;</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

Removes the "How to migrate from proprietary solutions like VMware to open source" from the infra solutions page per [copydoc](https://docs.google.com/document/d/1xbuIA53HKrMatjuiNQwf1ORwLvNXFEF0UqGTbB6sXL0/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Open [`/solutions/infrastructure`](https://canonical-com-2199.demos.haus/solutions/infrastructure)
- Verify that the "How to migrate from proprietary solutions like VMware to open source" link and its separator rule have been removed, matching the [copydoc](https://docs.google.com/document/d/1xbuIA53HKrMatjuiNQwf1ORwLvNXFEF0UqGTbB6sXL0/edit?tab=t.0).

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-33088
