### PR TITLE
feat: store utms on essential cookies

### DIFF
--- a/static/js/cookie-policy-with-callback.js
+++ b/static/js/cookie-policy-with-callback.js
@@ -52,21 +52,15 @@ function setUtmCookies(urlParams) {
 }
 
 function setUtms() {
-  cookieAcceptanceValue = getCookie("_cookies_accepted");
-  if (
-    cookieAcceptanceValue?.[2] === "all" ||
-    cookieAcceptanceValue?.[2] === "performance"
-  ) {
-    let utmCookies = getCookie("utms");
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.size > 0) {
-      setUtmCookies(urlParams);
-    } else if (utmCookies) {
-      const referrer = document.referrer;
-      const currentHost = window.location.host;
-      if (!referrer.includes(currentHost)) {
-        document.cookie = "utms=;max-age=0;path=/;";
-      }
+  let utmCookies = getCookie("utms");
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.size > 0) {
+    setUtmCookies(urlParams);
+  } else if (utmCookies) {
+    const referrer = document.referrer;
+    const currentHost = window.location.host;
+    if (referrer && !referrer.includes(currentHost)) {
+      document.cookie = "utms=;max-age=0;path=/;";
     }
   }
 }


### PR DESCRIPTION
## Done
- Store utm values in cookies for all cookie preferences

## QA
- Go to ?utm_content=test1&utm_medium=test2
- Select "essential" cookies only
- Navigate to another page
- Check that `utms` cookie is populated with the utm content
- Additionally, submit a form and check that the utm content is passed to Marketo's enrichment (not payload) form successfully

## Issue / Card

Fixes [WD-32752](https://warthogs.atlassian.net/browse/WD-32752)

## Screenshots

[if relevant, include a screenshot]


[WD-32752]: https://warthogs.atlassian.net/browse/WD-32752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ