### PR TITLE
chore: remove link in /openstack/compare

### DIFF
--- a/templates/openstack/compare/index.html
+++ b/templates/openstack/compare/index.html
@@ -566,13 +566,6 @@
           "content": "Gain more than a decade of stability with an open source, enterprise cloud solution. Contrary to traditional, proprietary virtualization platforms, Canonical OpenStack helps you reduce vendor lock-in and lower your infrastructure costs by up to 85%."
         }
       },
-      {
-        "type": "description",
-        "item": {
-          "type": "html",
-          "content": "<a href='https://ubuntu.com/engage/from-vmware-to-openstack'>Read the white paper &mdash; “From VMware to OpenStack” &rsaquo;</a>"
-        }
-      },
     ]) }}
 
   {{ vf_basic_section(title={"text": "Repatriate your cloud workloads and regain control over your data"},
@@ -665,7 +658,7 @@
             ]
           },
         ],
-      ) 
+      )
     }}
 
   {{ vf_basic_section(title={"text": "Get in touch with Canonical"},


### PR DESCRIPTION
## Done

Remove link in [/openstack/compare](https://canonical-com-2212.demos.haus/openstack/compare)

## QA
[Copydoc](https://warthogs.atlassian.net/browse/WD-33252)
[Demo](https://canonical-com-2212.demos.haus/openstack/compare)
- Check out the [demo link](https://canonical-com-2212.demos.haus/openstack/compare)
- cehck that it aligns with copydoc
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-33252

## Screenshots
Before
<img width="1554" height="1234" alt="image" src="https://github.com/user-attachments/assets/6126d44c-7787-4dc7-b55f-1bb15b883a99" />

After
<img width="1480" height="1122" alt="image" src="https://github.com/user-attachments/assets/48dec26f-331f-40c1-9764-47f8879e4c0f" />


[if relevant, include a screenshot]
