### PR TITLE
[WD-32968] update Screenly logo on two pages

### DIFF
--- a/templates/solutions/iot-and-devices/index.html
+++ b/templates/solutions/iot-and-devices/index.html
@@ -178,9 +178,9 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image (url="https://assets.ubuntu.com/v1/744d29b7-screenly-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/1c576c31-screenly_logo_updated.png",
             alt="",
-            width="104",
+            width="106",
             height="104",
             hi_def=True,
             loading="lazy"

--- a/templates/solutions/ubuntu-os/index.html
+++ b/templates/solutions/ubuntu-os/index.html
@@ -453,12 +453,13 @@
         <hr class="p-rule--muted" />
         <div class="row p-section--shallow">
           <div class="col-3 p-image-wrapper">
-            {{ image(url="https://assets.ubuntu.com/v1/bf624470-image%20wrapper.png",
+            {{ image(url="https://assets.ubuntu.com/v1/a182b1e8-Full%20Logo.png",
                         alt="Screenly",
-                        width="125",
-                        height="43",
+                        width="120",
+                        height="120",
                         hi_def=True,
-                        loading="lazy") | safe
+                        loading="lazy"
+                        ) | safe
             }}
           </div>
           <div class="col-6">


### PR DESCRIPTION
## Done

Update Screenly logo on:
  - /solutions/iot-and-devices: [copy doc](https://docs.google.com/document/d/1htb7rb55Ks5ZHn7RLzoeU51nZpWOX6YC10CfZ8UJxDM)
  - /solutions/ubuntu-os: [copy doc
](https://docs.google.com/document/d/1X3osSqcm3rWLqYUJr5G4fXEEHCby-j5FEJwClLNx5S4/edit?tab=t.0)
## QA

- Open each of the following pages:
  - https://canonical-com-2213.demos.haus/solutions/iot-and-devices
  - https://canonical-com-2213.demos.haus/solutions/ubuntu-os
- Check that Screenly logo has been updated and that the layout around the new logo looks intact.

## Issue / Card

https://warthogs.atlassian.net/browse/WD-32968

