### PR TITLE
copy-update: remove whitepaper section [WD-3353]

### DIFF
--- a/templates/openstack/resources.html
+++ b/templates/openstack/resources.html
@@ -247,33 +247,6 @@
           <div class="col-3 col-medium-3">
             <div class="p-section--shallow">
               <div class="p-image-container">
-                {{ image(url="https://assets.ubuntu.com/v1/ca3ff0c9-vmware.png",
-                  alt="",
-                  width="568",
-                  height="321",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"class": "p-image-container__image"}
-                ) | safe
-                }}
-              </div>
-            </div>
-          </div>
-          <div class="col-6 col-medium-3">
-            <h4 class="p-heading--5 u-no-margin--bottom">
-              <a href="https://assets.ubuntu.com/v1/774776c6-Canonical%20infrastructure%20for%20the%20public%20sector.pdf">
-                From VMware to OpenStack
-              </a>
-            </h4>
-            <p>This paper explores the benefits of moving from VMware to one of its open source alternatives: OpenStack. By looking at the similarities and differences of both platforms, we demonstrate how organizations can perform a successful migration while achieving feature parity.</p>
-          </div>
-        </div>
-
-        <hr class="p-rule--muted" />
-        <div class="row">
-          <div class="col-3 col-medium-3">
-            <div class="p-section--shallow">
-              <div class="p-image-container">
                 {{ image(url="https://assets.ubuntu.com/v1/e61fd5dd-cloud-pricing.png",
                   alt="",
                   width="568",


### PR DESCRIPTION
## Done

Removed the section highlighting the whitepaper: [From VMware to OpenStack](https://assets.ubuntu.com/v1/774776c6-Canonical%20infrastructure%20for%20the%20public%20sector.pdf) on [this](https://canonical.com/openstack/resources) page. 

Copy doc:
https://docs.google.com/document/d/1Fv9eAy2_iPm5m4lOliqQIJN0Gg4OSo9XtrtvH180Jvg/edit?tab=t.0
Demo:
https://canonical-com-2217.demos.haus/openstack/resources

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Navigate to /openstack/resources
- The section highlighting the "From VMware to OpenStack" whitepaper should be gone

## Issue / Card

Fixes #[WD-3353](https://warthogs.atlassian.net/browse/WD-33253)

## Screenshots

Before:
<img width="1522" height="682" alt="image" src="https://github.com/user-attachments/assets/bffdfdd8-a015-4290-bc64-310dccada891" />

After:
<img width="2242" height="693" alt="image" src="https://github.com/user-attachments/assets/ef9e3c2f-ea2e-40e3-9ce9-519ae1de478f" />



[WD-3353]: https://warthogs.atlassian.net/browse/WD-3353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ