### PR TITLE
fix: failing link

### DIFF
--- a/templates/public-sector/index.html
+++ b/templates/public-sector/index.html
@@ -186,7 +186,7 @@
         }
         },
         {
-        "href": "https://ubuntu.com/security/disa",
+        "href": "https://ubuntu.com/security/disa-stig",
         "text": "Learn more about meeting DISA-STIG requirements with Canonical&nbsp;&rsaquo;",
         "label": "DISA",
         "image_attrs": {


### PR DESCRIPTION
## Done

- Fix incorrect link

## QA

- Go to /public-sector
- Search for "Learn more about meeting DISA-STIG requirements with Canonical", click on link
- See that it redirects to a webpage successfully

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
