### PR TITLE
feat: attach utms cookie value to ubuntu.com redirects

### DIFF
--- a/static/js/cookie-policy-with-callback.js
+++ b/static/js/cookie-policy-with-callback.js
@@ -13,8 +13,8 @@ if (!cookieAcceptanceValue) {
 } else {
   setUserId();
   cpNs.cookiePolicy();
-  setUtms();
 }
+setUtms();
 
 function setUserId() {
   cookieAcceptanceValue = getCookie("_cookies_accepted");

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -51,6 +51,7 @@ from webapp.views import (
     build_case_study_index,
     build_events_index,
     build_canonical_days_index,
+    append_utms_cookie_to_ubuntu_links,
 )
 from webapp.application import application
 from webapp.canonical_cla.views import (
@@ -1876,3 +1877,9 @@ if environment != "production":
         """Endpoint to trigger a Sentry error for testing purposes."""
         1 / 0
         return "This won't be reached"
+
+
+# Append utms cookie to Ubuntu redirect links
+@app.after_request
+def check_redirect(response):
+    return append_utms_cookie_to_ubuntu_links(response)


### PR DESCRIPTION
## Done

- Attach `utms` cookie value to ubuntu.com redirects

## QA

- Go to https://canonical-com-2238.demos.haus/?utm_content=test1&utm_medium=test2
- Check that utm contents are stored in `utms` cookie
- Scroll down to "Webinar & Events", click on any of the links that are redirecting to ubuntu.com
- Once redirected, check that the `utms` cookie values are appended in the URL

## Issue / Card

Fixes [WD-32640](https://warthogs.atlassian.net/browse/WD-32640)

## Screenshots

[if relevant, include a screenshot]


[WD-32640]: https://warthogs.atlassian.net/browse/WD-32640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ