### PR TITLE
disable apply button for unlisted jobposts from primary board

### DIFF
--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -65,7 +65,7 @@
     <div class="job-desc">
       {{ job.content | filtered_html_tags | safe }}
     </div>
-    {% if job.active %}
+    {% if job.active and not job.unlisted %}
       <button class="p-button--positive" id="apply-button">Apply</button>
     {% else %}
       <button class="p-button--positive" disabled="">No longer accepting applications</button>

--- a/tests/test_greenhouse.py
+++ b/tests/test_greenhouse.py
@@ -137,6 +137,7 @@ class TestGreenhouseAPI(unittest.TestCase):
         self.assertEqual(
             [dept.name for dept in vacancy.departments], ["Engineering"]
         )
+        self.assertFalse(vacancy.unlisted)
 
     def test_get_vacancy_fallback_on_404(self):
         """
@@ -162,6 +163,7 @@ class TestGreenhouseAPI(unittest.TestCase):
             f"{gh.canonicaljobs_url}/404-job?questions=true", timeout=15
         )
         self.assertEqual(vacancy.id, "404-job")
+        self.assertTrue(vacancy.unlisted)
 
     def test_submit_application_builds_payload(self):
         """

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -560,6 +560,7 @@ def job_details(session, greenhouse, harvest, job_id):
         job_post = greenhouse.get_vacancy(job_id)
         context["job"]["content"] = job_post.content
         context["job"]["is_remote"] = is_remote(context["job"])
+        context["job"]["unlisted"] = job_post.unlisted
 
     except HTTPError as error:
         if error.response.status_code == 404:

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -206,7 +206,7 @@ class Department(object):
 
 
 class Vacancy:
-    def __init__(self, job: dict):
+    def __init__(self, job: dict, unlisted: bool):
         self.id: str = job["id"]
         self.title: str = job["title"]
         self.meta_title: str = _get_meta_title(job)
@@ -231,6 +231,7 @@ class Vacancy:
         self.skills: list = _get_metadata(job, "skills") or []
         self.featured: str = _get_metadata(job, "is_featured")
         self.fast_track: str = _get_metadata(job, "is_fast_track")
+        self.unlisted: bool = unlisted
 
     def parse_questions(self, job):
         questions = job.get("questions", {})
@@ -303,7 +304,7 @@ class Greenhouse:
         for job in feed["jobs"]:
             # Filter out those without departments or offices
             if _get_metadata(job, "departments") and job["offices"]:
-                vacancies.append(Vacancy(job))
+                vacancies.append(Vacancy(job, False))
 
         return vacancies
 
@@ -355,7 +356,7 @@ class Greenhouse:
                 f"{self.base_url}/{job_id}?questions=true", timeout=15
             )
             response.raise_for_status()
-            return Vacancy(response.json())
+            return Vacancy(response.json(), False)
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
                 # try canonicaljobs board as fallback
@@ -364,7 +365,7 @@ class Greenhouse:
                     timeout=15,
                 )
                 response.raise_for_status()
-                return Vacancy(response.json())
+                return Vacancy(response.json(), True)
             # re-raise any other HTTP errors
             raise
 


### PR DESCRIPTION
## Done

- disable "Apply" button  if jobpost is unlisted from the primary job board.

## QA

- goto https://canonical-com-2239.demos.haus/careers/5146709
- check if Apply button is not disabled

