### PR TITLE
fix: linting errors

### DIFF
--- a/templates/solutions/infrastructure/sovereign-cloud.html
+++ b/templates/solutions/infrastructure/sovereign-cloud.html
@@ -48,7 +48,7 @@
   {% call(slot) vf_cta_section(
     title_text='Learn about sovereign clouds in our free, comprehensive guide.',
     variant='default',
-    layout='100',
+    layout='100'
     ) -%}
     {%- if slot == 'cta' -%}
     <a href="https://ubuntu.com/engage/sovereign-cloud-guide">Get the guide&nbsp;&rsaquo;</a>
@@ -427,7 +427,7 @@
               "type": "description",
               "item": {
                 "type": "html",
-                "content": "
+                "content": '
                   <p>
                     Every cloud requires servers to support workloads. However, server management and maintenance can be hugely time consuming. MAAS lightens this burden. 
                   </p>
@@ -435,9 +435,9 @@
                     It streamlines the entire hardware lifecycle, enabling automated and remote server provisioning, configuration, installation, deployment, and discovery, all in a single workflow. 
                   </p>
                   <div class="p-cta-block">
-                    <a href='/maas'>Discover MAAS&nbsp;&rsaquo;</a>
+                    <a href="/maas">Discover MAAS&nbsp;&rsaquo;</a>
                   </div>
-                "
+                '
               }
             }
           ]
@@ -466,14 +466,14 @@
               "type": "description",
               "item": {''
                 "type": "html",
-                "content": "
+                "content": '
                   <p>
                     Canonical Ceph helps to organize the data on sovereign cloud servers. Ceph is an elastic distributed storage system which combines block, file, and object storage at scale, making it a strong foundation for sovereign clouds.
                   </p>
                   <div class="p-cta-block">
                     <a href="https://ubuntu.com/ceph">Discover Canonical Ceph&nbsp;&rsaquo;</a>
                   </div>
-                "
+                '
               }
             }
           ]
@@ -502,7 +502,7 @@
               "type": "description",
               "item": {
                 "type": "html",
-                "content": "
+                "content": '
                   <p>
                     Canonical Landscape delivers control up to the systems management level.
                   </p>
@@ -511,9 +511,9 @@
                     as well as managing users and their permissions &mdash; on a single pane of glass. 
                   </p>
                   <div class="p-cta-block">
-                    <a href='https://ubuntu.com/landscape'>Discover Landscape&nbsp;&rsaquo;</a>
+                    <a href="https://ubuntu.com/landscape">Discover Landscape&nbsp;&rsaquo;</a>
                   </div>
-                "
+                '
               }
             }
           ]
@@ -542,17 +542,17 @@
               "type": "description",
               "item": {
                 "type": "html",
-                "content": "
+                "content": '
                   <p>
                     Each element in Canonical’s sovereign cloud software stack is optimized to run on Ubuntu. Through features like AppArmor, File Encryption, Stack Protector, and UEFI Secure Boot, Ubuntu prioritizes user privacy and system integrity by default &mdash; which is key for sovereign clouds.
                   </p>
                   <p>
-                    With <a href='https://ubuntu.com/pro'>Ubuntu Pro</a>, enterprises get up to 15 years of security maintenance for thousands of open source packages, tools for compliance, and the option to add 24/7 enterprise support.
+                    With <a href="https://ubuntu.com/pro">Ubuntu Pro</a>, enterprises get up to 15 years of security maintenance for thousands of open source packages, tools for compliance, and the option to add 24/7 enterprise support.
                   </p>
                   <div class="p-cta-block">
-                    <a href='https://ubuntu.com/pro'>Discover Ubuntu&nbsp;&rsaquo;</a>
+                    <a href="https://ubuntu.com/pro">Discover Ubuntu&nbsp;&rsaquo;</a>
                   </div>
-                "
+                '
               }
             }
           ]
@@ -581,14 +581,14 @@
               "type": "description",
               "item": {
                 "type": "html",
-                "content": "
+                "content": '
                   <p>
                     Canonical’s lightweight open source cloud, MicroCloud, is designed for companies without extensive on-premise infrastructure. It has a low barrier to entry, with automated deployment and on-site operations. MicroCloud helps you create a sovereign cloud in minutes, from a single node, to 50 node clusters.
                   </p>
                   <div class="p-cta-block">
-                    <a href='/microcloud'>Discover MicroCloud&nbsp;&rsaquo;</a>
+                    <a href="/microcloud">Discover MicroCloud&nbsp;&rsaquo;</a>
                   </div>
-                "
+                '
               }
             }
           ]
@@ -617,14 +617,14 @@
               "type": "description",
               "item": {
                 "type": "html",
-                "content": "
+                "content": '
                   <p>
                     OpenStack is a highly customizable cloud platform, used for everything from a regional public cloud, to an on-premise extension of the public cloud, to sovereign clouds.
                   </p>
                   <div class="p-cta-block">
                     <a href="https://ubuntu.com/openstack">Discover Canonical OpenStack&nbsp;&rsaquo;</a>
                   </div>
-                "
+                '
               }
             }
           ]
@@ -653,7 +653,7 @@
               "type": "description",
               "item": {
                 "type": "html",
-                "content": "
+                "content": '
                   <p>
                     Canonical Kubernetes makes building sovereign clouds across multiple environments that align with your compliance and IT requirements much easier. 
                     It provides a layer that makes data and AI applications portable across development frameworks, with minimal adaptations or configuration changes. 
@@ -661,7 +661,7 @@
                   <div class="p-cta-block">
                     <a href="https://ubuntu.com/kubernetes">Discover Canonical Kubernetes&nbsp;&rsaquo;</a>
                   </div>
-                "
+                '
               }
             }
           ]
@@ -839,7 +839,7 @@
   
   {% call(slot) vf_resources(
     title={
-      "text": "Take the next step <br class="u-hide--small u-hide--medium" />in your journey",
+      "text": "Take the next step <br class=\"u-hide--small u-hide--medium\" />in your journey",
     },
     padding="deep",
     blocks=[


### PR DESCRIPTION
## Done

- Fix linting errors with double and single quotes, causing the page not to load as expected

## QA

- Go to https://canonical-com-2241.demos.haus/solutions/infrastructure/sovereign-cloud
- See that the page loads and does not show this error:
`jinja2.exceptions.TemplateSyntaxError: expected token ',', got 'p'`


## Issue / Card

Fixes [WD-33492](https://warthogs.atlassian.net/browse/WD-33492)

## Screenshots

[if relevant, include a screenshot]


[WD-33492]: https://warthogs.atlassian.net/browse/WD-33492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ