### PR TITLE
feat: Update deployment runner to noble private endpoint

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -86,7 +86,7 @@ jobs:
         run: skopeo --insecure-policy copy oci-archive:$(ls *.rock) docker://${{ steps.set_image_url.outputs.image_url }} --dest-creds "canonical:${{ secrets.GITHUB_TOKEN }}"
 
   deploy-staging:
-    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-medium]
     needs: [pack-charm, publish-image]
     steps:
       - name: Checkout Code


### PR DESCRIPTION
## Done

- Updated label for private github runners

## QA

- See that all checks pass
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
