### PR TITLE
copy update: update lxd/manage

### DIFF
--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -61,7 +61,7 @@ meta_copydoc %}
         <p>
           LXD offers an intuitive and crisp CLI for easy operations. To control LXD, you typically use two different
           commands: <code>lxd</code> and <code>lxc</code>. The <code>lxd</code> command is used to control the daemon and
-          is typically used only for initialisation and debugging. The <code>lxc</code> command is the command-line client
+          is typically used only for initialization and debugging. The <code>lxc</code> command is the command-line client
           that you use to interact with your instances. See <code>lxc --help</code> for an overview of all available
           subcommands.
         </p>
@@ -228,7 +228,7 @@ meta_copydoc %}
               infrastructure.
             </p>
             <p>
-              Juju can be used to deploy a variety of workloads across many different clouds and virtualisation
+              Juju can be used to deploy a variety of workloads across many different clouds and virtualization
               providers. It supports both deploying workloads against a LXD server or cluster and using LXD on the
               machines it's deploying to separate otherwise colocated services.
             </p>
@@ -365,7 +365,7 @@ meta_copydoc %}
               Documentation on LXD</a>.
             </p>
             <p>
-              To manage LXD in Puppet Bolt, you need a LXD server (see <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/getting_started/">Getting started</a>).
+              To manage LXD in Puppet Bolt, you need a LXD server (see <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/getting_started/">"Getting started"</a>).
             </p>
           </div>
         </div>
@@ -399,7 +399,7 @@ meta_copydoc %}
               configuration</a> might contain useful information regarding image choice, configuration options etc.
             </p>
             <p>
-              To create LXD images in Packer, you need a LXD server (see <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/getting_started/">Getting started</a>).
+              To create LXD images in Packer, you need a LXD server (see <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/getting_started/">"Getting started"</a>).
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Update lxd/manage to change from UK to US English and fix grammatical errors
- Refer copydoc: https://docs.google.com/document/d/1doGyKYSTOsX8dHvQ6W9W2U_pHQY6yfiq1bqSAJyredQ/edit?tab=t.0

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/ or check against demo
- View that all requested changes have been made

## Issue / Card

Fixes [WD-33533](https://warthogs.atlassian.net/browse/WD-33533)



[WD-33533]: https://warthogs.atlassian.net/browse/WD-33533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ