### PR TITLE
try prevent career/<id> cached pages from being stale for more than 1h.

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -605,7 +605,7 @@ def job_details(session, greenhouse, harvest, job_id):
                 "title": f"Error {response.status_code}",
                 "text": f"{response.reason}. Please try again!",
             }
-            
+
     response = flask.make_response(
         flask.render_template("careers/job-detail.html", **context)
     )
@@ -617,6 +617,7 @@ def job_details(session, greenhouse, harvest, job_id):
         "stale-if-error=0"
     )
     return response
+
 
 @app.route("/careers/career-explorer")
 def start_career():


### PR DESCRIPTION
## Done

This is an attempt to prevent cache server serving stale job pages (stale for few days).
For /careers/<id> we set this header:
```
Cache-Control: public, max-age=3600, must-revalidate, stale-while-revalidate=0, stale-if-error=0
```

Reason for =0 values is because flask-base sets some default values if these are missing..

