### PR TITLE
fix: add raw.githubusercontent.com to CSP whitelist

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -84,6 +84,7 @@ CSP = {
         "*.mktoresp.com",
         "assets.ubuntu.com",
         "api.github.com",
+        "raw.githubusercontent.com",
         "api.livechatinc.com",
         "cdn.livechatinc.com",
         "secure.livechatinc.com",


### PR DESCRIPTION
## Done

- add raw.githubusercontent.com to CSP whitelist

## QA

- Check https://canonical-com-2269.demos.haus/maas/docs/api returns 200

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-33625