### PR TITLE
Setup redirect for infra modernization link

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -2030,3 +2030,6 @@ jaas/u/(?P<username>.*)/(?P<charm_or_bundle_name>.*)/(?P<series_or_version>.*)/(
 # Blog redirects
 blog/tag/charmed-aether-sd-core: /solutions/telco
 blog/group/(?P<group>[^/]+)/?: /blog/archives?group={group}
+
+# Infrastructure modernization redirects
+blog/cloudify-your-data-centre: https://assets.ubuntu.com/v1/855af1ef-infrastructure_modernization_and_sovereignty_datasheet.pdf


### PR DESCRIPTION
## Done

Setup redirect links as instructed in WD-33645.

## QA

Use the demo link below and try to access the old URLs or...
- Check out this feature branch
- Run the site using `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Try to access the old URLs (it should start a download of the PDF file).

## Issue / Card

https://warthogs.atlassian.net/browse/WD-33645