### PR TITLE
feat: update `canonical.com` navigation (WD-33826)

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -689,16 +689,14 @@ company:
   sibling_lists:
     - title: Explore Canonical
       links:
-        - title: Documentation practice
-          url: /documentation
-        - title: Open source projects
+        - title: Open source in your enterprise
+          url: /open-source-adoption
+        - title: Open source projects we support
           url: /projects
-        - title: Ubuntu Summit
-          url: https://ubuntu.com/summit
+        - title: Company events
+          url: /events
         - title: Company Trust Center
           url: https://trust.canonical.com/
-        - title: Enterprise open source adoption
-          url: /open-source-adoption
 
     - title: Latest updates
       links:
@@ -711,12 +709,12 @@ company:
     title: Company highlights
     title_url: /blog
     links:
-      - description: Canonical announces 12 year Kubernetes LTS
-        url: /blog/12-year-lts-for-kubernetes
-        image_url: https://assets.ubuntu.com/v1/ea74a20b-canonical_announces.jpg
-      - description: BT Group and Canonical deliver 5G to UK stadiums
-        url: /blog/bt-group-and-canonical-deliver-5g-to-uk-stadiums
-        image_url: https://assets.ubuntu.com/v1/5ed3ccb9-bt_group.jpg
+      - description: Canonical announces Ubuntu Pro for WSL
+        url: /blog/canonical-announces-ubuntu-pro-for-wsl
+        image_url: https://assets.ubuntu.com/v1/55a9f067-ubuntu_pro_on_windows_store.png
+      - description: Ubuntu Pro Legacy add-on expands coverage for Ubuntu LTS releases to 15 years
+        url: /blog/canonical-expands-total-coverage-for-ubuntu-lts-releases-to-15-years-with-legacy-add-on
+        image_url: https://assets.ubuntu.com/v1/4ff2e4b3-canonical_announces.png
       - description: Canonical Releases Ubuntu 25.10 Questing Quokka
         url: /blog/canonical-releases-ubuntu-25-10-questing-quokka
         image_url: https://assets.ubuntu.com/v1/01403c6c-canonical_releases.jpg


### PR DESCRIPTION
## Done

- Update navigation

## QA

- Open the [DEMO](https://canonical-com-2286.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Ensure navigation matches copy doc

## Issue / Card

WD-33826

## Screenshots

<img width="3508" height="2226" alt="image" src="https://github.com/user-attachments/assets/f99561f7-4e9a-4cc6-9f70-91edbca47394" />