### PR TITLE
refactor: adjust link style on /careers/hiring-process

### DIFF
--- a/templates/careers/hiring-process/index.html
+++ b/templates/careers/hiring-process/index.html
@@ -68,10 +68,12 @@
           This creates a unique environment with multicultural teams spanning many time zones giving our people the chance to work with colleagues from all over the world. Our open source world relies on a rich and varied set of perspectives; to deliver our best products we seek diversity of ideas through effective and impactful collaboration.
         </p>
         <hr class="p-rule--muted" />
-        <div class="p-cta-block">
-          <a class="p-button" href="/careers/company-culture/remote-work">Learn about remote working at Canonical</a>
+        <p>
+          <a href="/careers/company-culture/remote-work">Learn about remote working at Canonical&nbsp;&rsaquo;</a>
+        </p>
+        <p>
           <a href="/blog/how-to-get-a-job-at-canonical">Read our blog on how to get a job at Canonical&nbsp;&rsaquo;</a>
-        </div>
+        </p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

- adjust link style to match https://ubuntu.com/download/server stacked links

## QA

- Open the [DEMO](https://canonical-com-2295.demos.haus/careers/hiring-process)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]

