### PR TITLE
fix: use flask env secret

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1749,7 +1749,7 @@ def build_sitemap_tree(exclude_paths=None):
 
         # Update sitemap with POST request
         if flask.request.method == "POST":
-            expected_secret = os.getenv("SITEMAP_SECRET")
+            expected_secret = get_flask_env("SITEMAP_SECRET")
             provided_secret = flask.request.headers.get(
                 "Authorization", ""
             ).replace("Bearer ", "")


### PR DESCRIPTION
## Done

- Use `get_flask_env` for sitemap secrets

## QA

- Go to https://canonical-com-2300.demos.haus/sitemap_parser and https://canonical-com-2300.demos.haus/sitemap_tree.xml
- See that it loads without error

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-34079

## Screenshots

[if relevant, include a screenshot]

