### PR TITLE
WD-34130 Update financial services page copy

### DIFF
--- a/templates/solutions/financial-services/index.html
+++ b/templates/solutions/financial-services/index.html
@@ -282,28 +282,44 @@
           "is_fixed_width": true,
           "logos": [
             {
-              "attrs": {
-                "src": "https://assets.ubuntu.com/v1/a98574d9-FedRAMP.png",
-                "alt": "FedRAMP logo"
-              }
+              "attrs": image(url="https://assets.ubuntu.com/v1/a98574d9-FedRAMP.png",
+                  alt="FedRAMP logo",
+                  width="111",
+                  height="312",
+                  hi_def=True,
+                  loading="lazy",
+                  output_mode="attrs"
+                  )
             },
             {
-              "attrs": {
-                "src": "https://assets.ubuntu.com/v1/06eb2988-DISA-logo.png",
-                "alt": "DISA logo"
-              }
+              "attrs": image(url="https://assets.ubuntu.com/v1/06eb2988-DISA-logo.png",
+                  alt="DISA logo",
+                  width="221",
+                  height="312",
+                  hi_def=True,
+                  loading="lazy",
+                  output_mode="attrs"
+                  )
             },
             {
-              "attrs": {
-                "src": "https://assets.ubuntu.com/v1/5a48958f-CIS-logo.png",
-                "alt": "CIS logo"
-              }
+              "attrs": image(url="https://assets.ubuntu.com/v1/5a48958f-CIS-logo.png",
+                  alt="CIS logo",
+                  width="130",
+                  height="312",
+                  hi_def=True,
+                  loading="lazy",
+                  output_mode="attrs"
+                  )
             },
             {
-              "attrs": {
-                "src": "https://assets.ubuntu.com/v1/b6b16099-nist-logo.png",
-                "alt": "NIST logo"
-              }
+              "attrs": image(url="https://assets.ubuntu.com/v1/b6b16099-nist-logo.png",
+                  alt="NIST logo",
+                  width="186",
+                  height="312",
+                  hi_def=True,
+                  loading="lazy",
+                  output_mode="attrs"
+                 )
             }
           ]
         }


### PR DESCRIPTION
## Done

Copy update of financial services page, including changing the logo section into basic section pattern.

Copy doc: https://docs.google.com/document/d/1CMEo3IsFkybk1SuKWpvZGxU6e24iNoDZkjrgloYXEkU/edit?tab=t.0



## QA

- Open the [DEMO](https://canonical-com-2307.demos.haus/solutions/financial-services)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Review changes in comparison with copy doc.

## Issue / Card

Fixes WD-34130


