### PR TITLE
fix: use stage id instead of name for candidate dashboard milestone progress

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -24,19 +24,19 @@ from webapp.greenhouse import Harvest
 from webapp.utils.cipher import Cipher, InvalidToken
 
 all_stages = [
-    {"name": "Application Review"},
-    {"name": "Written Interview"},
-    {"name": "Devskiller"},
-    {"name": "Thomas International - GIA"},
-    {"name": "Hold"},
-    {"name": "Technical Exercise"},
-    {"name": "Early Stage Interviews"},
-    {"name": "Thomas International - PPA"},
-    {"name": "Talent Interview"},
-    {"name": "Late Stage Interviews"},
-    {"name": "Shortlist"},
-    {"name": "Executive Review"},
-    {"name": "Offer"},
+    {"id": 1, "name": "Application Review"},
+    {"id": 2, "name": "Written Interview"},
+    {"id": 3, "name": "Devskiller"},
+    {"id": 4, "name": "Thomas International - GIA"},
+    {"id": 5, "name": "Hold"},
+    {"id": 6, "name": "Technical Exercise"},
+    {"id": 7, "name": "Early Stage Interviews"},
+    {"id": 8, "name": "Thomas International - PPA"},
+    {"id": 9, "name": "Talent Interview"},
+    {"id": 10, "name": "Late Stage Interviews"},
+    {"id": 11, "name": "Shortlist"},
+    {"id": 12, "name": "Executive Review"},
+    {"id": 13, "name": "Offer"},
 ]
 
 
@@ -90,7 +90,7 @@ class TestApplicationPageHelpers(VCRTestCase):
     def test_milestone_progress_current_stage_defined(self):
         self.assertDictEqual(
             _milestones_progress(
-                all_stages, {"name": "Early Stage Interviews"}
+                all_stages, {"id": 7, "name": "Early Stage Interviews"}
             ),
             {
                 "application": True,
@@ -103,22 +103,22 @@ class TestApplicationPageHelpers(VCRTestCase):
 
     def test_milestone_progress_unordered_stages_list(self):
         all_stages = [
-            {"name": "Offer"},
-            {"name": "Application Review"},
-            {"name": "Written Interview"},
-            {"name": "Devskiller"},
-            {"name": "Thomas International - GIA"},
-            {"name": "Hold"},
-            {"name": "Late Stage Interviews"},
-            {"name": "Talent Interview"},
-            {"name": "Technical Exercise"},
-            {"name": "Early Stage Interviews"},
-            {"name": "Shortlist"},
-            {"name": "Thomas International - PPA"},
-            {"name": "Executive Review"},
+            {"id": 13, "name": "Offer"},
+            {"id": 1, "name": "Application Review"},
+            {"id": 2, "name": "Written Interview"},
+            {"id": 3, "name": "Devskiller"},
+            {"id": 4, "name": "Thomas International - GIA"},
+            {"id": 5, "name": "Hold"},
+            {"id": 10, "name": "Late Stage Interviews"},
+            {"id": 9, "name": "Talent Interview"},
+            {"id": 6, "name": "Technical Exercise"},
+            {"id": 7, "name": "Early Stage Interviews"},
+            {"id": 11, "name": "Shortlist"},
+            {"id": 8, "name": "Thomas International - PPA"},
+            {"id": 12, "name": "Executive Review"},
         ]
         self.assertDictEqual(
-            _milestones_progress(all_stages, {"name": "Offer"}),
+            _milestones_progress(all_stages, {"id": 13, "name": "Offer"}),
             {
                 "application": True,
                 "assessment": True,
@@ -134,6 +134,31 @@ class TestApplicationPageHelpers(VCRTestCase):
             {
                 "application": False,
                 "assessment": False,
+                "early_stage": False,
+                "late_stage": False,
+                "offer": False,
+            },
+        )
+
+    def test_milestone_progress_duplicate_hold_uses_stage_id_anchor(self):
+        stages = [
+            {"id": 1, "name": "Application Review"},
+            {"id": 2, "name": "Written Interview"},
+            {"id": 3, "name": "Hold"},
+            {"id": 4, "name": "Technical Exercise"},
+            {"id": 5, "name": "Hold"},
+            {"id": 6, "name": "Early Stage Interviews"},
+            {"id": 7, "name": "Talent Interview"},
+            {"id": 8, "name": "Hold"},
+        ]
+
+        # candidate is in the middle "Hold" (assessment section), not the
+        # final "Hold" (after early-stage interviews).
+        self.assertDictEqual(
+            _milestones_progress(stages, {"id": 5, "name": "Hold"}),
+            {
+                "application": True,
+                "assessment": True,
                 "early_stage": False,
                 "late_stage": False,
                 "offer": False,
@@ -491,7 +516,7 @@ class TestGetApplication(unittest.TestCase):
             "jobs": [{"id": 1, "name": "Original Role"}],
             "candidate_id": 55,
             "attachments": [],
-            "current_stage": {"name": "Application Review"},
+            "current_stage": {"id": 999, "name": "Application Review"},
             "status": "active",
             "rejection_reason": {"type": {"id": 2}},
             "rejected_at": None,
@@ -522,6 +547,7 @@ class TestGetApplication(unittest.TestCase):
         }
         harvest.get_stages.return_value = [
             {
+                "id": 999,
                 "name": "Application Review",
                 "interviews": [{"id": 1}],
             }

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -184,17 +184,17 @@ def _milestones_progress(stages, current_stage=None):
             progress[milestone] = False
         return progress
 
-    stages = [stage["name"] for stage in stages]
-    current_stage = current_stage["name"]
+    current_stage_id = current_stage["id"]
 
     # Filter out todo stages that candidate hasn't done yet
     candidate_finished_stages = []
-    last_occurrence_found = False
+    current_stage_found = False
     for stage in reversed(stages):
-        if stage == current_stage:
-            last_occurrence_found = True
-        if last_occurrence_found:
-            candidate_finished_stages.append(stage)
+        if stage["id"] == current_stage_id:
+            current_stage_found = True
+
+        if current_stage_found:
+            candidate_finished_stages.append(stage["name"])
 
     candidate_finished_stages = _sort_stages_by_milestone(
         candidate_finished_stages, milestone_stages


### PR DESCRIPTION
## Rationale

Previously, to show milestone progress on Candidate Dash we were matching stages by name. This was causing issues because some job pipelines can contain duplicate stage names (usually "Hold"), which can appear a different points in the pipeline. If a candidate is in an earlier "Hold" stage for e.g., the name-based match would land on the last "Hold" stage instead and cause the Candidate Dash to report incorrect milestones. This change fixes by matching current stage on ID instead of name.

## Done

- match current stage by ID instead of name
- updated tests

## QA

- Open the [demo](https://canonical-com-2310.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Go to [this](https://canonical.greenhouse.io/people/454835550/applications/483237067/redesign) candidate's Candidate Dash. They were showing up in Early Stage when they should have been showing up in Assessment (this can be seen on their dash on the current prod site). Ensure they show up in Assessment stage now.
 

