### PR TITLE
perf: update MAAS page to use image template and lite_video

### DIFF
--- a/templates/maas/index.html
+++ b/templates/maas/index.html
@@ -449,16 +449,6 @@
                 }
               },
               {
-                "type": "video",
-                "item": {
-                  "attrs": {
-                    "src": "https://www.youtube.com/embed/dSZqax12Q7A?si=6NHwBl6f6kVGNZY-",
-                    "allowfullscreen": "",
-                    "title": "Building the data centre: Implementing self-service for large scale operations - T-Mobile"
-                  }
-                }
-              },
-              {
                 "type": "description",
                 "item": {
                   "type": "html",
@@ -492,16 +482,6 @@
                 "item": {
                   "type": "html",
                   "content": lite_video(video_id="SwlU4U-BWRo", video_title="How Roblox went from Windows to Ubuntu in 7 days for edge compute nodes"),
-                }
-              },
-              {
-                "type": "video",
-                "item": {
-                  "attrs": {
-                    "src": "https://www.youtube.com/embed/SwlU4U-BWRo?si=8gQWKZ2jd_r2jN6W",
-                    "allowfullscreen": "",
-                    "title": "How Roblox went from Windows to Ubuntu in 7 days for edge compute nodes"
-                  }
                 }
               }
             ]


### PR DESCRIPTION
## Done
Replace static image src/alt attributes with the image() helper function to consistently include width, height, hi_def, loading, and output_mode. 
Also replace a raw YouTube iframe with the lite_video() helper for better performance and maintainability. Improve template formatting and indentation for readability.

## QA

- Open the [DEMO](https://canonical-com-2328.demos.haus/maas)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots
<img width="2066" height="538" alt="image" src="https://github.com/user-attachments/assets/012d7723-1e08-4ad4-b03c-9e184c445151" />
<img width="1946" height="530" alt="image" src="https://github.com/user-attachments/assets/bc461d93-b396-4127-a695-d4fc6ab49d8e" />


<img width="2244" height="462" alt="image" src="https://github.com/user-attachments/assets/2cb7fc59-309a-4cf6-975c-b88cdc14115a" />
<img width="2080" height="594" alt="image" src="https://github.com/user-attachments/assets/60fe38fa-38ff-465c-86dc-03e034dacb41" />


[if relevant, include a screenshot]

