### PR TITLE
chore: sort events by earliest upcoming instead of latest

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -220,12 +220,12 @@ def build_events_index(engage_docs):
                         pass
             metadata = valid_events
 
-            # Sort by earliest upcoming event
-            metadata.sort(
-                key=lambda x: datetime.datetime.strptime(
-                    x.get("event_date", "31 December 1999"), "%d %B %Y"
-                ),
-            )
+        # Sort by earliest upcoming event
+        metadata.sort(
+            key=lambda x: datetime.datetime.strptime(
+                x.get("event_date", "31 December 1999"), "%d %B %Y"
+            ),
+        )
 
         return flask.render_template(
             "events/index.html",


### PR DESCRIPTION
## Done
Previously events were sorted in reverse chronological order (latest first), which was confusing for upcoming events. Now sorting chronologically so the earliest upcoming event appears first, improving user experience for event discovery.

## QA

- Open the [DEMO](https://canonical-com-2332.demos.haus/events)
- Check that
  - the events are orders by earliest date
  - you can sort the events by the table headers
  Compare that to https://canonical.com/events
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]

