### PR TITLE
OEDIV case study page

### DIFF
--- a/templates/case-study/oediv.html
+++ b/templates/case-study/oediv.html
@@ -50,7 +50,7 @@
     {%- if slot == 'list_item_content_4' -%}
       OEDIV has over 400 employees, more than 400 customers, and manages a fleet of 4,500 Linux systems
     {%- endif -%}
-  {%- endcall -%}c
+  {%- endcall -%}
 
   {%- call(slot) highlights(num_items=3) -%}
     {%- if slot == 'highlights_item_content_1' -%}


### PR DESCRIPTION
## Done

- added OEDIV case study page
[copydoc](https://docs.google.com/document/d/1zc2tStMpgS-Vx_HN6wk90dnDUG9eAn_WPttHdaDhb4A/edit?tab=t.0)
[figma](https://www.figma.com/design/rEDsQqLe8SfnvoxCcXJYLr/canonical.com-case-study---Sites?node-id=1726-1269&t=vjhO6jjE8U0Qp5ko-1)

## QA

- Open the [DEMO](https://canonical-com-2334.demos.haus/case-study/oediv)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/case-study/oediv
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- check that the page matches the copydoc and figma

## Issue / Card

Fixes WD-34096

