### PR TITLE
fix linkchecker issue

### DIFF
--- a/templates/solutions/ai/index.html
+++ b/templates/solutions/ai/index.html
@@ -474,7 +474,7 @@
 
   {% call(slot) vf_cta_section(variant='default', layout='100') -%}
   {%- if slot == 'cta' -%}
-  <a href="https://ubuntu.com/engage/source-ai-infrastructure">Get the enterprise guide to private AI infrastructure&nbsp;&rsaquo;</a>
+  <a href="https://ubuntu.com/engage/open-source-ai-infrastructure">Get the enterprise guide to private AI infrastructure&nbsp;&rsaquo;</a>
   {%- endif -%}
   {% endcall -%}
 


### PR DESCRIPTION
## Done

- Replaced broken link with updated link from the copydoc
- Fixes linkchecker issue

## QA
- Navigate to [/solutions/ai](https://canonical-com-2340.demos.haus/solutions/ai)
- Scroll down to 'Get the enterprise guide to private AI infrastructure' and click on link
- Ensure link works
- Reference with  [copydoc](https://docs.google.com/document/d/1AtAApqxX9cbWf4a3cakEYbk7OoTfdBBi7FlA3WZz5ZM/edit)


