### PR TITLE
fix: Update legal/data-privacy link

### DIFF
--- a/templates/legal/data-privacy/index.md
+++ b/templates/legal/data-privacy/index.md
@@ -80,7 +80,7 @@ Some webinars are directly hosted by Canonical on our sites. Where a webinar is 
 
 Canonical may collect non-personally-identifying information of the sort that web browsers and servers typically make available, such as the browser type, referring site, and the date and time of each visitor request. Our purpose in collecting non-personally identifying information is to better understand how visitors use our websites and services. For further information about how we use cookies, see the "cookie" section below.
 
-Please note that Canonical may also collect system information during installation of Ubuntu and on first login to Ubuntu. This system information is subject to a [Legal Notice](/legal/online-account-terms).
+Please note that Canonical may also collect system information during installation of Ubuntu and on first login to Ubuntu. This system information is subject to a [Legal Notice](/legal/systems-information-notice).
 
 ### Error reports
 


### PR DESCRIPTION
## Done
Updates legal/data-privacy link
[Copydoc](https://docs.google.com/document/d/1AlOE2_-BqZNP4hiiuf8kZney8g1zvqAlDYl2u3X6m6I/edit?tab=t.0)
[Jira task](https://warthogs.atlassian.net/browse/WD-34565?atlOrigin=eyJpIjoiNmIzN2U3YjM2OGYwNDNhOGJmYjBjZjQ2N2VmNDQ1MmIiLCJwIjoiaiJ9) 

## QA

- Open the [DEMO](__DEMO_URL__/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes legal/data-privacy link

## Screenshots

N/A