### PR TITLE
Form update on /solutions/infrastructure

### DIFF
--- a/templates/solutions/infrastructure/form-data.json
+++ b/templates/solutions/infrastructure/form-data.json
@@ -30,7 +30,7 @@
         {
           "title": "What would you like to talk with us about?",
           "id": "comments",
-          "isRequired": false,
+          "isRequired": true,
           "fields": [
             {
               "type": "long-text",


### PR DESCRIPTION
## Done

- Updated form on /solutions/infrastructure to require the comment input field

## QA

- Open the [DEMO](https://canonical-com-2353.demos.haus/solutions/infrastructure#get-in-touch)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card
[Jira ticket](https://warthogs.atlassian.net/browse/WD-34721)

## Screenshots
Before:
<img width="1980" height="1562" alt="image" src="https://github.com/user-attachments/assets/7ce0694e-223a-4910-a2ec-5ca37b994fb5" />


After:
<img width="1980" height="1562" alt="image" src="https://github.com/user-attachments/assets/11805383-59fb-407a-a557-9ace1ed02b7d" />

