### PR TITLE
chore(WD-34722): Form update on /openstack/features

### DIFF
--- a/templates/openstack/form-data.json
+++ b/templates/openstack/form-data.json
@@ -65,6 +65,7 @@
         {
           "title": "What would you like to talk with us about?",
           "id": "comments",
+          "isRequired": true,
           "fields": [
             {
               "type": "long-text",


### PR DESCRIPTION
## Done

- Updated form on `/openstack/features#get-in-touch` to require the comment input field
- Updated form on `/openstack/features/contact-us` to require the comment input field

## QA

- Open the [DEMO](https://canonical-com-2356.demos.haus/openstack/features#get-in-touch)
- Verify the field is required

## Issue / Card

[WD-34722](https://warthogs.atlassian.net/browse/WD-34722)

## Screenshots

<img width="1331" height="1080" alt="image" src="https://github.com/user-attachments/assets/d48acd02-9ded-4ef5-b002-91a9969f8100" />


[WD-34722]: https://warthogs.atlassian.net/browse/WD-34722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
