### PR TITLE
copy: add required text field

### DIFF
--- a/templates/maas/form-data.json
+++ b/templates/maas/form-data.json
@@ -96,7 +96,7 @@
         {
           "title": "What would you like to talk to us about?",
           "id": "comments",
-          "required": true,
+          "isRequired": true,
           "noCommentsFromLead": false,
           "fields": [{ "type": "long-text", "id": "comments" }]
         }

--- a/templates/openstack/support/form-data.json
+++ b/templates/openstack/support/form-data.json
@@ -27,6 +27,7 @@
         {
           "title": "What would you like to talk with us about?",
           "id": "comments",
+          "isRequired": true,
           "fields": [
             {
               "type": "long-text",


### PR DESCRIPTION
## Done

- Add required text field
- Drive-by: update incorrect form field key

## QA

- Go to https://canonical-com-2369.demos.haus/openstack/support#get-in-touch
- See that text field is marked required
- Fill up form except for text field and see that it requires it to be filled before submission

## Issue / Card

Fixes [WD-34724](https://warthogs.atlassian.net/browse/WD-34724)

## Screenshots

[if relevant, include a screenshot]


[WD-34724]: https://warthogs.atlassian.net/browse/WD-34724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ