### PR TITLE
chore: remove blog sitemap from robots, and disallow /blog

### DIFF
--- a/static/files/robots.txt
+++ b/static/files/robots.txt
@@ -61,7 +61,7 @@ User-Agent: Claude-Web
 Allow: /*?format=md
 
 # High-Value Content Priority (Verified product & doc routes)
-Allow: /blog/
+Disallow: /blog/
 Allow: /documentation/
 Allow: /juju/docs/
 Allow: /maas/docs/
@@ -99,7 +99,6 @@ Sitemap: https://canonical.com/sitemap.xml
 
 # Prioritized Trees for AI Crawlers
 Sitemap: https://canonical.com/sitemap_tree.xml
-Sitemap: https://canonical.com/blog/sitemap.xml
 Sitemap: https://canonical.com/microk8s/docs/sitemap.xml
 Sitemap: https://canonical.com/juju/docs/sitemap.xml
 Sitemap: https://canonical.com/maas/docs/sitemap.xml


### PR DESCRIPTION
**Note:** Currently investigating the outage of blog.canonical.com. The PS6 configurations look okay, so temporarily removing these entries to verify if the crawlers are not taking up the available workers, resulting in 504s.

## Done

- Removed blog sitemap from robots.txt
- Disallow /blog endpoint on robots.txt


