### PR TITLE
chore: Update jira epic id

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -22,4 +22,4 @@ settings:
   sync_comments: true
 
   # (Optional) (Default: None) Parent Epic key to link the issue to
-  epic_key: "WD-31040"
+  epic_key: "WD-30420"


### PR DESCRIPTION
## Done

- Updated Jira epic key, as these will now go directly to the maintenance epic
