### PR TITLE
WD-35143: Update /data/spark/what-is-spark

### DIFF
--- a/templates/data/spark/what-is-spark.html
+++ b/templates/data/spark/what-is-spark.html
@@ -56,26 +56,26 @@
         </div>
       </div>
       <div class="col">
-        <p>Spark delivers an advanced palette of capabilities for today's data engineers, data scientists and analysts:</p>
+        <p>Spark delivers an advanced set of capabilities for today's data engineers, data scientists, and analysts:</p>
         <hr class="p-rule--muted u-no-margin--bottom" />
         <div class="p-section--shallow">
           <ul class="p-list--divided u-no-margin--bottom">
             <li class="p-list__item has-bullet">
-              Write custom parallel, distributed data processing applications with popular languages including Python, Scala and Java.
+              Write custom parallel, distributed data processing applications with popular languages including Python, Scala, and Java
             </li>
             <li class="p-list__item has-bullet">
-              Use Spark MLLib to perform all manner of common machine learning tasks at scale, and use Spark GraphX to perform graph processing over vast graphs with an incredible number of vertices.
+              Use Spark MLLib to train and evaluate machine learning models at scale, and use Spark GraphX to perform graph processing over large graphs characterized by high numbers of vertices and edges
             </li>
             <li class="p-list__item has-bullet">
-              Write SQL queries and process big data using common data warehousing techniques, with SparkSQL.
+              Write SQL queries and process big data using common data warehousing techniques, with SparkSQL
             </li>
             <li class="p-list__item has-bullet">
-              Write continuous data processing applications that reliably process streaming data using Spark's Spark Streaming API.
+              Write continuous data processing applications that reliably process streaming data using Spark's Spark Streaming API
             </li>
           </ul>
         </div>
         <p>
-          Spark is widely used to build sophisticated data pipelines, which can be continuous event stream processing applications or batch based jobs that run on a schedule. Spark is also widely adopted by data scientists for data analysis as well as for machine learning tasks including data preparation.
+          Spark is widely used to build sophisticated data pipelines, which can be made of long-lived event stream processing applications or batch-based jobs that run on a schedule. Spark is also widely adopted by data scientists for data analysis as well as for machine learning tasks including data preparation.
         </p>
       </div>
     </div>
@@ -118,7 +118,7 @@
             <h3 class="p-heading--5">Proven solution</h3>
           </div>
           <div class="col-6 col-medium-3">
-            <p>Apache Spark has been battle tested in real world deployments around the globe for more than a decade.</p>
+            <p>Apache Spark has been tested in real world deployments around the globe for more than a decade.</p>
           </div>
         </div>
         <hr class="p-rule--muted" />
@@ -172,7 +172,7 @@
             </div>
             <div class="p-equal-height-row__item">
               <p>
-                You can use Spark to develop applications that process continuous data streams, for example for analysing web clickstream data and providing real time insights and alerts at web scale.
+                You can use Spark to develop applications that process continuous data streams, for example for analyzing web clickstream data and providing real time insights and alerts at web scale.
               </p>
             </div>
           </div>
@@ -195,7 +195,7 @@
             </div>
             <div class="p-equal-height-row__item">
               <p>
-                Spark is a popular choice for empowering data scientists. Spark helps data scientists to prepare data, train models and explore data sets with a compute cluster. And with support for Python and R, data scientists can work with the tooling that they already know.
+                Spark is a popular choice for empowering data scientists. Spark helps data scientists to prepare data, train models, and explore data sets using a compute cluster. With Spark's support for Python and R, data scientists can work with common and easy-to-learn languages for data analysis.
               </p>
             </div>
           </div>
@@ -218,7 +218,7 @@
             </div>
             <div class="p-equal-height-row__item">
               <p>
-                With Spark, you can use industry standard Structured Query Language (SQL) to query your big data. Or, you can use Spark data frame API to analyse massive datasets using Python in a familiar way.
+                With Spark, you can use industry standard Structured Query Language (SQL) to query your big data. Or, you can use Spark data frame API to analyze massive datasets using Python in a familiar way.
               </p>
             </div>
           </div>
@@ -235,16 +235,16 @@
       </div>
       <div class="col">
         <p>
-          Spark runs as an application on a compute cluster, under a resource scheduler. You can use the popular Kubernetes scheduler, YARN or set up a standalone Spark cluster.
+          Spark runs as an application on a compute cluster, under a resource scheduler.
         </p>
         <p>
-          Users write Spark applications using the language of their choice &ndash; Python, SQL, Scala, R or Java &ndash; and submit them to the cluster, where the Spark application can be run on many compute nodes at once, dividing the workload into tasks in order to parallelise efforts and complete processing faster.
+          Users write Spark applications using the language of their choice &ndash; Python, SQL, Scala, R, or Java &ndash; and submit them to the cluster, where the Spark application can be run on many compute nodes at once, dividing the workload into tasks in order to parallelize efforts and complete processing faster.
         </p>
         <p>
           Spark makes use of in-memory caching in order to accelerate data processing even further, but falls back to persistent storage media if memory is insufficient.
         </p>
         <p>
-          Spark applications are composed of a Driver and Executors. The driver component can run on the cluster; or it can run on the user's local machine when using an interactive session like spark-shell. The driver acts as task coordinator. Executors perform the actual processing tasks. Data is partitioned and distributed amongst the executors for processing.
+          Spark applications are composed of a Driver and Executors. The driver component can run on the cluster; or it can run on the user's local machine when using an interactive session like spark-shell. The driver acts as task coordinator. Executors perform the actual processing tasks. Data is partitioned and distributed amongst the executors for enabling distributed processing.
         </p>
 
       </div>
@@ -277,7 +277,7 @@
           </li>
           <li class="p-list__item is-ticked">
             <p class="p-heading--5 u-no-padding--top u-no-margin--bottom">Distributed processing</p>
-            Spark workloads are distributed across many executors. Executors can be distributed across many servers in a compute cluster, which can massively accelerate data processing times by dividing data processing tasks and distributing them across the cluster.
+            Spark workloads are distributed across many executors. Executors can be distributed in a compute cluster, which can significantly accelerate data processing times by dividing data processing tasks and distributing them across the cluster.
           </li>
           <li class="p-list__item is-ticked">
             <p class="p-heading--5 u-no-padding--top u-no-margin--bottom">Data warehousing</p>
@@ -315,8 +315,14 @@
         </div>
         <div class="col">
           <p>
-            Charmed Spark delivers up to 10 years of support and security maintenance for Apache Spark as an integrated, turnkey solution with advanced management features.
+            Charmed Spark delivers up to 15 years of support and security maintenance for Apache Spark as an integrated, turnkey solution with advanced management features.
           </p>
+          <p>
+            Ubuntu Pro is Canonical's comprehensive subscription for open source security, support, and compliance. It covers the Spark framework and its vast ecosystem of dependencies, ensuring the integrity of your big data processing and ETL pipelines, securing your toolchains and frameworks across your compute clusters.
+          </p>
+          <div class="p-cta-block">
+            <a href="https://www.ubuntu.com/pro">Find out more about Ubuntu Pro&nbsp;&rsaquo;</a>
+          </div>
         </div>
       </div>
     </div>
@@ -332,16 +338,16 @@
             <p>When you purchase an Ubuntu Pro + Support  plan, you also get support for the full Charmed Apache Spark solution.</p>
             <hr class="p-rule--muted u-no-margin--bottom" />
             <ul class="p-list--divided u-no-margin--bottom">
-              <li class="p-list__item is-ticked">Up to 10 years of Spark support per release track</li>
+              <li class="p-list__item is-ticked">Up to 15 years of Spark support per release track</li>
               <li class="p-list__item is-ticked">24/7 or weekday phone and ticket support</li>
               <li class="p-list__item is-ticked">
-                Up to 10 years of security maintenance for Spark covering critical and high severity CVEs
+                Up to 15 years of security maintenance for Spark covering critical and high severity CVEs
               </li>
             </ul>
             <hr class="p-rule--muted u-no-margin--bottom" />
             <div class="p-section--shallow">
               <p>
-                Charmed Spark allows you to automate deployment and operation of Spark at web scale in the environment of your choice &ndash; on the cloud or in your data centre. Supports deployment to most popular clouds or to CNCF conformant Kubernetes.
+                Charmed Spark allows you to automate deployment and operation of Spark at massive scale in the environment of your choice &ndash; on the cloud or in your data center. It also supports deployment to most popular clouds or to CNCF-conformant Kubernetes.
               </p>
             </div>
             <div class="p-cta-block">
@@ -357,11 +363,11 @@
           <div class="col-6 col-medium-3">
             <p class="p-heading--5">Included in Ubuntu Pro</p>
             <p>
-              Also included in Ubuntu Pro, you get support for Canonical's OCI-compliant container image for Spark in GitHub Container Registry (GHCR) &ndash; the slimmest, fastest, niftiest Spark container image on the market, based on Ubuntu LTS.
+              Also included in Ubuntu Pro, you get support for Canonical's OCI-compliant container image for Spark in GitHub Container Registry (GHCR) &ndash; a securely-designed Spark container image based on Ubuntu LTS.
             </p>
             <hr class="p-rule--muted" />
             <ul class="p-list--divided">
-              <li class="p-list__item is-ticked">Up to 10 years of support per release track</li>
+              <li class="p-list__item is-ticked">Up to 15 years of support per release track</li>
               <li class="p-list__item is-ticked">Same 24/7 or weekday phone and ticket support commitment</li>
               <li class="p-list__item is-ticked">
                 Same 10 years of security maintenance covering critical and high severity CVEs in the image
@@ -380,15 +386,15 @@
           <div class="col-6 col-medium-3">
             <p class="p-heading--5">Advanced professional services for Spark, when you need them</p>
             <p>
-              Get help designing, planning and building and even operating a hyper automated production Spark solution that perfectly fits your needs, with Canonical's expert services.
+              Get help in designing, planning, building, and even operating a hyper automated production Spark solution that perfectly fits your needs, with Canonical's expert services.
             </p>
             <hr class="p-rule--muted" />
             <ul class="p-list--divided">
               <li class="p-list__item is-ticked">
-                Help with design and build of both production and non-production Spark environments with Charmed Spark
+                Help with design and build of both production and non-production Spark workloads with Charmed Spark
               </li>
               <li class="p-list__item is-ticked">
-                Managed services for Spark lake houses in your cloud tenancy or data centre, backed by an SLA
+                Managed services for Spark lake houses in your cloud tenancy or data center, backed by an SLA
               </li>
               <li class="p-list__item is-ticked">
                 Firefighting support with a Spark operations expert, who works alongside your team when crisis hits
@@ -417,7 +423,7 @@
                 hi_def=True,
                 loading="lazy") | safe
         }}
-        <p>Get an introduction to Apache Spark and how to prioritise your security requirements.</p>
+        <p>Get an introduction to Apache Spark and how to prioritize your security requirements.</p>
         <div class="p-cta-block">
           <a href="https://ubuntu.com/engage/spark-security-webinar">Watch our webinar&nbsp;&rsaquo;</a>
         </div>
@@ -441,7 +447,7 @@
           <li class="p-list__item">
             <a class="p-heading--5"
                href="https://ubuntu.com/engage/open-source-big-data-ai">Make better decisions with open source Big Data and AI solutions</a>
-            <p class="u-no-margin--bottom">Learn how to build a smarter enterprise with a secure, integrated open source stack.</p>
+            <p class="u-no-margin--bottom">Learn how to build a smarter enterprise with a securely designed, integrated open source stack.</p>
           </li>
           <li class="p-list__item">
             <a class="p-heading--5"


### PR DESCRIPTION
## Done

Copy update of https://canonical.com/data/spark/what-is-spark

## QA

- Open the [DEMO](https://canonical-com-2394.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/data/spark/what-is-spark
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Compare the site with [the copy doc](https://docs.google.com/document/d/1pyX-BOXmIZY6_8imIft1SAp1-S0i8bGYWEo5zoVEgQw/edit?tab=t.0)

## Issue / Card
- [WD-35143](https://warthogs.atlassian.net/browse/WD-35143)
- [Copy doc](https://docs.google.com/document/d/1pyX-BOXmIZY6_8imIft1SAp1-S0i8bGYWEo5zoVEgQw/edit?tab=t.0)


[WD-35143]: https://warthogs.atlassian.net/browse/WD-35143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
