### PR TITLE
WD-35584 adjust logos at /data

### DIFF
--- a/templates/data/index.html
+++ b/templates/data/index.html
@@ -478,7 +478,7 @@
     <div class="p-logo-section">
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
-          <img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/c1752bd9-ubuntu_logo.png" alt="Canonical Ubuntu" width="27" height="32">
+          <img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/788e434d-bt_logo.png" alt="BT" width="13" height="32">
         </div>
         <div class="p-logo-section__item">
           <img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/4a6a5fa8-deutsche_telekom.png" alt="Deutsche Telekom" width="32" height="32">
@@ -506,9 +506,6 @@
         </div>
         <div class="p-logo-section__item">
           <img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/3273252a-swissquote_logo.png" alt="Swissquote" width="44" height="32">
-        </div>
-        <div class="p-logo-section__item">
-          <img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/788e434d-bt_logo.png" alt="BT" width="13" height="32">
         </div>
         <div class="p-logo-section__item">
           <img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/3ed20843-yahoo_jp_logo.png" alt="Yahoo Japan" width="26" height="32">


### PR DESCRIPTION
## Done

at /data bottom logos section
- removed canonical logo
- BT logo brought to the front

## QA

- goto https://canonical-com-2420.demos.haus/data
- scroll down
- compare logos to copydoc https://docs.google.com/document/d/1QKc7tHZZSJttrPOziK_w_9yKLLgoC4Vcufke9dSvQ-g

## Issue / Card

https://warthogs.atlassian.net/browse/WD-35584

## Screenshots

Previously:
<img width="1597" height="382" alt="image" src="https://github.com/user-attachments/assets/c0db3685-4607-484e-aadb-360191685f61" />



Now:
<img width="1597" height="382" alt="image" src="https://github.com/user-attachments/assets/8debb4c9-358e-4102-8e6e-0a77a9ee1b4e" />

