### PR TITLE
fix: update title text formatting in OEDIV case study

### DIFF
--- a/templates/case-study/oediv-de.html
+++ b/templates/case-study/oediv-de.html
@@ -42,7 +42,7 @@
 {% block title %}Null Ausfallzeiten seit sechs Jahren: OEDIV standardisiert auf Ubuntu Pro{% endblock %}
 
 {% block meta_description %}
-  Durch die Standardisierung auf Ubuntu Pro reduzierte OEDIV die Upgrade-Zeit um 60 %, erreichte 6 Jahre ohne Ausfallzeiten und erschloss neue Einnahmequellen.
+  Durch die Standardisierung auf Ubuntu Pro reduzierte OEDIV die Upgrade-Zeit um 60%, erreichte 6 Jahre ohne Ausfallzeiten und erschloss neue Einnahmequellen.
 {% endblock %}
 
 {% block meta_company_name %}OEDIV{% endblock %}


### PR DESCRIPTION
## Done
Update title text from `60 %` to `60%`

## QA

- Open the [/case-study/oediv-de](https://canonical-com-2423.demos.haus/case-study/oediv-de)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [WD-35522](https://warthogs.atlassian.net/browse/WD-35522)

## Screenshots

[if relevant, include a screenshot]



[WD-35522]: https://warthogs.atlassian.net/browse/WD-35522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ