### PR TITLE
fix: modify deploy.yaml to use stable rockcraft

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: canonical/setup-lxd@main
 
       - name: Setup Rockcraft
-        run: sudo snap install rockcraft --classic --channel=latest/edge
+        run: sudo snap install rockcraft --classic --channel=latest/stable
 
       - name: Pack Rock
         run: rockcraft pack


### PR DESCRIPTION
## Done

- modified deploy.yaml to no longer use rockcraft `edge` release (currently breaking for flask-base)
