### PR TITLE
feat: Resources generation with schema definition and validation

### DIFF
--- a/static/json/page-generator/examples/resources.json
+++ b/static/json/page-generator/examples/resources.json
@@ -1,0 +1,945 @@
+{
+  "page_name": "test-resources",
+  "page_path": "page-generator/examples",
+  "patterns": [
+    {
+      "name": "resources",
+      "data": {
+        "title": {
+          "text": "Additional resources",
+          "link_attrs": {
+            "href": "#"
+          }
+        },
+        "blocks": [
+          {
+            "type": "description",
+            "item": {
+              "type": "text",
+              "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+            }
+          },
+          {
+            "type": "cta-block",
+            "item": {
+              "secondaries": [
+                {
+                  "content_html": "Action",
+                  "attrs": {
+                    "href": "#"
+                  }
+                }
+              ],
+              "link": {
+                "content_html": "Lorem ipsum dolor sit amet ›",
+                "attrs": {
+                  "href": "#"
+                }
+              }
+            }
+          },
+          {
+            "type": "resources",
+            "render_images": true,
+            "categories": [
+              {
+                "title": "Category 1",
+                "items": [
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        },
+                        {
+                          "text": "Jane Foster",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "title": "Category 2",
+                "items": [
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "resources",
+      "data": {
+        "title": {
+          "text": "Additional resources"
+        },
+        "blocks": [
+          {
+            "type": "description",
+            "item": {
+              "type": "text",
+              "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+            }
+          },
+          {
+            "type": "cta-block",
+            "item": {
+              "secondaries": [
+                {
+                  "content_html": "Action",
+                  "attrs": {
+                    "href": "#"
+                  }
+                }
+              ],
+              "link": {
+                "content_html": "Lorem ipsum dolor sit amet ›",
+                "attrs": {
+                  "href": "#"
+                }
+              }
+            }
+          },
+          {
+            "type": "resources",
+            "render_images": false,
+            "categories": [
+              {
+                "title": "Category 1",
+                "items": [
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "title": "Category 2",
+                "items": [
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "resources",
+      "data": {
+        "title": {
+          "text": "Additional resources"
+        },
+        "blocks": [
+          {
+            "type": "description",
+            "item": {
+              "type": "text",
+              "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+            }
+          },
+          {
+            "type": "cta-block",
+            "item": {
+              "secondaries": [
+                {
+                  "content_html": "Action",
+                  "attrs": {
+                    "href": "#"
+                  }
+                }
+              ],
+              "link": {
+                "content_html": "Lorem ipsum dolor sit amet ›",
+                "attrs": {
+                  "href": "#"
+                }
+              }
+            }
+          },
+          {
+            "type": "resources",
+            "render_images": true,
+            "render_categories": false,
+            "categories": [
+              {
+                "title": "Category 1",
+                "items": [
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "title": "Category 2",
+                "items": [
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "resources",
+      "data": {
+        "title": {
+          "text": "Additional resources"
+        },
+        "blocks": [
+          {
+            "type": "resources",
+            "render_images": false,
+            "render_categories": false,
+            "categories": [
+              {
+                "title": "Category 1",
+                "items": [
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "resources",
+      "data": {
+        "title": {
+          "text": "Additional resources"
+        },
+        "blocks": [
+          {
+            "type": "resources",
+            "render_images": false,
+            "render_categories": false,
+            "categories": [
+              {
+                "title": "Category 1",
+                "items": [
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "resources",
+      "data": {
+        "title": {
+          "text": "Additional resources"
+        },
+        "blocks": [
+          {
+            "type": "description",
+            "item": {
+              "type": "text",
+              "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+            }
+          },
+          {
+            "type": "cta-block",
+            "item": {
+              "secondaries": [
+                {
+                  "content_html": "Action",
+                  "attrs": {
+                    "href": "#"
+                  }
+                }
+              ],
+              "link": {
+                "content_html": "Lorem ipsum dolor sit amet ›",
+                "attrs": {
+                  "href": "#"
+                }
+              }
+            }
+          },
+          {
+            "type": "resources",
+            "render_images": true,
+            "categories": [
+              {
+                "title": "Category 1",
+                "items": [
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "default",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/9374033b-9374033b77400848b48de4d9746e205c48077ed8.jpg",
+                        "alt": "Default 16:9 aspect ratio image"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "title": "Category 2",
+                "items": [
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "title": "Category 3",
+                "items": [
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "logo",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/c7ed6de4-canonical_logo.svg",
+                        "alt": "Logo image"
+                      }
+                    }
+                  },
+                  {
+                    "title": {
+                      "text": "How to enable Real-time Ubuntu on your machine",
+                      "link_attrs": {
+                        "href": "#"
+                      }
+                    },
+                    "description": {
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                      "attrs": {}
+                    },
+                    "metadata": {
+                      "authors": [
+                        {
+                          "text": "John Doe",
+                          "link_attrs": {
+                            "href": "#"
+                          }
+                        }
+                      ],
+                      "date": {
+                        "text": "20th April 2024",
+                        "link": {}
+                      }
+                    },
+                    "image": {
+                      "type": "logo",
+                      "attrs": {
+                        "src": "https://assets.ubuntu.com/v1/c7ed6de4-canonical_logo.svg",
+                        "alt": "Logo image"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/static/json/page-generator/schemas/resources.json
+++ b/static/json/page-generator/schemas/resources.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "const": "resources"
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "title": { "$ref": "#/definitions/titleObject" },
+        "padding": { "enum": ["deep", "shallow", "default"] },
+        "blocks": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "$ref": "#/definitions/descriptionBlock" },
+              { "$ref": "#/definitions/ctaBlock" },
+              { "$ref": "#/definitions/resourcesBlock" }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "titleObject": {
+      "type": "object",
+      "properties": {
+        "text": { "type": "string" },
+        "link_attrs": {
+          "type": "object",
+          "properties": {
+            "href": { "type": "string" }
+          }
+        }
+      }
+    },
+    "descriptionBlock": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "description" },
+        "padding": { "enum": ["shallow"] },
+        "item": {
+          "type": "object",
+          "properties": {
+            "type": { "enum": ["text", "html"] },
+            "content": { "type": "string" }
+          }
+        }
+      }
+    },
+    "ctaBlock": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "cta-block" },
+        "padding": { "enum": ["shallow"] },
+        "item": {
+          "type": "object",
+          "properties": {
+            "primary": { "$ref": "#/definitions/linkObject" },
+            "secondaries": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/linkObject" }
+            },
+            "link": { "$ref": "#/definitions/linkObject" }
+          }
+        }
+      }
+    },
+    "linkObject": {
+      "type": "object",
+      "properties": {
+        "content_html": { "type": "string" },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "href": { "type": "string" }
+          }
+        }
+      }
+    },
+    "resourcesBlock": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "resources" },
+        "render_images": { "type": "boolean" },
+        "render_categories": { "type": "boolean" },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "title": { "type": "string" },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "title": { "$ref": "#/definitions/titleObject" },
+                    "description": {
+                      "type": "object",
+                      "properties": {
+                        "text": { "type": "string" }
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "properties": {
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "text": { "type": "string" },
+                              "link_attrs": {
+                                "type": "object",
+                                "properties": {
+                                  "href": { "type": "string" }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "date": {
+                          "type": "object",
+                          "properties": {
+                            "text": { "type": "string" },
+                            "link_attrs": {
+                              "type": "object",
+                              "properties": {
+                                "href": { "type": "string" }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "image": {
+                      "type": "object",
+                      "properties": {
+                        "type": { "enum": ["default", "logo"] },
+                        "attrs": {
+                          "type": "object",
+                          "properties": {
+                            "src": { "type": "string" },
+                            "alt": { "type": "string" }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/static/json/page-generator/schemas/resources.json
+++ b/static/json/page-generator/schemas/resources.json
@@ -7,11 +7,13 @@
     },
     "data": {
       "type": "object",
+      "required": ["title", "blocks"],
       "properties": {
         "title": { "$ref": "#/definitions/titleObject" },
         "padding": { "enum": ["deep", "shallow", "default"] },
         "blocks": {
           "type": "array",
+          "contains": { "$ref": "#/definitions/resourcesBlock" },
           "items": {
             "oneOf": [
               { "$ref": "#/definitions/descriptionBlock" },
@@ -26,6 +28,7 @@
   "definitions": {
     "titleObject": {
       "type": "object",
+      "required": ["text"],
       "properties": {
         "text": { "type": "string" },
         "link_attrs": {
@@ -34,7 +37,8 @@
             "href": { "type": "string" }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "descriptionBlock": {
       "type": "object",
@@ -43,12 +47,14 @@
         "padding": { "enum": ["shallow"] },
         "item": {
           "type": "object",
+          "required": ["type", "content"],
           "properties": {
             "type": { "enum": ["text", "html"] },
             "content": { "type": "string" }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "ctaBlock": {
       "type": "object",
@@ -64,12 +70,18 @@
               "items": { "$ref": "#/definitions/linkObject" }
             },
             "link": { "$ref": "#/definitions/linkObject" }
-          }
+          },
+          "anyOf": [
+            { "required": ["primary"] },
+            { "required": ["secondaries"] },
+            { "required": ["link"] }
+          ]
         }
       }
     },
     "linkObject": {
       "type": "object",
+      "required": ["content_html", "attrs"],
       "properties": {
         "content_html": { "type": "string" },
         "attrs": {
@@ -82,6 +94,7 @@
     },
     "resourcesBlock": {
       "type": "object",
+      "required": ["categories"],
       "properties": {
         "type": { "const": "resources" },
         "render_images": { "type": "boolean" },
@@ -90,19 +103,29 @@
           "type": "array",
           "items": {
             "type": "object",
+            "required": ["title", "items"],
             "properties": {
               "title": { "type": "string" },
               "items": {
                 "type": "array",
                 "items": {
                   "type": "object",
+                  "required": ["title"],
                   "properties": {
                     "title": { "$ref": "#/definitions/titleObject" },
                     "description": {
                       "type": "object",
+                      "required": ["text"],
                       "properties": {
-                        "text": { "type": "string" }
-                      }
+                        "text": { "type": "string" },
+                        "attrs": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
                     },
                     "metadata": {
                       "type": "object",
@@ -111,6 +134,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
+                            "required": ["text"],
                             "properties": {
                               "text": { "type": "string" },
                               "link_attrs": {
@@ -124,9 +148,10 @@
                         },
                         "date": {
                           "type": "object",
+                          "required": ["text"],
                           "properties": {
                             "text": { "type": "string" },
-                            "link_attrs": {
+                            "link": {
                               "type": "object",
                               "properties": {
                                 "href": { "type": "string" }
@@ -134,7 +159,8 @@
                             }
                           }
                         }
-                      }
+                      },
+                      "additionalProperties": false
                     },
                     "image": {
                       "type": "object",
@@ -142,20 +168,25 @@
                         "type": { "enum": ["default", "logo"] },
                         "attrs": {
                           "type": "object",
+                          "required": ["src"],
                           "properties": {
                             "src": { "type": "string" },
                             "alt": { "type": "string" }
                           }
                         }
-                      }
+                      },
+                      "additionalProperties": false
                     }
-                  }
+                  },
+                  "additionalProperties": false
                 }
               }
-            }
+            },
+            "additionalProperties": false
           }
         }
-      }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1809,7 +1809,7 @@ def check_redirect(response):
 def generator():
     with open(
         Path(app.root_path).resolve().parent
-        / "static/json/page-generator/examples/cta-section.json",
+        / "static/json/page-generator/examples/resources.json",
         "r",
         encoding="utf-8",
     ) as f:

--- a/webapp/page_generator/__init__.py
+++ b/webapp/page_generator/__init__.py
@@ -369,7 +369,7 @@ class ResourcesSection(Pattern):
 
     @property
     def schema_name(self) -> str:
-        return "resources-section"
+        return "resources"
 
     def process_pattern(self):
         params_str = self._build_params_str()
@@ -384,24 +384,6 @@ class ResourcesSection(Pattern):
 
     def write_import(self):
         return '{% from "_macros/vf_resources.jinja" import vf_resources %}'
-
-    def validate_payload(self):
-        # load json schema for resources
-        with open(
-            Path(current_app.root_path).resolve().parent
-            / "static/json/page-generator/schemas/resources.json",
-            "r",
-        ) as f:
-            RESOURCES_SCHEMA = json.load(f)
-
-        # Extract the "data" schema
-        # self.data only contains the inner data object
-        data_schema = RESOURCES_SCHEMA.get("properties", {}).get("data", {})
-        # Preserve definitions for referenced schemas
-        if "definitions" in RESOURCES_SCHEMA:
-            data_schema["definitions"] = RESOURCES_SCHEMA["definitions"]
-
-        return super().validate_payload(data_schema)
 
 
 def create_page_generator(data: dict) -> PageGenerator:

--- a/webapp/page_generator/__init__.py
+++ b/webapp/page_generator/__init__.py
@@ -74,7 +74,9 @@ class PatternFactory:
     def register_pattern(self, pattern_type: str, pattern_class: type):
         self._patterns[pattern_type] = pattern_class
 
-    def create(self, pattern_type: str, pattern_data: dict) -> Optional["Pattern"]:
+    def create(
+        self, pattern_type: str, pattern_data: dict
+    ) -> Optional["Pattern"]:
         """Create a pattern instance based on type."""
         pattern_class = self._patterns.get(pattern_type)
         if pattern_class:
@@ -162,7 +164,9 @@ class PageGenerator:
         for pattern in self.data.get("patterns", []):
             pattern_type = pattern.get("name")
             pattern_data = pattern.get("data", {})
-            pattern_instance = self.pattern_factory.create(pattern_type, pattern_data)
+            pattern_instance = self.pattern_factory.create(
+                pattern_type, pattern_data
+            )
             if pattern_instance:
                 self.patterns.append(pattern_instance)
 
@@ -390,7 +394,8 @@ class ResourcesSection(Pattern):
         ) as f:
             RESOURCES_SCHEMA = json.load(f)
 
-        # Extract the "data" schema since self.data only contains the inner data object
+        # Extract the "data" schema
+        # self.data only contains the inner data object
         data_schema = RESOURCES_SCHEMA.get("properties", {}).get("data", {})
         # Preserve definitions for referenced schemas
         if "definitions" in RESOURCES_SCHEMA:

--- a/webapp/page_generator/__init__.py
+++ b/webapp/page_generator/__init__.py
@@ -74,9 +74,7 @@ class PatternFactory:
     def register_pattern(self, pattern_type: str, pattern_class: type):
         self._patterns[pattern_type] = pattern_class
 
-    def create(
-        self, pattern_type: str, pattern_data: dict
-    ) -> Optional["Pattern"]:
+    def create(self, pattern_type: str, pattern_data: dict) -> Optional["Pattern"]:
         """Create a pattern instance based on type."""
         pattern_class = self._patterns.get(pattern_type)
         if pattern_class:
@@ -164,9 +162,7 @@ class PageGenerator:
         for pattern in self.data.get("patterns", []):
             pattern_type = pattern.get("name")
             pattern_data = pattern.get("data", {})
-            pattern_instance = self.pattern_factory.create(
-                pattern_type, pattern_data
-            )
+            pattern_instance = self.pattern_factory.create(pattern_type, pattern_data)
             if pattern_instance:
                 self.patterns.append(pattern_instance)
 
@@ -372,11 +368,35 @@ class ResourcesSection(Pattern):
         return "resources-section"
 
     def process_pattern(self):
-        # TODO: Implement resources section pattern
-        pass
+        params_str = self._build_params_str()
+
+        self.pattern_html += f"""
+            {{% call(slot) vf_resources(
+                {params_str}
+            ) -%}}
+
+            {{% endcall -%}}
+        """
 
     def write_import(self):
-        return None
+        return '{% from "_macros/vf_resources.jinja" import vf_resources %}'
+
+    def validate_payload(self):
+        # load json schema for resources
+        with open(
+            Path(current_app.root_path).resolve().parent
+            / "static/json/page-generator/schemas/resources.json",
+            "r",
+        ) as f:
+            RESOURCES_SCHEMA = json.load(f)
+
+        # Extract the "data" schema since self.data only contains the inner data object
+        data_schema = RESOURCES_SCHEMA.get("properties", {}).get("data", {})
+        # Preserve definitions for referenced schemas
+        if "definitions" in RESOURCES_SCHEMA:
+            data_schema["definitions"] = RESOURCES_SCHEMA["definitions"]
+
+        return super().validate_payload(data_schema)
 
 
 def create_page_generator(data: dict) -> PageGenerator:


### PR DESCRIPTION
## Done

- Created a metadata schema for Resources pattern
- Implemented Resources section pattern generator
- Include a sample payload containing all the possible variations of Resources pattern
- Generate and render a page using Resources pattern

## QA

- Check out this pull request
- Run the project using `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Access the `/create-page` endpoint, which should generate a test page with all the variations of resources section and render the preview

## Issue / Card

Fixes [WD-33150](https://warthogs.atlassian.net/browse/WD-33150) [WD-33154](https://warthogs.atlassian.net/browse/WD-33154)

## Screenshots

<img width="1691" height="6493" alt="image" src="https://github.com/user-attachments/assets/b5f1b646-f475-4602-b5e2-d9b05ad07f6b" />


[WD-33150]: https://warthogs.atlassian.net/browse/WD-33150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-33154]: https://warthogs.atlassian.net/browse/WD-33154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ