### PR TITLE
Changing country field logic in a couple of forms for misrouting experiment

### DIFF
--- a/static/js/prepare-form-inputs.js
+++ b/static/js/prepare-form-inputs.js
@@ -22,7 +22,8 @@ export async function prepareInputFields(phoneInput, countryInput) {
     setupIntlTelInput(countryCode, phoneInput);
   }
   if (countryInput) {
-    preFormatCountry(countryCode, countryInput);
+    const noPreselect = countryInput.closest("form")?.hasAttribute("data-no-preselect-country");
+    preFormatCountry(countryCode, countryInput, noPreselect);
   }
 }
 
@@ -32,8 +33,18 @@ export async function prepareInputFields(phoneInput, countryInput) {
  * @param {string} countryCode - ISO country code to set as the value.
  * @param {HTMLSelectElement} countryInput - The select element for the country.
  */
-function preFormatCountry(countryCode, countryInput) {
-  countryInput.value = countryCode;
+function preFormatCountry(countryCode, countryInput, noPreselect) {
+  if (noPreselect) {
+    const matchingOption = countryInput.querySelector(`option[value="${countryCode.toUpperCase()}"]`);
+    if (matchingOption) {
+      const selectOption = countryInput.querySelector('option[value=""]');
+      if (selectOption) {
+        selectOption.after(matchingOption);
+      }
+    }
+  } else {
+    countryInput.value = countryCode;
+  }
 }
 
 /**

--- a/static/js/prepare-form-inputs.js
+++ b/static/js/prepare-form-inputs.js
@@ -28,10 +28,12 @@ export async function prepareInputFields(phoneInput, countryInput) {
 }
 
 /**
- * Sets the value of the country input field.
+ * Sets the value of the country input field, or moves the detected country
+ * to the top of the list without selecting it when noPreselect is true.
  *
  * @param {string} countryCode - ISO country code to set as the value.
  * @param {HTMLSelectElement} countryInput - The select element for the country.
+ * @param {boolean} noPreselect - If true, moves the detected country to the top of the list without selecting it.
  */
 function preFormatCountry(countryCode, countryInput, noPreselect) {
   if (noPreselect) {

--- a/templates/data/spark/form-data.json
+++ b/templates/data/spark/form-data.json
@@ -15,7 +15,8 @@
         "introText": "Fill in this form and a member of our team will be in touch shortly.",
         "formId": "5505",
         "returnUrl": "/data/spark#contact-form-success",
-        "product": ""
+        "product": "",
+        "noPreselectCountry": true
       },
       "fieldsets": [
         {

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -3,6 +3,7 @@
         action="https://ubuntu.com/marketo/submit"
         method="post"
         id="mktoForm_{{ form_id }}"
+        {% if formData.noPreselectCountry %}data-no-preselect-country{% endif %}
         onsubmit="getCustomFields(event)">
     {% for fieldset in fieldsets %}
 


### PR DESCRIPTION
We need to change the way the country field is presented on the UI in a couple of forms to see if the number of misroutings will decrease. 
Current way: country field is prepopulated based on the browser/IP setup
New way for 2 forms: Country field displays “Select a country”, and the prepopulated country is the first in the list of countries.
Second form is [#1622](https://github.com/canonical/ubuntu.com/pull/16222)

## Done
- Added a noPreselectCountry flag to form config (form-data.json) that changes country field behavior
- When enabled, the country dropdown shows "Select..." instead of auto-selecting the detected country
- The detected country is moved to the top of the dropdown list for easy access
- Applied the flag to the Spark form as the first candidate per the Jira ticket

## QA

- Open the [DEMO](https://canonical-com-2441.demos.haus/data/spark) and verify the country field shows "Select..." by default
- Check that the country is not preselected for the /data/spark page forms
- Verify your detected country appears first in the dropdown list
- Verify other forms with a country field still auto-select the detected country
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [WD-35381](https://warthogs.atlassian.net/browse/WD-35381)

## Screenshots

<img width="1172" height="866" alt="image" src="https://github.com/user-attachments/assets/83fb6762-3a7a-4f6f-8f92-9acb7b0cc877" />
<img width="1160" height="984" alt="image" src="https://github.com/user-attachments/assets/446b5391-7ca7-49c1-8f13-e770fc540899" />
### after
<img width="1180" height="780" alt="image" src="https://github.com/user-attachments/assets/605753dc-b5a0-4057-852b-56525f83c90f" />
<img width="1156" height="824" alt="image" src="https://github.com/user-attachments/assets/8d8bff57-6f4e-4f6f-b20e-99924cb254ca" />

[if relevant, include a screenshot]



[WD-35381]: https://warthogs.atlassian.net/browse/WD-35381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ