### PR TITLE
fix: udpate lxd docs paths

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -87,7 +87,7 @@ lxd:
     - title: Manage
       path: /lxd/manage
     - title: Docs
-      path: https://canonical-lxd.readthedocs-hosted.com/en/
+      path: https://documentation.ubuntu.com/lxd
     - title: Forum
       path: https://discourse.ubuntu.com/c/lxd/126?_ga=2.69179345.1978494405.1700868870-354120313.1700868870
 

--- a/templates/lxd/index.html
+++ b/templates/lxd/index.html
@@ -271,7 +271,7 @@
           </div>
           <div class="col-4 col-small-2">
             <p>
-              <a href="https://documentation.ubuntu.com/lxd/en/latest/">Read the documentation&nbsp;&rsaquo;</a>
+              <a href="https://documentation.ubuntu.com/lxd/">Read the documentation&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>

--- a/templates/lxd/install.html
+++ b/templates/lxd/install.html
@@ -142,7 +142,7 @@
         </div>
         <hr class="p-rule u-hide--small" />
         <p>
-          For other installation options, please <a href="https://documentation.ubuntu.com/lxd/en/latest/installing/">check our documentation</a>.
+          For other installation options, please <a href="https://documentation.ubuntu.com/lxd/default/installing/">check our documentation</a>.
         </p>
       </div>
     </div>
@@ -163,7 +163,7 @@
               You might see issues with your firewall blocking network access for your instances, or connectivity issues because you run LXD and Docker on the same host.
             </p>
             <p>
-              <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/howto/network_bridge_firewalld/#network-bridge-firewall">Access documentation about how to resolve these issues&nbsp;&rsaquo;</a>
+              <a href="https://documentation.ubuntu.com/lxd/default/howto/network_bridge_firewalld/#network-bridge-firewall">Access documentation about how to resolve these issues&nbsp;&rsaquo;</a>
             </p>
           </div>
           <div class="col-3 u-hide--small u-hide--medium u-aspect-ratio--3-2 p-image-wrapper u-vertically-center">
@@ -194,7 +194,7 @@
           <div class="col-6 col-medium-4">
             <p>LXD supports two types of instances: system containers and virtual machines.</p>
             <p>
-              <a href="https://documentation.ubuntu.com/lxd/en/latest/explanation/containers_and_vms/">Learn more about containers and VMs&nbsp;&rsaquo;</a>
+              <a href="https://documentation.ubuntu.com/lxd/default/explanation/containers_and_vms/">Learn more about containers and VMs&nbsp;&rsaquo;</a>
             </p>
           </div>
           <hr class="p-rule col-9 col-medium-6" />
@@ -206,7 +206,7 @@
               Security is at the forefront of everything we do and there are various things to consider to keep your LXD installation secure.
             </p>
             <p>
-              <a href="https://documentation.ubuntu.com/lxd/en/latest/explanation/containers_and_vms/">Learn more about LXD and security&nbsp;&rsaquo;</a>
+              <a href="https://documentation.ubuntu.com/lxd/default/explanation/security/">Learn more about LXD and security&nbsp;&rsaquo;</a>
             </p>
           </div>
           <hr class="p-rule col-9 col-medium-6" />
@@ -216,7 +216,7 @@
           <div class="col-6 col-medium-4">
             <p>LXD uses an image-based workflow, providing images for a large number of Linux distributions.</p>
             <p>
-              <a href="https://documentation.ubuntu.com/lxd/en/latest/image-handling/">Learn more about common operations with images&nbsp;&rsaquo;</a>
+              <a href="https://documentation.ubuntu.com/lxd/default/image-handling/">Learn more about common operations with images&nbsp;&rsaquo;</a>
             </p>
           </div>
           <hr class="p-rule col-9 col-medium-6" />
@@ -227,7 +227,7 @@
             <p>We welcome and value contributions from the community.</p>
             <div class="p-strip--shallow">
               <p>
-                <a href="https://documentation.ubuntu.com/lxd/en/latest/contributing">How to contribute to LXD&nbsp;&rsaquo;</a>
+                <a href="https://documentation.ubuntu.com/lxd/default/contributing">How to contribute to LXD&nbsp;&rsaquo;</a>
               </p>
             </div>
           </div>

--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -66,7 +66,7 @@ meta_copydoc %}
           subcommands.
         </p>
         <p>
-          <a href="https://documentation.ubuntu.com/lxd/en/stable-5.21/explanation/lxd_lxc/">Get started with the LXD
+          <a href="https://documentation.ubuntu.com/lxd/default/explanation/lxd_lxc/">Get started with the LXD
           CLI&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -88,7 +88,7 @@ meta_copydoc %}
           needed. LXD implements a single REST API for both local and remote access.
         </p>
         <p>
-          <a href="https://documentation.ubuntu.com/lxd/en/stable-5.21/rest-api/">Learn more about the LXD REST
+          <a href="https://documentation.ubuntu.com/lxd/default/rest-api/">Learn more about the LXD REST
           API&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -308,7 +308,7 @@ meta_copydoc %}
               </li>
             </ul>
             <p>
-              To manage LXD in Ansible, you need a LXD server (see <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/getting_started/">"Getting started"</a>).
+              To manage LXD in Ansible, you need a LXD server (see <a href="https://documentation.ubuntu.com/lxd/default/getting_started/">"Getting started"</a>).
             </p>
           </div>
         </div>
@@ -338,7 +338,7 @@ meta_copydoc %}
               LXD</a> for more information.
             </p>
             <p>
-              To manage LXD in Terraform, you need a LXD server (see <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/getting_started">"Getting started"</a>).
+              To manage LXD in Terraform, you need a LXD server (see <a href="https://documentation.ubuntu.com/lxd/default/getting_started/">"Getting started"</a>).
             </p>
           </div>
         </div>
@@ -365,7 +365,7 @@ meta_copydoc %}
               Documentation on LXD</a>.
             </p>
             <p>
-              To manage LXD in Puppet Bolt, you need a LXD server (see <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/getting_started/">"Getting started"</a>).
+              To manage LXD in Puppet Bolt, you need a LXD server (see <a href="https://documentation.ubuntu.com/lxd/default/getting_started/">"Getting started"</a>).
             </p>
           </div>
         </div>
@@ -395,11 +395,11 @@ meta_copydoc %}
               more information.
             </p>
             <p>
-              Additionally our guides about <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/images/">images</a> and <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/howto/instances_configure/">instance
+              Additionally our guides about <a href="https://documentation.ubuntu.com/lxd/default/images/">images</a> and <a href="https://documentation.ubuntu.com/lxd/default/howto/instances_configure/">instance
               configuration</a> might contain useful information regarding image choice, configuration options etc.
             </p>
             <p>
-              To create LXD images in Packer, you need a LXD server (see <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/getting_started/">"Getting started"</a>).
+              To create LXD images in Packer, you need a LXD server (see <a href="https://documentation.ubuntu.com/lxd/default/getting_started/">"Getting started"</a>).
             </p>
           </div>
         </div>


### PR DESCRIPTION
Updates LXD documentation paths to use the docs version corresponding to the current LTS release, and to remove the no-longer-used /en/ part of the path.
Also fixes a link in https://canonical.com/lxd/install - the link for "Learn more about LXD and security" was pointing to the docs on containers and VMs instead of the security docs.