### PR TITLE
copyupdate remove second microcloud logo WD-36072

### DIFF
--- a/templates/microcloud/what-is-microcloud.html
+++ b/templates/microcloud/what-is-microcloud.html
@@ -54,18 +54,6 @@
           }
         }
       },
-      {
-        "type": "signpost_image",
-        "item": {
-          "is_highlighted": false,
-          "attrs": {
-            "src": "https://assets.ubuntu.com/v1/60053d58-microcloud_logo.png",
-            "alt": "MicroCloud",
-            "width": "284",
-            "height": "86"
-          }
-        }
-      },
     ]
   ) -%}
   {%- endcall -%}


### PR DESCRIPTION
## Done

Remove second microcloud logo WD-36072. https://docs.google.com/document/d/1iKCpf2eOXzxZJcUll9TS2kAtpMbV4OtpqPxpHeL0OTA/edit?tab=t.jijjhiya0no5#heading=h.gidxspbfx4a7

## QA

- Open the [DEMO](https://canonical-com-2453.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Go to microcloud/what-is-microcloud
- Ensure there is only one logo at the top of the screen.

## Issue / Card

Fixes [WD-36072](https://warthogs.atlassian.net/browse/WD-36072)

## Screenshots

Before 

<img width="1912" height="944" alt="image" src="https://github.com/user-attachments/assets/a6181938-e67a-432d-a26d-72acc822eabc" />

After
<img width="1912" height="944" alt="image" src="https://github.com/user-attachments/assets/463c3b1f-89e9-442f-aea9-bce2ac0736ac" />



[WD-36072]: https://warthogs.atlassian.net/browse/WD-36072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ