### PR TITLE
feat: Basic section generation with schema definition and validation

### DIFF
--- a/static/json/page-generator/examples/basic-section.json
+++ b/static/json/page-generator/examples/basic-section.json
@@ -1,0 +1,604 @@
+{
+  "page_name": "test-basic-section",
+  "page_path": "page-generator/examples",
+  "patterns": [
+    {
+      "name": "basic-section",
+      "data": {
+        "title": {
+          "text": "Ubuntu Server"
+        },
+        "subtitle": {
+          "text": "The world's most popular Linux server platform, now with enhanced security and performance features."
+        },
+        "label_text": "Product Overview",
+        "top_rule_variant": "default",
+        "items": [
+          {
+            "type": "description",
+            "item": {
+              "type": "html",
+              "content": ""
+            }
+          },
+          {
+            "type": "image",
+            "item": {
+              "aspect_ratio": "16-9",
+              "caption_html": "Ubuntu Server running in production environment",
+              "attrs": {
+                "src": "https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png",
+                "class": "another-classname",
+                "alt": "Ubuntu Server dashboard"
+              }
+            }
+          },
+          {
+            "type": "list",
+            "item": {
+              "list_items": [
+                {
+                  "list_item_type": "tick",
+                  "content": "Enhanced security with AppArmor and live kernel patching"
+                },
+                {
+                  "list_item_type": "tick",
+                  "content": "Optimized performance for cloud and container workloads"
+                },
+                {
+                  "list_item_type": "tick",
+                  "content": "10-year long term support with regular security updates"
+                }
+              ]
+            }
+          },
+          {
+            "type": "code-block",
+            "item": {
+              "content": "# Install Ubuntu Server\nsudo apt update\nsudo apt install ubuntu-server\n\n# Enable security features\nsudo ufw enable\nsudo ufw default deny incoming"
+            }
+          },
+          {
+            "type": "logo-block",
+            "item": {
+              "logos": [
+                {
+                  "attrs": {
+                    "src": "https://assets.ubuntu.com/v1/38fdfd23-Dell-logo.png",
+                    "alt": "Dell Technologies"
+                  }
+                },
+                {
+                  "attrs": {
+                    "src": "https://assets.ubuntu.com/v1/cd5f636a-hp-logo.png",
+                    "alt": "Hewlett Packard"
+                  }
+                },
+                {
+                  "attrs": {
+                    "src": "https://assets.ubuntu.com/v1/f90702cd-lenovo-logo.png",
+                    "alt": "Lenovo"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "cta-block",
+            "item": {
+              "primary": {
+                "content_html": "Download Ubuntu Server",
+                "attrs": {
+                  "href": "#"
+                }
+              },
+              "secondaries": [
+                {
+                  "content_html": "View Documentation",
+                  "attrs": {
+                    "href": "#"
+                  }
+                },
+                {
+                  "content_html": "Contact Sales",
+                  "attrs": {
+                    "href": "#"
+                  }
+                }
+              ],
+              "link": {
+                "content_html": "Learn more about Ubuntu Server ›",
+                "attrs": {
+                  "href": "#"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "basic-section",
+      "data": {
+        "title": {
+          "text": "Ubuntu Server"
+        },
+        "subtitle": {
+          "text": "The world's most popular Linux server platform, now with enhanced security and performance features."
+        },
+        "label_text": "Product Overview",
+        "top_rule_variant": "default",
+        "items": [
+          {
+            "type": "description",
+            "item": {
+              "type": "text",
+              "content": "This is a plain text description. It will be wrapped in a paragraph tag automatically."
+            }
+          },
+          {
+            "type": "description",
+            "item": {
+              "type": "html",
+              "content": "<p>This is an HTML description with <strong>bold text</strong> and <em>italic text</em>. You can include any HTML markup.</p><p>You can even have multiple paragraphs.</p>"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "basic-section",
+      "data": {
+        "title": {
+          "text": "Ubuntu Server"
+        },
+        "subtitle": {
+          "text": "The world's most popular Linux server platform, now with enhanced security and performance features."
+        },
+        "label_text": "Product Overview",
+        "top_rule_variant": "default",
+        "items": [
+          {
+            "type": "image",
+            "item": {
+              "aspect_ratio": "16-9",
+              "attrs": {
+                "src": "https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png",
+                "alt": "16:9 aspect ratio image"
+              }
+            }
+          },
+          {
+            "type": "image",
+            "item": {
+              "aspect_ratio": "16-9",
+              "caption_html": "This image has a caption with <strong>HTML formatting</strong>",
+              "attrs": {
+                "src": "https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png",
+                "alt": "Image with caption"
+              }
+            }
+          },
+          {
+            "type": "video",
+            "item": {
+              "attrs": {
+                "src": "https://www.youtube.com/embed/lPaUMpAampI?si=nic5eE_mv5xrB9Go",
+                "allowfullscreen": ""
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "basic-section",
+      "data": {
+        "title": {
+          "text": "Ubuntu Server"
+        },
+        "subtitle": {
+          "text": "The world's most popular Linux server platform, now with enhanced security and performance features."
+        },
+        "label_text": "Product Overview",
+        "top_rule_variant": "default",
+        "items": [
+          {
+            "type": "list",
+            "item": {
+              "list_items": [
+                {
+                  "list_item_type": "bullet",
+                  "content": "Bullet list item 1"
+                },
+                {
+                  "list_item_type": "bullet",
+                  "content": "Bullet list item 2"
+                },
+                {
+                  "list_item_type": "bullet",
+                  "content": "Bullet list item 3"
+                }
+              ]
+            }
+          },
+          {
+            "type": "list",
+            "item": {
+              "list_items": [
+                {
+                  "list_item_type": "tick",
+                  "content": "Tick list item 1"
+                },
+                {
+                  "list_item_type": "tick",
+                  "content": "Tick list item 2"
+                },
+                {
+                  "list_item_type": "cross",
+                  "content": "Tick list item 3"
+                }
+              ]
+            }
+          },
+          {
+            "type": "list",
+            "item": {
+              "list_items": [
+                {
+                  "list_item_type": "number",
+                  "content": "Numbered list item 1"
+                },
+                {
+                  "list_item_type": "number",
+                  "content": "Numbered list item 2"
+                },
+                {
+                  "list_item_type": "number",
+                  "content": "Numbered list item 3"
+                }
+              ]
+            }
+          },
+          {
+            "type": "list",
+            "item": {
+              "list_items": [
+                {
+                  "list_item_type": "number",
+                  "content": "Parent item with nested list",
+                  "sublist": {
+                    "list_items": [
+                      {
+                        "list_item_type": "number",
+                        "content": "Nested item 1"
+                      },
+                      {
+                        "list_item_type": "number",
+                        "content": "Nested item 2"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "list_item_type": "number",
+                  "content": "Another parent item"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "basic-section",
+      "data": {
+        "title": {
+          "text": "Ubuntu Server"
+        },
+        "subtitle": {
+          "text": "The world's most popular Linux server platform, now with enhanced security and performance features."
+        },
+        "label_text": "Product Overview",
+        "top_rule_variant": "default",
+        "items": [
+          {
+            "type": "logo-block",
+            "item": {
+              "is_fixed_width": true,
+              "logos": [
+                {
+                  "attrs": {
+                    "src": "https://assets.ubuntu.com/v1/38fdfd23-Dell-logo.png",
+                    "alt": "Dell Technologies"
+                  }
+                },
+                {
+                  "attrs": {
+                    "src": "https://assets.ubuntu.com/v1/cd5f636a-hp-logo.png",
+                    "alt": "Hewlett Packard"
+                  }
+                },
+                {
+                  "attrs": {
+                    "src": "https://assets.ubuntu.com/v1/f90702cd-lenovo-logo.png",
+                    "alt": "Lenovo"
+                  }
+                },
+                {
+                  "attrs": {
+                    "src": "https://assets.ubuntu.com/v1/2ef3c028-amazon-web-services-logo.png",
+                    "alt": "Amazon Web Services"
+                  }
+                },
+                {
+                  "attrs": {
+                    "src": "https://assets.ubuntu.com/v1/cb7ef8ac-ibm-cloud-logo.png",
+                    "alt": "IBM Cloud"
+                  }
+                },
+                {
+                  "attrs": {
+                    "src": "https://assets.ubuntu.com/v1/a554a818-google-cloud-logo.png",
+                    "alt": "Google Cloud Platform"
+                  }
+                },
+                {
+                  "attrs": {
+                    "src": "https://assets.ubuntu.com/v1/b3e692f4-oracle-new-logo.png",
+                    "alt": "Oracle"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "basic-section",
+      "data": {
+        "title": {
+          "text": "Ubuntu Server"
+        },
+        "subtitle": {
+          "text": "The world's most popular Linux server platform, now with enhanced security and performance features."
+        },
+        "label_text": "Product Overview",
+        "top_rule_variant": "default",
+        "items": [
+          {
+            "type": "linked-logo-block",
+            "item": {
+              "links": [
+                {
+                  "href": "#",
+                  "text": "Learn more ›",
+                  "label": "Kubeflow",
+                  "image_attrs": {
+                    "src": "https://assets.ubuntu.com/v1/cd89477e-kubeflow-logo-container-vert-fill.png",
+                    "alt": "Kubeflow",
+                    "width": "432",
+                    "height": "481"
+                  }
+                },
+                {
+                  "href": "#",
+                  "text": "Learn more ›",
+                  "label": "MLflow",
+                  "image_attrs": {
+                    "src": "https://assets.ubuntu.com/v1/104192d9-mlflow-logo-container-vert-fill.png",
+                    "alt": "MLflow",
+                    "width": "222",
+                    "height": "481"
+                  }
+                },
+                {
+                  "href": "#",
+                  "text": "Learn more ›",
+                  "label": "Apache Spark",
+                  "image_attrs": {
+                    "src": "https://assets.ubuntu.com/v1/855deda8-apache-spark-logo-container-vert-fill.png",
+                    "alt": "Apache Spark",
+                    "width": "240",
+                    "height": "481"
+                  }
+                },
+                {
+                  "href": "#",
+                  "text": "Learn more ›",
+                  "label": "OpenSearch",
+                  "image_attrs": {
+                    "src": "https://assets.ubuntu.com/v1/a8185f91-opensearch-logo-container-vert-fill.png",
+                    "alt": "OpenSearch",
+                    "width": "330",
+                    "height": "481"
+                  }
+                },
+                {
+                  "href": "#",
+                  "text": "Learn more ›",
+                  "label": "Kafka",
+                  "image_attrs": {
+                    "src": "https://assets.ubuntu.com/v1/d30de1f1-kafka-logo-container-vert-fill.png",
+                    "alt": "Kafka",
+                    "width": "294",
+                    "height": "481"
+                  }
+                },
+                {
+                  "href": "#",
+                  "text": "Learn more ›",
+                  "label": "PostgreSQL",
+                  "image_attrs": {
+                    "src": "https://assets.ubuntu.com/v1/f5605b7e-postgre-sql-container-vert-fill.png",
+                    "alt": "PostgreSQL",
+                    "width": "432",
+                    "height": "481"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "basic-section",
+      "data": {
+        "title": {
+          "text": "Ubuntu Server"
+        },
+        "subtitle": {
+          "text": "The world's most popular Linux server platform, now with enhanced security and performance features."
+        },
+        "label_text": "Product Overview",
+        "top_rule_variant": "default",
+        "items": [
+          {
+            "type": "cta-block",
+            "item": {
+              "primary": {
+                "content_html": "Primary Button",
+                "attrs": {
+                  "href": "#"
+                }
+              }
+            }
+          },
+          {
+            "type": "cta-block",
+            "item": {
+              "primary": {
+                "content_html": "Primary Button",
+                "attrs": {
+                  "href": "#"
+                }
+              },
+              "secondaries": [
+                {
+                  "content_html": "Secondary Button 1",
+                  "attrs": {
+                    "href": "#"
+                  }
+                },
+                {
+                  "content_html": "Secondary Button 2",
+                  "attrs": {
+                    "href": "#"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "cta-block",
+            "item": {
+              "secondaries": [
+                {
+                  "content_html": "Secondary Button 1",
+                  "attrs": {
+                    "href": "#"
+                  }
+                },
+                {
+                  "content_html": "Secondary Button 2",
+                  "attrs": {
+                    "href": "#"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "cta-block",
+            "item": {
+              "link": {
+                "content_html": "Learn more ›",
+                "attrs": {
+                  "href": "#"
+                }
+              }
+            }
+          },
+          {
+            "type": "cta-block",
+            "item": {
+              "primary": {
+                "content_html": "Primary Button",
+                "attrs": {
+                  "href": "#"
+                }
+              },
+              "secondaries": [
+                {
+                  "content_html": "Secondary Button",
+                  "attrs": {
+                    "href": "#"
+                  }
+                }
+              ],
+              "link": {
+                "content_html": "Learn more ›",
+                "attrs": {
+                  "href": "#"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "basic-section",
+      "data": {
+        "title": {
+          "text": "Ubuntu Server"
+        },
+        "subtitle": {
+          "text": "The world's most popular Linux server platform, now with enhanced security and performance features."
+        },
+        "label_text": "Product Overview",
+        "top_rule_variant": "default",
+        "items": [
+          {
+            "type": "notification",
+            "item": {
+              "type": "positive",
+              "title": "This is a positive notificaton",
+              "content": "The quick brown fox jumps over the lazy dog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "basic-section",
+      "data": {
+        "title": {
+          "text": "Ubuntu Server"
+        },
+        "subtitle": {
+          "text": "The world's most popular Linux server platform, now with enhanced security and performance features."
+        },
+        "label_text": "Product Overview",
+        "top_rule_variant": "default",
+        "items": [
+          {
+            "type": "code-block",
+            "item": {
+              "content": "#!/bin/bash\n# Build CSS into the ./build/ directory:\ndotrun build\n\n# Build CSS into the ./build/ directory,\n# and start the server:\ndotrun\n\n# Dynamically watch for changes to the\n# Sass files and build automatically:\ndotrun watch\n\n# See a full list of commands:\ndotrun exec yarn run --non-interactive"
+            }
+          },
+          {
+            "type": "code-block",
+            "item": {
+              "is_code_snippet": true,
+              "content": "document.addEventListener(\"DOMContentLoaded\", () => {\n  const examples = document.querySelectorAll(\".js-example\");\n\n  [].slice.call(examples).forEach((placementElement) => {\n    renderExample(placementElement).catch((error) => {\n      console.error(\"Failed to render example\", {placementElement, error});\n    });\n  });\n});"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/static/json/page-generator/schemas/basic-section.json
+++ b/static/json/page-generator/schemas/basic-section.json
@@ -1,0 +1,335 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": { "const": "basic-section" },
+    "data": {
+      "type": "object",
+      "required": ["title", "items"],
+      "properties": {
+        "title": { "$ref": "#/definitions/titleObject" },
+        "label_text": { "type": "string" },
+        "subtitle": { "$ref": "#/definitions/subtitleObject" },
+        "top_rule_variant": {
+          "enum": ["default", "muted", "highlighted", "none"]
+        },
+        "attrs": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "padding": { "enum": ["deep", "shallow", "default"] },
+        "override_last_item_padding": { "type": "boolean", "default": false },
+        "items": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "$ref": "#/definitions/descriptionBlock" },
+              { "$ref": "#/definitions/imageBlock" },
+              { "$ref": "#/definitions/videoBlock" },
+              { "$ref": "#/definitions/ctaBlock" },
+              { "$ref": "#/definitions/listBlock" },
+              { "$ref": "#/definitions/codeBlock" },
+              { "$ref": "#/definitions/logoBlock" },
+              { "$ref": "#/definitions/linkedLogoBlock" },
+              { "$ref": "#/definitions/notificationBlock" }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "titleObject": {
+      "type": "object",
+      "required": ["text"],
+      "properties": {
+        "text": { "type": "string" },
+        "link_attrs": {
+          "type": "object",
+          "properties": {
+            "href": { "type": "string" }
+          }
+        }
+      }
+    },
+    "subtitleObject": {
+      "type": "object",
+      "required": ["text"],
+      "properties": {
+        "text": { "type": "string" },
+        "heading_level": { "enum": [4, 5] }
+      },
+      "additionalProperties": false
+    },
+    "descriptionBlock": {
+      "type": "object",
+      "required": ["item"],
+      "properties": {
+        "type": { "const": "description" },
+        "padding": { "enum": ["shallow"] },
+        "item": {
+          "type": "object",
+          "required": ["type", "content"],
+          "properties": {
+            "type": { "enum": ["text", "html"] },
+            "content": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "ctaBlock": {
+      "type": "object",
+      "required": ["item"],
+      "properties": {
+        "type": { "const": "cta-block" },
+        "padding": { "enum": ["shallow"] },
+        "item": {
+          "type": "object",
+          "properties": {
+            "primary": { "$ref": "#/definitions/linkObject" },
+            "secondaries": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/linkObject" }
+            },
+            "link": { "$ref": "#/definitions/linkObject" }
+          },
+          "anyOf": [
+            { "required": ["primary"] },
+            { "required": ["secondaries"] },
+            { "required": ["link"] }
+          ]
+        }
+      }
+    },
+    "linkObject": {
+      "type": "object",
+      "required": ["content_html", "attrs"],
+      "properties": {
+        "content_html": { "type": "string" },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "href": { "type": "string" }
+          }
+        }
+      }
+    },
+    "imageBlock": {
+      "type": "object",
+      "required": ["item"],
+      "properties": {
+        "type": { "const": "image" },
+        "item": {
+          "type": "object",
+          "required": ["attrs"],
+          "properties": {
+            "aspect_ratio": { "enum": ["16-9", "3-2", "2-3", "cinematic"] },
+            "caption_html": { "type": "string" },
+            "is_highlighted": { "type": "boolean" },
+            "is_cover": { "type": "boolean" },
+            "attrs": { "$ref": "#/definitions/imageAttrs" }
+          }
+        }
+      }
+    },
+    "videoBlock": {
+      "type": "object",
+      "required": ["item"],
+      "properties": {
+        "type": { "const": "video" },
+        "item": {
+          "type": "object",
+          "properties": {
+            "attrs": { "$ref": "#/definitions/videoAttrs" }
+          }
+        }
+      }
+    },
+    "imageAttrs": {
+      "type": "object",
+      "required": ["src"],
+      "properties": {
+        "src": { "type": "string", "format": "uri" },
+        "alt": { "type": "string" }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "videoAttrs": {
+      "type": "object",
+      "required": ["src"],
+      "properties": {
+        "src": { "type": "string", "format": "uri" },
+        "allowfullscreen": { "type": "string" }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "listBlock": {
+      "type": "object",
+      "required": ["item"],
+      "properties": {
+        "type": { "const": "list" },
+        "item": {
+          "type": "object",
+          "required": ["list_items"],
+          "properties": {
+            "list_items": {
+              "type": "array",
+              "contains": {
+                "$ref": "#/definitions/listItemObject"
+              },
+              "items": {
+                "$ref": "#/definitions/listItemObject"
+              }
+            }
+          }
+        }
+      }
+    },
+    "listItemObject": {
+      "type": "object",
+      "required": ["list_item_type", "content"],
+      "properties": {
+        "list_item_type": {
+          "enum": ["bullet", "tick", "cross", "number"]
+        },
+        "content": { "type": "string" },
+        "sublist": {
+          "type": "object",
+          "required": ["list_items"],
+          "properties": {
+            "list_items": {
+              "type": "array",
+              "contains": { "$ref": "#/definitions/listItemObject" },
+              "items": {
+                "$ref": "#/definitions/listItemObject"
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "codeBlock": {
+      "type": "object",
+      "required": ["item"],
+      "properties": {
+        "type": { "const": "code-block" },
+        "item": {
+          "type": "object",
+          "required": ["content"],
+          "properties": {
+            "content": { "type": "string" },
+            "is_code_snippet": { "type": "boolean", "default": false }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "logoBlock": {
+      "type": "object",
+      "required": ["item"],
+      "properties": {
+        "type": { "const": "logo-block" },
+        "item": {
+          "type": "object",
+          "required": ["logos"],
+          "properties": {
+            "is_fixed_width": { "type": "boolean", "default": true },
+            "logos": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["attrs"],
+                "properties": {
+                  "has_line_break_after": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "attrs": {
+                    "type": "object",
+                    "required": ["src"],
+                    "properties": {
+                      "src": { "type": "string", "format": "uri" },
+                      "alt": { "type": "string" },
+                      "class": { "type": "string" }
+                    },
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "linkedLogoBlock": {
+      "type": "object",
+      "required": ["item"],
+      "properties": {
+        "type": { "const": "linked-logo-block" },
+        "item": {
+          "type": "object",
+          "required": ["links"],
+          "properties": {
+            "links": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["href", "text", "image_attrs"],
+                "properties": {
+                  "href": { "type": "string", "format": "uri" },
+                  "text": { "type": "string" },
+                  "label": { "type": "string" },
+                  "image_attrs": {
+                    "type": "object",
+                    "required": ["src", "alt", "width", "height"],
+                    "properties": {
+                      "src": { "type": "string", "format": "uri" },
+                      "alt": { "type": "string" },
+                      "width": { "type": "string" },
+                      "height": { "type": "string" }
+                    },
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "notificationBlock": {
+      "type": "object",
+      "required": ["item"],
+      "properties": {
+        "type": { "const": "notification" },
+        "item": {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "enum": ["positive", "negative", "caution", "information"]
+            },
+            "title": { "type": "string" },
+            "content": { "type": "string" }
+          },
+          "anyOf": [{ "required": ["title"] }, { "required": ["content"] }],
+          "additionalProperties": false
+        }
+      }
+    }
+  }
+}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1838,7 +1838,7 @@ def check_redirect(response):
 def generator():
     with open(
         Path(app.root_path).resolve().parent
-        / "static/json/page-generator/examples/resources.json",
+        / "static/json/page-generator/examples/basic-section.json",
         "r",
         encoding="utf-8",
     ) as f:

--- a/webapp/page_generator/__init__.py
+++ b/webapp/page_generator/__init__.py
@@ -331,11 +331,19 @@ class BasicSection(Pattern):
         return "basic-section"
 
     def process_pattern(self):
-        # TODO: Implement basic section pattern
-        pass
+        params_str = self._build_params_str()
+
+        self.pattern_html += f"""
+            {{{{ vf_basic_section(
+                {params_str}
+            ) }}}}
+        """
 
     def write_import(self):
-        return None
+        return (
+            '{% from "_macros/vf_basic-section.jinja" '
+            "import vf_basic_section %}"
+        )
 
 
 class CTASection(Pattern):


### PR DESCRIPTION
## Done

- Created a metadata schema for Basic section pattern
- Implemented Basic section pattern generator
- Include a sample payload containing all the possible variations of Basic section pattern
- Generate and render a page using Basic section pattern

## QA

- Check out this pull request
- Run the project using `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Access the `/create-page` endpoint, which should generate a test page with all the variations of basic section and render the preview

## Issue / Card

Fixes [WD-33151](https://warthogs.atlassian.net/browse/WD-33151) [WD-33155](https://warthogs.atlassian.net/browse/WD-33155)

## Screenshots

<img width="1691" height="7671" alt="image" src="https://github.com/user-attachments/assets/67e39056-6d9d-42f4-bac7-3f6576593cfc" />



[WD-33151]: https://warthogs.atlassian.net/browse/WD-33151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-33155]: https://warthogs.atlassian.net/browse/WD-33155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
