### PR TITLE
fix(WD-36209): pack-rock requires explicit flask entry in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ cachetools==5.3.3
 sentry-sdk[flask]==2.49.0
 geopy==2.4.1
 PySocks==1.7.1 # httplib2 proxy fails otherwise
+flask==2.3.3


### PR DESCRIPTION
## Done

- Added flask to requirements.txt

## QA

- Verify the [pack-rock job](https://github.com/canonical/canonical.com/actions/runs/24711481966/job/72276991745) succeeded

## Issue / Card

Fixes [WD-36209](https://warthogs.atlassian.net/browse/WD-36209)


[WD-36209]: https://warthogs.atlassian.net/browse/WD-36209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
