### PR TITLE
update knowledge webpages to fix typo on newsletter sign up

### DIFF
--- a/templates/knowledge/_base_knowledge_category.html
+++ b/templates/knowledge/_base_knowledge_category.html
@@ -76,7 +76,7 @@
                       aria-labelledby="canonicalUpdatesOptIn"
                       name="canonicalUpdatesOptIn"
                       type="checkbox" />
-              <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical"s products and services.</span>
+              <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
             </label>
             <p>
               By submitting this form, I confirm that I have read and agree to <a href="#">Canonical's Privacy Policy</a>.

--- a/templates/knowledge/_base_knowledge_markdown.html
+++ b/templates/knowledge/_base_knowledge_markdown.html
@@ -62,7 +62,7 @@
                   aria-labelledby="canonicalUpdatesOptIn"
                   name="canonicalUpdatesOptIn"
                   type="checkbox" />
-          <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical"s products and services.</span>
+          <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
         </label>
         <p>
           By submitting this form, I confirm that I have read and agree to <a href="#">Canonical's Privacy Policy</a>.


### PR DESCRIPTION
## Done

- updated double quote mark `"` to single quote mark `'`
## QA

- Open the [DEMO](https://canonical-com-2470.demos.haus/knowledge/security-and-compliance/open-source-security)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card
[Jira ticket](https://warthogs.atlassian.net/browse/WD-36240)

## Screenshots
Before:
<img width="433" height="662" alt="image" src="https://github.com/user-attachments/assets/5303c984-25ca-4ed4-9e70-72143e9fd2f6" />


After:
<img width="433" height="662" alt="image" src="https://github.com/user-attachments/assets/1955e8e3-c74d-4dc5-bd75-5b3c5d32439a" />
