### PR TITLE
fix: add knowledge categories and remove duplicated anchors

### DIFF
--- a/static/js/in-page-navigation.js
+++ b/static/js/in-page-navigation.js
@@ -311,21 +311,11 @@ function generateSelectors(navRoot) {
  * @returns {string} The heading ID
  */
 function generateHeadingId(heading) {
-  if (heading.id && !document.getElementById(heading.id)) {
+  if (heading.id) {
     return heading.id;
   }
 
-  let baseId = slugify(heading.textContent);
-  let id = baseId;
-
-  // Handle duplicate IDs
-  let counter = 1;
-  while (document.getElementById(id)) {
-    appendix = counter == 1 ? '' : `-${counter}`;
-    id = baseId + appendix;
-    counter++;
-  }
-
+  const id = slugify(heading.textContent);
   heading.id = id;
   return id;
 }

--- a/templates/knowledge/_base_knowledge_category.html
+++ b/templates/knowledge/_base_knowledge_category.html
@@ -47,7 +47,9 @@
         </div>
       {% else %}
         <div class="grid-row">
-          <p>No articles available in this category.</p>
+          <div class="grid-col-start-large-3 grid-col-6">
+            <p>No articles available in this category.</p>
+          </div>
         </div>
       {% endif %}
     </section>

--- a/templates/knowledge/industries-and-verticals/index.html
+++ b/templates/knowledge/industries-and-verticals/index.html
@@ -1,0 +1,3 @@
+{% extends 'knowledge/_base_knowledge_category.html' %}
+
+{% set title = 'Industries and verticals' %}

--- a/templates/knowledge/partners/index.html
+++ b/templates/knowledge/partners/index.html
@@ -1,0 +1,3 @@
+{% extends 'knowledge/_base_knowledge_category.html' %}
+
+{% set title = 'Partners' %}


### PR DESCRIPTION
## Done

- Add two categories to knowledge hub
- Remove duplicated anchor heading

## QA

- Go to https://canonical-com-2475.demos.haus/knowledge/security-and-compliance/security-vs-compliance or any other knowledge articles
- Click on a link under the in-page-navigation
- See that the anchor link does not have "-2" appended to it
- For the category fix, see that the two parent categories match the entries on the [tag taxonomy sheet](https://docs.google.com/spreadsheets/d/1999CK3b1DbZuwj0CRfVX3pdYSdugeG1ALw0Wki8Vmgg/edit?gid=0#gid=0)

## Issue / Card

Fixes [WD-36139](https://warthogs.atlassian.net/browse/WD-36139)

## Screenshots

[if relevant, include a screenshot]


[WD-36139]: https://warthogs.atlassian.net/browse/WD-36139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ