### PR TITLE
feat: generate dynamic sitemaps for knowledge hub

### DIFF
--- a/templates/knowledge/_base_knowledge_category.html
+++ b/templates/knowledge/_base_knowledge_category.html
@@ -46,7 +46,9 @@
           {% endfor %}
         </div>
       {% else %}
-        <p>No articles available in this category.</p>
+        <div class="grid-row">
+          <p>No articles available in this category.</p>
+        </div>
       {% endif %}
     </section>
 

--- a/templates/knowledge/sitemap.xml
+++ b/templates/knowledge/sitemap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {% for section in sections %}
+  <url>
+    <loc>https://canonical.com/knowledge/{{ section.slug }}</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  
+  {% for article in section.articles %}
+  <url>
+    <loc>https://canonical.com{{ article.url }}</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  {% endfor %}
+  {% endfor %}
+</urlset>

--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -13,6 +13,9 @@
     <loc>https://canonical.com/blog/sitemap.xml</loc>
   </sitemap>
   <sitemap>
+    <loc>https://canonical.com/knowledge/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
     <loc>https://canonical.com/microk8s/docs/sitemap.xml</loc>
   </sitemap>
   <sitemap>

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -4,12 +4,12 @@ import logging
 import re
 import os
 import xml.etree.ElementTree as ET
-from webapp.app import app, build_sitemap_tree
+from webapp.app import app, build_sitemap_tree, knowledge_sitemap
 
 logging.getLogger("talisker.context").disabled = True
 
 
-class TestSitemap(unittest.TestCase):
+class TestSitemapTree(unittest.TestCase):
     def setUp(self):
         """
         Set up Flask app for testing
@@ -190,6 +190,146 @@ class TestSitemap(unittest.TestCase):
         result = create_sitemap("/invalid/path/sitemap_tree.xml")
         self.assertIn("Generate_sitemap error", result[0])
         self.assertEqual(result[1], 500)
+
+
+class TestKnowledgeSitemap(unittest.TestCase):
+    def setUp(self):
+        """Set up test client and app context"""
+        app.testing = True
+        self.client = app.test_client()
+
+    @patch("webapp.app.get_knowledge_sections")
+    def test_knowledge_sitemap_returns_xml(self, mock_get_sections):
+        """Test that knowledge_sitemap returns valid XML response"""
+        # Mock the sections data
+        mock_get_sections.return_value = [
+            {
+                "slug": "ubuntu-and-linux",
+                "title": "Ubuntu and Linux",
+                "description": "Learn about Ubuntu and Linux",
+                "articles": [
+                    {
+                        "hero_title": "Getting Started",
+                        "description": "A beginner's guide",
+                        "url": "/knowledge/ubuntu-and-linux/getting-started",
+                        "tag": "beginner",
+                    }
+                ],
+            }
+        ]
+
+        # Call the function
+        with app.app_context():
+            response = knowledge_sitemap()
+
+        # Verify response is a Flask response object
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "application/xml")
+        self.assertEqual(
+            response.headers["Cache-Control"], "public, max-age=43200"
+        )
+
+    @patch("webapp.app.get_knowledge_sections")
+    def test_knowledge_sitemap_contains_urls(self, mock_get_sections):
+        """Test that knowledge_sitemap contains expected URLs"""
+        mock_get_sections.return_value = [
+            {
+                "slug": "ubuntu-and-linux",
+                "title": "Ubuntu and Linux",
+                "description": "Learn about Ubuntu and Linux",
+                "articles": [
+                    {
+                        "hero_title": "Getting Started",
+                        "description": "A beginner's guide",
+                        "url": "/knowledge/ubuntu-and-linux/getting-started",
+                        "tag": "beginner",
+                    }
+                ],
+            }
+        ]
+
+        with app.app_context():
+            response = knowledge_sitemap()
+
+        # Get the XML content
+        xml_content = response.get_data(as_text=True)
+
+        # Verify XML structure
+        self.assertIn("<?xml version", xml_content)
+        self.assertIn("<urlset", xml_content)
+        self.assertIn("</urlset>", xml_content)
+
+        # Verify expected URLs are present
+        self.assertIn(
+            "https://canonical.com/knowledge/ubuntu-and-linux", xml_content
+        )
+        self.assertIn(
+            "https://canonical.com/knowledge/ubuntu-and-linux/getting-started",
+            xml_content,
+        )
+
+    @patch("webapp.app.get_knowledge_sections")
+    def test_knowledge_sitemap_empty_sections(self, mock_get_sections):
+        """Test that knowledge_sitemap handles empty sections gracefully"""
+        mock_get_sections.return_value = []
+
+        with app.app_context():
+            response = knowledge_sitemap()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "application/xml")
+
+        xml_content = response.get_data(as_text=True)
+        self.assertIn("<?xml version", xml_content)
+        self.assertIn("<urlset", xml_content)
+
+    @patch("webapp.app.get_knowledge_sections")
+    def test_knowledge_sitemap_multiple_sections(self, mock_get_sections):
+        """Test that knowledge_sitemap handles multiple sections"""
+        mock_get_sections.return_value = [
+            {
+                "slug": "cloud",
+                "title": "Cloud",
+                "description": "Cloud computing",
+                "articles": [
+                    {
+                        "hero_title": "Cloud Basics",
+                        "description": "Cloud basics",
+                        "url": "/knowledge/cloud/basics",
+                        "tag": "cloud",
+                    }
+                ],
+            },
+            {
+                "slug": "security",
+                "title": "Security",
+                "description": "Security topics",
+                "articles": [
+                    {
+                        "hero_title": "Security Best Practices",
+                        "description": "Security practices",
+                        "url": "/knowledge/security/best-practices",
+                        "tag": "security",
+                    }
+                ],
+            },
+        ]
+
+        with app.app_context():
+            response = knowledge_sitemap()
+
+        xml_content = response.get_data(as_text=True)
+
+        # Verify both sections are present
+        self.assertIn("https://canonical.com/knowledge/cloud", xml_content)
+        self.assertIn("https://canonical.com/knowledge/security", xml_content)
+        self.assertIn(
+            "https://canonical.com/knowledge/cloud/basics", xml_content
+        )
+        self.assertIn(
+            "https://canonical.com/knowledge/security/best-practices",
+            xml_content,
+        )
 
 
 if __name__ == "__main__":

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -57,6 +57,7 @@ from webapp.views import (
     append_utms_cookie_to_ubuntu_links,
     build_knowledge_index,
     build_knowledge_category_index,
+    get_knowledge_sections,
 )
 from webapp.application import application_bp
 from webapp.canonical_cla.views import (
@@ -92,6 +93,7 @@ DYNAMIC_SITEMAPS = [
     "careers",
     "partners",
     "blog",
+    "knowledge",
 ]
 
 # Web tribe websites custom search ID
@@ -1020,6 +1022,22 @@ app.register_blueprint(build_blueprint(blog_views), url_prefix="/blog")
 
 # Knowledge hub
 app.add_url_rule("/knowledge", view_func=build_knowledge_index())
+
+
+@app.route("/knowledge/sitemap.xml")
+def knowledge_sitemap():
+    sections = get_knowledge_sections()
+
+    context = {
+        "sections": sections,
+    }
+
+    xml_sitemap = flask.render_template("knowledge/sitemap.xml", **context)
+    response = flask.make_response(xml_sitemap)
+    response.headers["Content-Type"] = "application/xml"
+    response.headers["Cache-Control"] = "public, max-age=43200"
+
+    return response
 
 
 def register_knowledge_category_routes():


### PR DESCRIPTION
## Done

- Add dynamic sitemaps for knowledge hub articles and category pages
- Note: knowledge index page is not in the dynamic sitemap, as it's already included in /sitemap_tree.xml
- Drive-by: fix text grid on category pages with no articles

## QA

- Go to https://canonical-com-2476.demos.haus/sitemap.xml
- See that https://canonical-com-2476.demos.haus/knowledge/sitemap.xml entry is present
- Go to https://canonical-com-2476.demos.haus/knowledge/sitemap.xml
- Check that all category pages and knowledge articles are included

## Issue / Card

Fixes [WD-36245](https://warthogs.atlassian.net/browse/WD-36245)

## Screenshots

[if relevant, include a screenshot]


[WD-36245]: https://warthogs.atlassian.net/browse/WD-36245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ