### PR TITLE
fix(WD-36269): Copy update for navigation bar

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -719,6 +719,6 @@ company:
       - description: Ubuntu Pro Legacy add-on expands coverage for Ubuntu LTS releases to 15 years
         url: /blog/canonical-expands-total-coverage-for-ubuntu-lts-releases-to-15-years-with-legacy-add-on
         image_url: https://assets.ubuntu.com/v1/4ff2e4b3-canonical_announces.png
-      - description: Canonical Releases Ubuntu 25.10 Questing Quokka
-        url: /blog/canonical-releases-ubuntu-25-10-questing-quokka
-        image_url: https://assets.ubuntu.com/v1/01403c6c-canonical_releases.jpg
+      - description: Canonical releases Ubuntu 26.04 LTS Resolute Raccoon
+        url: /blog/canonical-releases-ubuntu-26-04-lts-resolute-raccoon
+        image_url: https://assets.ubuntu.com/v1/1ccf5d21-resolute_raccoon_wallpaper_color_1920x1080.png


### PR DESCRIPTION
## Done

- Updated company highlights to link to new Ubuntu release [(relevant comment)](https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?disco=AAAB3yvhRjk)

## QA

- Open the [DEMO](https://canonical-com-2482.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check whether the company -> highlights tab in the top bar displays and links to the new release

## Issue / Card

Fixes [WD-36269](https://warthogs.atlassian.net/browse/WD-36269)


[WD-36269]: https://warthogs.atlassian.net/browse/WD-36269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
