### PR TITLE
fix(WD-36286): add redirect from old documentation/work-and-careers/ to new site

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -32,6 +32,7 @@ data/docs/kafka/iaas(?P<path>.*)/?: "https://documentation.ubuntu.com/charmed-ka
 data/docs/kafka/k8s(?P<path>.*)/?: "https://documentation.ubuntu.com/charmed-kafka-k8s/3/{path}"
 data/docs/spark/k8s(?P<path>.*)/?: "https://canonical-charmed-spark.readthedocs-hosted.com/main/{path}"
 data/docs/opensearch/iaas(?P<path>.*)/?: "https://canonical-charmed-opensearch.readthedocs-hosted.com/2/{path}"
+documentation/work-and-careers/?: "/documentation/working-in-documentation"
 edge-computing/?: "/solutions/infrastructure/edge-computing"
 embedding/?: "/partners/isv-program"
 embedding/faqs/?: "/partners/isv-program/embedding-faq"


### PR DESCRIPTION
## Done

- Redirect from old `documentation/work-and-careers/` to new `documentation/working-in-careers/`

## QA

- Open the [DEMO](https://canonical-com-2483.demos.haus/)
- Add `/documentation/work-and-careers` to the demo url and click enter
- Verify you landed on `/documentation/working-in-documentation` page instead

## Issue / Card

[WD-36286](https://warthogs.atlassian.net/browse/WD-36286)


[WD-36286]: https://warthogs.atlassian.net/browse/WD-36286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
