### PR TITLE
chore: ignore DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 Desktop.ini
 Thumbs.db
 ._*
+.DS_Store
 *.DS_Store
 *~
 \#*\#

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -88,12 +88,11 @@ from webapp.utils.juju_doc_search import (
 logger = logging.getLogger(__name__)
 
 # Sitemaps that are already generated and don't need to be updated.
-# Can be seen on sitemap_index.xml
+# Can be seen on sitemap.xml
 DYNAMIC_SITEMAPS = [
     "careers",
     "partners",
     "blog",
-    "knowledge",
 ]
 
 # Web tribe websites custom search ID


### PR DESCRIPTION
## Done

- Ignore mac generated DS_Store files
- Fixes directory parsing of template files

## QA

- Go to /sitemap_parser
- See that it loads as expected

## Issue / Card

Fixes [WD-36257](https://warthogs.atlassian.net/browse/WD-36257)

## Screenshots

[if relevant, include a screenshot]


[WD-36257]: https://warthogs.atlassian.net/browse/WD-36257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ