### PR TITLE
copy update: add new DevOps exam

### DIFF
--- a/templates/academy/exam-content/exam-content.json
+++ b/templates/academy/exam-content/exam-content.json
@@ -120,5 +120,35 @@
         ]
       }
     ]
+  },
+  {
+    "exam_name": "Using DevOps Principles",
+    "exam_description": "Verify your implementation of DevOps principles. Topics include system automation and deployment, management of updates and patches, application and system monitoring, and troubleshooting connected systems.",
+    "syllabus": [
+      {
+        "chapter_title": "Using tools for automation and system updating",
+        "chapter_sections": [
+          "Write and maintain system automation scripts in Bash or Python using git version control",
+          "Use workflow automation tools such as cloud-init and Ansible",
+          "Apply system updates and patches using Landscape, Ubuntu Pro tools, Livepatch and ESM"
+        ]
+      },
+      {
+        "chapter_title": "Understanding deployment technologies",
+        "chapter_sections": [
+          "Manage simple containerized web and database applications using Docker or LXD",
+          "Provision basic virtualized environments using virsh, virt-manager or LXD"
+        ]
+      },
+      {
+        "chapter_title": "Monitoring & Troubleshooting Systems",
+        "chapter_sections": [
+          "Analyze and assess the impact of system configuration on compute resources, and network performance",
+          "Troubleshoot systems at rest with basic system tools like tcpdump, dig, ss and iproute2",
+          "Respond to real time system degradation due to resource contention",
+          "Monitor and automatically detect connectivity and load issues"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Done

Update [DEMO](https://canonical-com-2487.demos.haus/academy/exam-content) as per [copydoc](https://docs.google.com/document/d/1bnA-f5m2zvZLh8NB2eR51s--7DarJTmWLXjWShK6378/edit?tab=t.0)

## QA

- Open the [DEMO](https://canonical-com-2487.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes WD-36303
