### PR TITLE
copy-update: update 10->15 years for opensearch

### DIFF
--- a/templates/data/opensearch/index.html
+++ b/templates/data/opensearch/index.html
@@ -9,7 +9,7 @@
 {% block canonical_url %}{{ request.host_url }}data/opensearch{% endblock %}
 
 {% block meta_description %}
-  Charmed OpenSearch delivers up to 10 years of support and security maintenance for OpenSearch as an integrated, turnkey
+  Charmed OpenSearch delivers up to 15 years of support and security maintenance for OpenSearch as an integrated, turnkey
   solution with advanced management features.
 {% endblock %}
 
@@ -59,7 +59,7 @@
       <div class="col-9 col-medium-4">
         <ul class="p-list--divided">
           <li class="p-list__item">
-            <p class="p-heading--2 u-no-padding">10 years security maintenance and support</p>
+            <p class="p-heading--2 u-no-padding">15 years of security maintenance and support</p>
           </li>
           <li class="p-list__item">
             <p class="p-heading--2 u-no-padding">Open source</p>
@@ -215,7 +215,7 @@
           </div>
         </div>
         <p>
-          We provide 10 years of support and security patching for your OpenSearch artefacts in the format of your choice
+          We provide 15 years of support and security patching for your OpenSearch artefacts in the format of your choice
           through our Ubuntu Pro subscription.
         </p>
         <hr class="p-rule--muted" />
@@ -248,7 +248,7 @@
           </div>
         </div>
         <p>
-          Get comprehensive, 24/7 or weekday support for Charmed OpenSearch, covering the entire solution for up to 10
+          Get comprehensive, 24/7 or weekday support for Charmed OpenSearch, covering the entire solution for up to 15
           years.
         </p>
         <hr class="p-rule--muted" />
@@ -380,7 +380,7 @@
           </div>
           <p class="u-align-text--right">Per node, per year</p>
           <p>
-            24/7, weekday or advanced fire-fighting support for OpenSearch from Canonical for up to 10 years per release
+            24/7, weekday or advanced fire-fighting support for OpenSearch from Canonical for up to 15 years per release
             track.
           </p>
           <hr class="p-rule--muted" />

--- a/templates/data/opensearch/support.html
+++ b/templates/data/opensearch/support.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block meta_description %}
-  Get support for OpenSearch, from Canonical. 24/7 or weekday support and up to ten years security patching per release
+  Get support for OpenSearch, from Canonical. 24/7 or weekday support and up to fifteen years security patching per release
   track.
 {% endblock %}
 
@@ -67,7 +67,7 @@
       <div class="col-9 col-medium-4">
         <ul class="p-list--divided">
           <li class="p-list__item u-no-padding">
-            <p class="p-heading--2 u-no-padding">Up to 10 years support and security maintenance</p>
+            <p class="p-heading--2 u-no-padding">Up to 15 years support and security maintenance</p>
           </li>
           <li class="p-list__item u-no-padding">
             <p class="p-heading--2 u-no-padding">Low total cost of ownership</p>
@@ -155,11 +155,11 @@
         </div>
         <div class="p-equal-height-row__item">
           <hr class="p-rule--highlight u-hide--medium u-hide--small" />
-          <h3 class="p-heading--5">10 years of security</h3>
+          <h3 class="p-heading--5">15 years of security</h3>
         </div>
         <p class="p-equal-height-row__item">
           Not every organisation is willing or able to upgrade their critical data infrastructure on a regular
-          basis. With Canonical, your service stays secure for up to 10 years with no need for major upgrades.
+          basis. With Canonical, your service stays secure for up to 15 years with no need for major upgrades.
         </p>
       </div>
       <div class="p-equal-height-row__col">

--- a/templates/data/opensearch/what-is-opensearch.html
+++ b/templates/data/opensearch/what-is-opensearch.html
@@ -531,10 +531,10 @@
             <hr class="p-rule--muted" />
             <div class="p-section--shallow">
               <ul class="p-list--divided">
-                <li class="p-list__item is-ticked">Up to 10 years of OpenSearch support per release track</li>
+                <li class="p-list__item is-ticked">Up to 15 years of OpenSearch support per release track</li>
                 <li class="p-list__item is-ticked">24/7 or weekday phone and ticket support</li>
                 <li class="p-list__item is-ticked">
-                  Up to 10 years of security maintenance for OpenSearch covering critical and high
+                  Up to 15 years of security maintenance for OpenSearch covering critical and high
                   severity CVEs
                 </li>
               </ul>
@@ -564,10 +564,10 @@
             <hr class="p-rule--muted" />
             <div class="p-section--shallow">
               <ul class="p-list--divided">
-                <li class="p-list__item is-ticked">Up to 10 years of support per release track</li>
+                <li class="p-list__item is-ticked">Up to 15 years of support per release track</li>
                 <li class="p-list__item is-ticked">Same 24/7 or weekday phone and ticket support commitment</li>
                 <li class="p-list__item is-ticked">
-                  Same 10 years of security maintenance covering critical and high severity CVEs in the
+                  Same 15 years of security maintenance covering critical and high severity CVEs in the
                   image
                 </li>
               </ul>


### PR DESCRIPTION
## Done

- Updated 10 to 15 years on OpenSearch-related pages according to the following copydocs:
  - https://docs.google.com/document/d/1nVdoKoPrXw8lsvHEtMichlPNfxYU9Uj1zmKowcUXQ_w/edit?tab=t.0
  - https://docs.google.com/document/d/1p_dRRGsePAmoBNCZ-7wO6bUAUzxx8Nnr9NJqITMaVzo/edit?tab=t.0
  - https://docs.google.com/document/d/1ovtXv8RBybw-flvttyqWOzZivUryQMP34T1UGe90HlY/edit?tab=t.0 

## QA

- Open the [DEMO](__DEMO_URL__/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that all instances of 10 have been updated to 15

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36451
