### PR TITLE
new-page: ceph/support [WD-35847]

### DIFF
--- a/templates/ceph/support.html
+++ b/templates/ceph/support.html
@@ -1,0 +1,170 @@
+{% extends 'base_index.html' %}
+
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+{% from "_macros/vf_equal-heights.jinja" import vf_equal_heights %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+{% from "_macros/vf_data-spotlight.jinja" import vf_data_spotlight %}
+
+{% block title %}Canonical Ceph support{% endblock %}
+{% block body_class %}is-paper{% endblock %}
+
+{% block meta_description %}
+  Canonical is the leading managed Ceph provider, we build, support and manage Ceph clusters in any location.
+{% endblock meta_description %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1HFtvu3abhwL5ulgWZzZGpElJNqMVAW3qeeEs7APvZRA/edit?tab=t.jijjhiya0no5
+{% endblock meta_copydoc %}
+
+{% block content %}
+  {% call(slot) vf_hero(
+    title_text='Canonical Ceph support ',
+    subtitle_text='Design, deployment, <br /> and operational support',
+    layout='50/50',
+    is_split_on_medium=true
+  ) -%}
+    {%- if slot == 'description' -%}
+      <p>Canonical helps you adopt Ceph software defined storage, with a variety of options to suit your organization’s needs and available expertise. From fully managed services to 24/7/365 on-demand troubleshooting, get Ceph support with <a href="https://ubuntu.com/support">guaranteed SLAs</a> from a team of trusted experts.</p>
+      <p>Learn how the European Space Agency leverages Ceph, managed by Canonical, to support space missions. </p>
+    {%- endif -%}
+    {%- if slot == 'cta' -%}
+      <a href="#get-in-touch" class="p-button--positive" aria-label="contact-modal">Get in touch</a>
+      <a href="/case-study/esa" class="p-button" aria-label="case study">Access the case study</a>
+    {%- endif -%}
+    {%- if slot == 'image' -%}
+      <div class="p-image-container--3-2 is-highlighted is-cover u-hide--small">
+        {{ image(
+          url="https://assets.ubuntu.com/v1/b129e512-hero_img.jpg",
+          alt="",
+          width="1800",
+          height="1128",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-image-container__image"}
+        ) | safe }}
+      </div>
+    {%- endif -%}
+  {% endcall -%}
+
+  {%- call(slot) vf_tiered_list(
+    is_description_full_width_on_desktop=false,
+    is_list_full_width_on_tablet=true
+  ) -%}
+    {%- if slot == 'title' -%}
+      <h2>Services for Canonical Ceph</h2>
+    {%- endif -%}
+
+    {%- if slot == 'description' -%}
+      <p>
+        From the initial design and hardware selection, to ongoing software support and management, Canonical’s offerings cover all types of Ceph deployments on Ubuntu. Available 24/7/365, by telephone and ticket.
+      </p>
+      <p><a href="/ceph">Discover Canonical Ceph &rsaquo;</a></p>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_title_1' -%}
+      <h3 class="p-heading--5">Design and delivery</h3>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_description_1' -%}
+      <p>Canonical offers fixed price Ceph consulting packages. Our basic package gets your Ceph cluster up and running in a standardized configuration. Alternatively, for a tailored deployment architecture which meets your unique requirements, choose our plus offering.</p>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_title_2' -%}
+      <h3 class="p-heading--5">Support</h3>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_description_2' -%}
+      <p>24/7/365 on demand enterprise Ceph support. Get guaranteed SLAs, including knowledge base access, troubleshooting, and bug fixing, to ensure peace of mind for your Ceph deployments.</p>
+      <p><a href="https://ubuntu.com/support">Explore support &rsaquo;</a></p>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_title_3' -%}
+      <h3 class="p-heading--5">Managed services</h3>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_description_3' -%}
+      <p>Fully managed storage as a service, based on Ceph. Managed services covers operations and maintenance, with 24/7 monitoring, incident management, capacity planning, and upgrades.</p>
+      <p><a href="https://ubuntu.com/managed-infrastructure">Explore managed services &rsaquo;</a></p>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_title_4' -%}
+      <h3 class="p-heading--5">Firefighting support</h3>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_description_4' -%}
+      <p>Firefighting support offers a bridge between self-management with troubleshooting support, and a managed service. Get access to on-call engineers to assist with the most critical problems.</p>
+      <p><a href="https://ubuntu.com/managed/firefighting-support">Explore firefighting support &rsaquo;</a></p>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_title_5' -%}
+      <h3 class="p-heading--5">Security and compliance</h3>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_description_5' -%}
+      <p>Make your systems more secure and simplify compliance with Ubuntu Pro. Get up to 15 years of security maintenance for all artifacts used in Canonical Ceph.</p>
+      <p><a href="https://ubuntu.com/pro">Learn about Ubuntu Pro &rsaquo;</a></p>
+    {%- endif -%}
+  {%- endcall -%}
+
+  {{ vf_data_spotlight(
+    title={
+      "text": "Enterprise-grade Ceph support",
+    },
+    blocks=[
+      {
+        "stat": "1 hour",
+        "headline": "Response time SLA for severity 1 issues.",
+      },
+      {
+        "stat": "24/7/365",
+        "headline": "Access to phone and ticket support.",
+      },
+      {
+        "stat": "Up to 15 years",
+        "headline": "Security fixes and support with Ubuntu Pro.",
+      },
+    ],
+  ) }}
+
+  <section class="p-section">
+    {% call(slot) vf_equal_heights(
+      title_text="Cost-effective Ceph support",
+      attrs={"id": "4-columns-responsive"},
+      highlight_images=True,
+      items=[
+        {
+          "title_text": "Fixed price consulting",
+          "image_html": '<img src="https://assets.ubuntu.com/v1/818348a8-price.png" class="p-image-container__image" width="284" height="426" alt="" />',
+          "description_html": "<p>Get clarity from the beginning with our <a href='https://assets.ubuntu.com/v1/ef493e88-canonical_ceph_consulting_datasheet_11_09_2025.pdf'>fixed price packages</a>. Straightforward Ceph consulting: no surprises, no run-away costs.</p>",
+        },
+        {
+          "title_text": "Support subscription",
+          "image_html": '<img src="https://assets.ubuntu.com/v1/f9d7aa7b-subscription.png" class="p-image-container__image" width="284" height="426" alt="" />',
+          "description_html": "<p>Transparent support pricing on a per-node basis to keep your project costs predictable. Up to 384TB RAW storage for Ceph included.</p>",
+        },
+        {
+          "title_text": "Firefighting support",
+          "image_html": '<img src="https://assets.ubuntu.com/v1/716f7279-firefighting.png" class="p-image-container__image" width="284" height="426" alt="" />',
+          "description_html": "<p>Reduce the risk of business impact from critical maintenance activities by getting engineers on call to help you resolve any critical issues.</p>",
+        },
+        {
+          "title_text": "Managed Ceph",
+          "image_html": '<img src="https://assets.ubuntu.com/v1/c836fe3e-managed.png" class="p-image-container__image" width="284" height="426" alt="" />',
+          "description_html": "<p>Reduce operational complexity and treat storage as a service. Let Canonical's experts operate and maintain your Ceph cluster, filling knowledge gaps and freeing your engineering team to focus on your core business.</p>",
+        }
+      ]
+    ) %}
+      {% if slot == "description" %}
+        <div>
+          <p>Transparent pricing meets enterprise-grade Ceph support. Optimize your storage environment and get peace of mind over your deployments, without the premium overhead.</p>
+          <p>Try our <a href="https://ubuntu.com/ceph/pricing-calculator">S3 cost calculator</a> for an indication of the total cost of ownership (TCO) for Canonical Ceph across various capacities, in both fully managed and self-operated configurations, and for different project durations.</p>
+          <a class="p-button" href="#get-in-touch">Get in touch</a>
+        </div>
+      {% endif %}
+    {% endcall %}
+  </section>
+
+  {{ load_form("/ceph") | safe }}
+  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+  <script src="{{ versioned_static('js/in-page-navigation.js') }}"></script>
+{% endblock content %}


### PR DESCRIPTION
## Done

- [copy-doc](https://docs.google.com/document/d/1HFtvu3abhwL5ulgWZzZGpElJNqMVAW3qeeEs7APvZRA/edit?tab=t.jijjhiya0no5#heading=h.n7un9v779syf)
- [Figma](https://www.figma.com/design/d3yDJFcSFPv8baDTWnk0jR/canonical.com-ceph---Sites?node-id=1-10481)
- [Assets](https://assets.ubuntu.com/manager?tag=canonical-ceph-support-assets)
- The images at the end of the copy doc are wrong and we should use the ones in the Figma design (confirmed with designer)
- There are two links that will have to be changed before merging. The link will be available once [this](https://warthogs.atlassian.net/browse/WD-36247) is done

## QA

- Open the [DEMO](https://canonical-com-2512.demos.haus/ceph/support)
- **Navigate to /ceph/support**
- Alternatively, check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure the design follows the Figma design
- Make sure the page follows the copy-doc
- Also please check that the buttons open the contact modal correctly

## Issue / Card

Fixes #[WD-35847](https://warthogs.atlassian.net/browse/WD-35847)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-35847]: https://warthogs.atlassian.net/browse/WD-35847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ