### PR TITLE
refactor: /events/canonical-days

### DIFF
--- a/templates/events/canonical-days.html
+++ b/templates/events/canonical-days.html
@@ -61,14 +61,18 @@
         <thead>
           <tr>
             <th data-column="0" data-type="string">
+              <strong>Event Name</strong>
+              <button class="js-sortable-table__button p-icon--sort-both" aria-label="Sort by Event Name" style="border-style: none;"></button>
+            </th>
+            <th data-column="1" data-type="string">
               <strong>Location</strong>
               <button class="js-sortable-table__button p-icon--sort-both" aria-label="Sort by Location" style="border-style: none;"></button>
             </th>
-            <th data-column="1" data-type="string">
+            <th data-column="2" data-type="string">
               <strong>Region</strong>
               <button class="js-sortable-table__button p-icon--sort-both" aria-label="Sort by Region" style="border-style: none;"></button>
             </th>
-            <th data-column="2" data-type="date">
+            <th data-column="3" data-type="date">
               <strong>Date</strong>
               <button class="js-sortable-table__button p-icon--sort-both" aria-label="Sort by Date" style="border-style: none;"></button>
             </th>
@@ -81,6 +85,9 @@
             {% set ns.counter = ns.counter + 1 %}
             {% if ns.counter <= 10 or metadata | length < TRUNCATE_THRESHOLD %}
               <tr>
+                <td data-heading="Event Name">
+                  <a href="{{ data.path }}">{{ data.topic_name or '—' }}</a>
+                </td>
                 <td data-heading="Location">
                   <a href="{{ data.path }}">{{ data.event_location or '—' }}</a>
                 </td>


### PR DESCRIPTION
## Done
- Updated the /events/canonical-days page
- Added new 'Event name' column to the table
- **NOTE**: the 'Show all events' button works as expected. It is only displayed when the number of events exceed 4.

## QA
- Open the demo
- Navigate to the [/events/canonical-days](https://canonical-com-2518.demos.haus/events/canonical-days) page
- Click on different elements on the table
- Ensure they all function as expected
- Ensure the design matches the [figma](https://www.figma.com/design/zQpiTIblf61FpLDo7Uc6BH/Canonical.com-events-and-roadshows?node-id=4756-6560&m=dev#1741566740) doc

## Issue / Card
https://warthogs.atlassian.net/browse/WD-36239

## Screenshots
<img width="1744" height="715" alt="image" src="https://github.com/user-attachments/assets/0a2dbc50-96ae-4f34-b81f-e61c98a43afc" />


