### PR TITLE
Fix TICS violations (scan 4)

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1446,7 +1446,7 @@ def handle_maas_goget():
 def bad_gateway(e):
     prefix = "502 Bad Gateway: "
     if str(e).find(prefix) != -1:
-        message = str(e)[len(prefix) :]
+        message = str(e)[len(prefix):]
     return flask.render_template("502.html", message=message), 502
 
 

--- a/webapp/navigation.py
+++ b/webapp/navigation.py
@@ -114,7 +114,7 @@ def split_list(array, parts):
 
     k, m = divmod(len(array), parts)
     return [
-        array[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)]
+        array[i * k + min(i, m): (i + 1) * k + min(i + 1, m)]
         for i in range(parts)
     ]
 


### PR DESCRIPTION
## TIOBE TICS Auto-Fix

This PR automatically fixes **2** TICS violations.

### Summary by Category

| Category | Fixed |
|----------|-------|
| Coding Standards | 2 |

### Changes

- **`webapp/app.py`** (L1449): whitespace before ':'
  - Rule: `E203` | Source: flake8
- **`webapp/navigation.py`** (L117): whitespace before ':'
  - Rule: `E203` | Source: flake8

---
*Generated by TiobeFix — verify before merging*
