### PR TITLE
fix: add SRIs to scripts

### DIFF
--- a/templates/anbox-cloud/index.html
+++ b/templates/anbox-cloud/index.html
@@ -12,7 +12,9 @@
 
 {% block extra_metatags %}
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block body_class %}

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -108,6 +108,8 @@
                 crossorigin />
 
           <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js"
+                  integrity="sha384-TI/T2gDQjjlI4xuVcADfKuha0uICGVNowMXFblCWGz6MMkwVNIEuc59dlu6rQuNE"
+                  crossorigin="anonymous"
                   defer></script>
 
           <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}" />

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -108,8 +108,6 @@
                 crossorigin />
 
           <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js"
-                  integrity="sha384-TI/T2gDQjjlI4xuVcADfKuha0uICGVNowMXFblCWGz6MMkwVNIEuc59dlu6rQuNE"
-                  crossorigin="anonymous"
                   defer></script>
 
           <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}" />

--- a/templates/careers/_base-department.html
+++ b/templates/careers/_base-department.html
@@ -207,4 +207,7 @@
   {% include custom_blog_section %}
 {% endif %}
 
-<script async defer src="https://buttons.github.io/buttons.js"></script>
+<script async defer
+        src="https://cdn.jsdelivr.net/npm/github-buttons@2.32.0/dist/buttons.min.js"
+        integrity="sha384-ZhcuGDV+Yp73dqAwwf9TcmQydIjkGkv+3oJxfQFaadDitRkt+COogTczHw8CTFgH"
+        crossorigin="anonymous"></script>

--- a/templates/careers/company-culture/progression.html
+++ b/templates/careers/company-culture/progression.html
@@ -395,5 +395,7 @@
   <script type="text/javascript"
           src="{{ versioned_static('js/careers-progression.js') }}"></script>
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock %}

--- a/templates/careers/hiring-process/index.html
+++ b/templates/careers/hiring-process/index.html
@@ -14,7 +14,9 @@
 
 {% block extra_metatags %}
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block body_class %}

--- a/templates/company/index.html
+++ b/templates/company/index.html
@@ -389,6 +389,8 @@
   <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCiUVShD6fwLGQ8_iF-sCclFkVQFCsazxc&callback=initMap&v=weekly"
           defer></script>
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 
 {% endblock %}

--- a/templates/data/spark/index.html
+++ b/templates/data/spark/index.html
@@ -405,5 +405,7 @@
   {{ load_form("/data/spark") | safe }}
 
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock %}

--- a/templates/dqlite/index.html
+++ b/templates/dqlite/index.html
@@ -203,5 +203,8 @@
     </div>
   </section>
 
-  <script async defer src="https://buttons.github.io/buttons.js"></script>
+  <script async defer
+          src="https://cdn.jsdelivr.net/npm/github-buttons@2.32.0/dist/buttons.min.js"
+          integrity="sha384-ZhcuGDV+Yp73dqAwwf9TcmQydIjkGkv+3oJxfQFaadDitRkt+COogTczHw8CTFgH"
+          crossorigin="anonymous"></script>
 {% endblock content %}

--- a/templates/jaas/index.html
+++ b/templates/jaas/index.html
@@ -721,6 +721,9 @@
   {{ load_form("/jaas") | safe }}
 
   <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
-  <script async defer src="https://buttons.github.io/buttons.js"></script>
+  <script async defer
+          src="https://cdn.jsdelivr.net/npm/github-buttons@2.32.0/dist/buttons.min.js"
+          integrity="sha384-ZhcuGDV+Yp73dqAwwf9TcmQydIjkGkv+3oJxfQFaadDitRkt+COogTczHw8CTFgH"
+          crossorigin="anonymous"></script>
 
 {% endblock content %}

--- a/templates/juju/index.html
+++ b/templates/juju/index.html
@@ -1221,5 +1221,8 @@
   {{ load_form("/juju") | safe }}
 
   <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
-  <script async defer src="https://buttons.github.io/buttons.js"></script>
+  <script async defer
+          src="https://cdn.jsdelivr.net/npm/github-buttons@2.32.0/dist/buttons.min.js"
+          integrity="sha384-ZhcuGDV+Yp73dqAwwf9TcmQydIjkGkv+3oJxfQFaadDitRkt+COogTczHw8CTFgH"
+          crossorigin="anonymous"></script>
 {% endblock %}

--- a/templates/knowledge/_base_knowledge_markdown.html
+++ b/templates/knowledge/_base_knowledge_markdown.html
@@ -134,7 +134,10 @@
       {% endif %}
     })
   </script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+  <script type="module"
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
   
   {% endblock %}
 

--- a/templates/maas/index.html
+++ b/templates/maas/index.html
@@ -779,5 +779,7 @@
   {{ load_form("/maas") | safe }}
 
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock %}

--- a/templates/microcloud/index.html
+++ b/templates/microcloud/index.html
@@ -503,7 +503,9 @@
   <script src="/static/js/typer.js" defer></script>
   <script defer src="{{ versioned_static('js/modals.js') }}"></script>
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 
   {{ load_form("/microcloud") | safe }}
 

--- a/templates/microk8s/index.html
+++ b/templates/microk8s/index.html
@@ -470,7 +470,10 @@
 
   {{ load_form("/microk8s") | safe }}
 
-  <script async defer src="https://buttons.github.io/buttons.js"></script>
+  <script async defer
+          src="https://cdn.jsdelivr.net/npm/github-buttons@2.32.0/dist/buttons.min.js"
+          integrity="sha384-ZhcuGDV+Yp73dqAwwf9TcmQydIjkGkv+3oJxfQFaadDitRkt+COogTczHw8CTFgH"
+          crossorigin="anonymous"></script>
   <script src="{{ versioned_static('js/tabbed-content.js') }}"></script>
   <script defer src="{{ versioned_static('js/modals.js') }}"></script>
 

--- a/templates/mir/index.html
+++ b/templates/mir/index.html
@@ -367,5 +367,8 @@
 
   {{ load_form("/mir") | safe }}
 
-  <script async defer src="https://buttons.github.io/buttons.js"></script>
+  <script async defer
+          src="https://cdn.jsdelivr.net/npm/github-buttons@2.32.0/dist/buttons.min.js"
+          integrity="sha384-ZhcuGDV+Yp73dqAwwf9TcmQydIjkGkv+3oJxfQFaadDitRkt+COogTczHw8CTFgH"
+          crossorigin="anonymous"></script>
 {% endblock %}

--- a/templates/public-sector/index.html
+++ b/templates/public-sector/index.html
@@ -26,7 +26,9 @@
 
 {% block extra_metatags %}
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/templates/solutions/automotive/index.html
+++ b/templates/solutions/automotive/index.html
@@ -20,7 +20,9 @@
 
 {% block extra_metatags %}
     <script type="module"
-            src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+            src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+            integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+            crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/templates/solutions/financial-services/index.html
+++ b/templates/solutions/financial-services/index.html
@@ -19,7 +19,9 @@
 
 {% block extra_metatags %}
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/templates/solutions/infrastructure/virtualization-solutions/index.html
+++ b/templates/solutions/infrastructure/virtualization-solutions/index.html
@@ -26,7 +26,9 @@ Canonical's open source virtualization solutions scale from a single laptop to m
 
 {% block extra_metatags %}
   <script type="module"
-          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -66,6 +66,7 @@ CSP = {
         "www.google-analytics.com",
         "*.crazyegg.com",
         "*.g.doubleclick.net",
+        "www.googleadservices.com",
         "js.zi-scripts.com",
         "*.google-analytics.com",
         "px.ads.linkedin.com",


### PR DESCRIPTION
## Done
- Added cryptographic hashes for SRI to relevant scripts
- Switched to [jsDelivr](https://www.jsdelivr.com/) for the github buttons package to implement fixed versioning.
- **Note**: the `asciinema` script was left alone since there's no way to implement fixed versioning for it.

## QA

- Open the [DEMO](https://canonical-com-2531.demos.haus/)
- Review the relevant (updated) pages for breaking changes 
- Ensure the cryptographic hashes generated for each script matches your own generated hash using sha384.

## Issue / Card
https://warthogs.atlassian.net/browse/WD-36599
