### PR TITLE
fix(ceph): change spotlight blocks from headline to description style

### DIFF
--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -82,15 +82,15 @@
     blocks=[
       {
         "stat": "10+",
-        "headline": "Years"
+        "description": "Years"
       },
       {
         "stat": "1,000,000+",
-        "headline": "Downloads"
+        "description": "Downloads"
       },
       {
         "stat": "1 minute",
-        "headline": "To get started"
+        "description": "To get started"
       }
     ]
   ) }}


### PR DESCRIPTION
## Done

The `vf_data_spotlight` blocks for the "Canonical Ceph: Proven and Trusted" section were using headline instead of description for the labels, these fields have been updated to use description.
The headline field renders as p-heading--3 (header style), while description renders as a plain `<p>` (body text), which is the correct style as shown in the equivalent section on /openstack/support (please see the ticket for more information and context).

## QA

- Open the [DEMO](https://canonical-com-2534.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/ceph
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card
https://warthogs.atlassian.net/browse/WD-36640

## Screenshots

<img width="1432" height="225" alt="image" src="https://github.com/user-attachments/assets/b884d038-654b-481e-b938-e0a22df8df2b" />



[WD-36640]: https://warthogs.atlassian.net/browse/WD-36640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ