### PR TITLE
ci: grant packages:write to publish-image job

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -87,6 +87,9 @@ jobs:
   publish-image:
     runs-on: ubuntu-latest
     needs: pack-rock
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image_url: ${{ steps.set_image_url.outputs.image_url }}
     steps:


### PR DESCRIPTION
## Done
- Added permissions: packages: write to the publish-image job in .github/workflows/deploy.yaml so GITHUB_TOKEN can push images to ghcr.io/canonical/canonical.com.

## QA
- This change only affects the deploy workflow; it cannot be QA'd locally.
- Verify by watching the next run of the Deploy workflow on main (or via workflow_dispatch). The publish-image job's Push to GHCR step should succeed instead of failing with denied: installation not allowed to Write organization package.

