### PR TITLE
fix: add CSP nonce setup and apply nonces to inline scripts

### DIFF
--- a/templates/academy/exam-content/index.html
+++ b/templates/academy/exam-content/index.html
@@ -87,7 +87,7 @@
       </div>
     </div>
   </section>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var keys = {
         left: 'ArrowLeft',

--- a/templates/academy/exam-guide.html
+++ b/templates/academy/exam-guide.html
@@ -1026,7 +1026,7 @@ body_class %}
   </div>
 </section>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   /**
     Toggles the necessary aria- attributes' values on the accordion panels
     and handles to show or hide them.

--- a/templates/academy/self-study.html
+++ b/templates/academy/self-study.html
@@ -488,7 +488,7 @@
       </div>
     </div>
   </section>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const setupTabs = () => {
       var keys = {
         left: 'ArrowLeft',

--- a/templates/anbox-cloud/index.html
+++ b/templates/anbox-cloud/index.html
@@ -14,7 +14,7 @@
   <script type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 {% endblock extra_metatags %}
 
 {% block body_class %}

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -60,7 +60,7 @@
 
           {% set current_path = url_for(request.endpoint, **request.view_args) %}
           {% if "/careers" in current_path %}
-            <script src="https://www.google.com/recaptcha/enterprise.js?render={{ recaptcha_site_key }}" defer></script>
+            <script src="https://www.google.com/recaptcha/enterprise.js?render={{ recaptcha_site_key }}" defer nonce="{{ csp_nonce }}"></script>
             <meta name="twitter:image"
                   content="https://assets.ubuntu.com/v1/c17ef7b4-careers-meta-image-resized.png" />
             <meta property="og:image"
@@ -108,7 +108,7 @@
                 crossorigin />
 
           <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js"
-                  defer></script>
+                  defer nonce="{{ csp_nonce }}"></script>
 
           <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}" />
         </head>
@@ -136,9 +136,9 @@
             {% include 'partial/_footer.html' %}
           {% endblock footer %}
 
-          <script defer src="{{ versioned_static('js/dist/navigation.js') }}"></script>
-          <script src="{{ versioned_static('js/dist/forms.js') }}"></script>
-          <script>
+          <script defer src="{{ versioned_static('js/dist/navigation.js') }}" nonce="{{ csp_nonce }}"></script>
+          <script src="{{ versioned_static('js/dist/forms.js') }}" nonce="{{ csp_nonce }}"></script>
+          <script nonce="{{ csp_nonce }}">
             (function() {
               // Form submission notification
               var bannerElements = ["#success", "#newsletter-signup", "#contact-form-success", "#contact-form-fail"];
@@ -162,12 +162,12 @@
           </script>
           
           <!-- Cookie policy -->
-          <script src="{{ versioned_static('js/modules/cookie-policy/cookie-loader.js') }}"></script>
-          <script src="{{ versioned_static('js/dist/cookie-policy-with-callback.js') }}"></script>
-          <script src="{{ versioned_static('js/dist/watch-consent-changes.js') }}"></script>
+          <script src="{{ versioned_static('js/modules/cookie-policy/cookie-loader.js') }}" nonce="{{ csp_nonce }}"></script>
+          <script src="{{ versioned_static('js/dist/cookie-policy-with-callback.js') }}" nonce="{{ csp_nonce }}"></script>
+          <script src="{{ versioned_static('js/dist/watch-consent-changes.js') }}" nonce="{{ csp_nonce }}"></script>
 
            <!-- Google Tag Manager -->
-          <script>
+          <script nonce="{{ csp_nonce }}">
             document.addEventListener('DOMContentLoaded', () => {
               /** init gtm after 2 seconds - can be adjusted */
               setTimeout(initGTM, 2000);

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -24,7 +24,7 @@
 
 {% block extra_metatags %}
   {# djlint: off #}
-  <script type="application/ld+json">
+  <script type="application/ld+json" nonce="{{ csp_nonce }}">
     {
       "@context": "http://schema.org",
       "@id": "https://canonical.com/#article",

--- a/templates/blog/filters.html
+++ b/templates/blog/filters.html
@@ -17,7 +17,7 @@
   </div>
 </form>
   
-<script>
+<script nonce="{{ csp_nonce }}">
   var select = document.querySelector('.js-submit-on-change');
   select.addEventListener('change', function(e) {
     var form = this.closest('form');

--- a/templates/careers/_base-department.html
+++ b/templates/careers/_base-department.html
@@ -187,9 +187,9 @@
           </div>
         </article>
       </template>
-      <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
+      <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}" nonce="{{ csp_nonce }}"></script>
       {# djlint: off #}
-      <script>
+      <script nonce="{{ csp_nonce }}">
         canonicalLatestNews.fetchLatestNews({
           articlesContainerSelector: "#latest-articles",
           articleTemplateSelector: "#articles-template",
@@ -210,4 +210,4 @@
 <script async defer
         src="https://cdn.jsdelivr.net/npm/github-buttons@2.32.0/dist/buttons.min.js"
         integrity="sha384-ZhcuGDV+Yp73dqAwwf9TcmQydIjkGkv+3oJxfQFaadDitRkt+COogTczHw8CTFgH"
-        crossorigin="anonymous"></script>
+        crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>

--- a/templates/careers/_search.html
+++ b/templates/careers/_search.html
@@ -16,8 +16,8 @@
     <button type="submit"  alt="search roles" class="p-button--positive" style="white-space: nowrap; border: none;">Search roles</button>
   </form>
 </div>
-<script src="{{ versioned_static('js/modules/fuse/fuse.js') }}"></script>
-<script type="text/javascript">
+<script src="{{ versioned_static('js/modules/fuse/fuse.js') }}" nonce="{{ csp_nonce }}"></script>
+<script type="text/javascript" nonce="{{ csp_nonce }}">
   window.addEventListener('DOMContentLoaded', (event) => {
     const searchInput = document.querySelector(".js-careers__search-input");
     const urlParams = new URLSearchParams(window.location.search);

--- a/templates/careers/all.html
+++ b/templates/careers/all.html
@@ -23,6 +23,6 @@
 
 {% block careers_content %}
   {% include 'partial/_careers-available-roles.html' %}
-	<script defer src="{{ versioned_static('js/careers-filter-and-sort.js') }}"></script>
-	<script defer src="{{ versioned_static('js/file-validation.js') }}"></script>
+	<script defer src="{{ versioned_static('js/careers-filter-and-sort.js') }}" nonce="{{ csp_nonce }}"></script>
+	<script defer src="{{ versioned_static('js/file-validation.js') }}" nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/careers/application/_interview-card.html
+++ b/templates/careers/application/_interview-card.html
@@ -11,7 +11,7 @@
       {% endif %}
   {% endif %}
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
   const interviewTime = new Date("{{ interview["start"]["datetime"] }}");
   const userTime = interviewTime.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
   const offset = -(interviewTime.getTimezoneOffset() / 60)

--- a/templates/careers/application/_withdrawal-form.html
+++ b/templates/careers/application/_withdrawal-form.html
@@ -13,7 +13,7 @@
           <label for="email">Email address</label>
           <input required type="email" id="email" name="email" placeholder="example@canonical.com" autocomplete="email"/>
           <label for="textarea">Reason you wish to withdraw your application</label>
-          <select name="withdrawal-reason" id="withdrawal-reason" onchange="showInput()" required>
+          <select name="withdrawal-reason" id="withdrawal-reason" required>
               <option value="" disabled="disabled" selected="">Select</option>
             {% for reason_id, reason_message in withdrawal_reasons.items() %}
               <option value="{{ reason_id }}">{{ reason_message }}</option>

--- a/templates/careers/application/faq.html
+++ b/templates/careers/application/faq.html
@@ -316,7 +316,7 @@
     </ol>
   </div>
 </section>
-<script>
+<script nonce="{{ csp_nonce }}">
       /**
   Toggles the necessary aria- attributes' values on the accordion panels
   and handles to show or hide them.

--- a/templates/careers/application/index.html
+++ b/templates/careers/application/index.html
@@ -7,7 +7,7 @@
 {% block extra_metatags %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function showProgressDetail(stage) {
       const showMoreBtn = document.querySelector(`.show-more-${stage}`);
       const showLessBtn = document.querySelector(`.show-less-${stage}`);
@@ -330,19 +330,22 @@
     </section>
   {% endif %}
 
-  <script>
-    function showInput() {
-      const selectValue = document.getElementById('withdrawal-reason').value;
-      const withdrawalReasonOther = document.getElementById('withdrawal-reason-other');
-      const otherInput = document.querySelector('.other-input')
-      if (selectValue === "33") {
-        otherInput.style.display = "block";
-        withdrawalReasonOther.setAttribute("required", "true")
-      } else {
-        otherInput.style.display = "none";
-        withdrawalReasonOther.removeAttribute("required")
-      }
-    }
+  <script nonce="{{ csp_nonce }}">
+    (function () {
+      const withdrawalReason = document.getElementById('withdrawal-reason');
+      if (!withdrawalReason) return;
+      withdrawalReason.addEventListener('change', function () {
+        const withdrawalReasonOther = document.getElementById('withdrawal-reason-other');
+        const otherInput = document.querySelector('.other-input');
+        if (withdrawalReason.value === "33") {
+          otherInput.style.display = "block";
+          withdrawalReasonOther.setAttribute("required", "true");
+        } else {
+          otherInput.style.display = "none";
+          withdrawalReasonOther.removeAttribute("required");
+        }
+      });
+    })();
 
     (function() {
 

--- a/templates/careers/application/partial/_feedback.html
+++ b/templates/careers/application/partial/_feedback.html
@@ -88,7 +88,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   const tutorialFeedbackOptions = document.querySelector(
   ".l-tutorial__feedback-options"
 );

--- a/templates/careers/base_job-details.html
+++ b/templates/careers/base_job-details.html
@@ -30,7 +30,7 @@
 
 
 
-<script>
+<script nonce="{{ csp_nonce }}">
   const applyButton = document.getElementById("apply-button");
   const backRoles = document.getElementById("back-roles");
   const backDetails = document.getElementById("back-details");

--- a/templates/careers/career-explorer.html
+++ b/templates/careers/career-explorer.html
@@ -11,5 +11,5 @@
 {% block content %}
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
-  <script defer src="{{ versioned_static('js/dist/careerExplorer.js') }}"></script>
+  <script defer src="{{ versioned_static('js/dist/careerExplorer.js') }}" nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/careers/company-culture/progression.html
+++ b/templates/careers/company-culture/progression.html
@@ -393,9 +393,9 @@
   {% endif %}
 
   <script type="text/javascript"
-          src="{{ versioned_static('js/careers-progression.js') }}"></script>
+          src="{{ versioned_static('js/careers-progression.js') }}" nonce="{{ csp_nonce }}"></script>
   <script type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/careers/company-culture/remote-work.html
+++ b/templates/careers/company-culture/remote-work.html
@@ -418,11 +418,11 @@
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/modules/leaflet/leaflet.js') }}"></script>
+  <script src="{{ versioned_static('js/modules/leaflet/leaflet.js') }}" nonce="{{ csp_nonce }}"></script>
 
-  <script src="{{ versioned_static('js/modules/flickity/flickity.pkgd.min.js') }}"></script>
+  <script src="{{ versioned_static('js/modules/flickity/flickity.pkgd.min.js') }}" nonce="{{ csp_nonce }}"></script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     initCarousel('#carousel_target', '#carousel-next', '#carousel-previous');
     initMap("locations-map");
 

--- a/templates/careers/hiring-process/index.html
+++ b/templates/careers/hiring-process/index.html
@@ -16,7 +16,7 @@
   <script type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 {% endblock extra_metatags %}
 
 {% block body_class %}
@@ -349,6 +349,6 @@
       </div>
     </div>
   </section>
-  <script src="{{ versioned_static('js/tabbed-content.js') }}"></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" nonce="{{ csp_nonce }}"></script>
 
 {% endblock %}

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -16,7 +16,7 @@
 
 {% block content %}
   <!-- StackOverflow ad tracking pixel -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var a = String(Math.floor(Math.random() * 10000000000000000));
       new Image().src = "https://pubads.g.doubleclick.net/activity;xsp=5024608;ord=" + a + "?";
@@ -186,6 +186,6 @@
     </div>
   </section>
 
-  <script defer src="{{ versioned_static('js/careers-filter-and-sort.js') }}"></script>
+  <script defer src="{{ versioned_static('js/careers-filter-and-sort.js') }}" nonce="{{ csp_nonce }}"></script>
 
 {% endblock %}

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -11,7 +11,7 @@
 {% block extra_metatags %}
 <link rel="alternate" type="application/rss+xml"  href="/careers/feed" title="All job roles | Canonical Careers"/>
 
-<script type="application/ld+json">
+<script type="application/ld+json" nonce="{{ csp_nonce }}">
   {
     "@context" : "https://schema.org/",
     "@type" : "JobPosting",
@@ -131,7 +131,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   (function () {
     const formEl = document.getElementById("job-apply-form");
     if (!formEl) {
@@ -196,11 +196,11 @@
   })();
 </script>
 
-<script defer>
+<script defer nonce="{{ csp_nonce }}">
     document.querySelectorAll('a[href*="legal"]').forEach(function (a) {
       a.setAttribute('target', '_blank');
     })
 </script>
 
-<script defer src="{{ versioned_static('js/file-validation.js') }}"></script>
+<script defer src="{{ versioned_static('js/file-validation.js') }}" nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/case-study/index.html
+++ b/templates/case-study/index.html
@@ -97,7 +97,7 @@
   </section>
 {% endif %}
 
-<script>
+<script nonce="{{ csp_nonce }}">
   function clearFilters() {
     window.location.assign("/case-study");
   }

--- a/templates/ceph/_blog.html
+++ b/templates/ceph/_blog.html
@@ -20,9 +20,9 @@
   </template>
 </section>
 
-<script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
+<script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}" nonce="{{ csp_nonce }}"></script>
 {# djlint:off #}
-<script>
+<script nonce="{{ csp_nonce }}">
   canonicalLatestNews.fetchLatestNews({
     articlesContainerSelector: "#ceph-latest",
     articleTemplateSelector: "#ceph-latest-template",

--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -82,15 +82,15 @@
     blocks=[
       {
         "stat": "10+",
-        "description": "Years"
+        "headline": "Years"
       },
       {
         "stat": "1,000,000+",
-        "description": "Downloads"
+        "headline": "Downloads"
       },
       {
         "stat": "1 minute",
-        "description": "To get started"
+        "headline": "To get started"
       }
     ]
   ) }}
@@ -406,6 +406,6 @@
   {% include "ceph/_blog.html" %}
 
 {{ load_form("/ceph") | safe }}
-<script defer src="{{ versioned_static('js/modals.js') }}"></script>
-<script src="{{ versioned_static('js/in-page-navigation.js') }}"></script>
+<script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
+<script src="{{ versioned_static('js/in-page-navigation.js') }}" nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/ceph/support.html
+++ b/templates/ceph/support.html
@@ -165,6 +165,6 @@
   </section>
 
   {{ load_form("/ceph") | safe }}
-  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
-  <script src="{{ versioned_static('js/in-page-navigation.js') }}"></script>
+  <script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script src="{{ versioned_static('js/in-page-navigation.js') }}" nonce="{{ csp_nonce }}"></script>
 {% endblock content %}

--- a/templates/cloud-marketplace/index.html
+++ b/templates/cloud-marketplace/index.html
@@ -689,6 +689,6 @@
 
   {{ load_form("/cloud-marketplace") | safe }}
 
-  <script defer src="{{ versioned_static('js/tabbed-content.js') }}"></script>
-  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
+  <script defer src="{{ versioned_static('js/tabbed-content.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js" nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/company/index.html
+++ b/templates/company/index.html
@@ -352,7 +352,7 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const locations = [
       [{
         "lat": 51.5043601,
@@ -385,12 +385,12 @@
     ]
     const isSprintMap = false;
   </script>
-  <script defer src="{{ versioned_static('js/locations-map.js') }}"></script>
+  <script defer src="{{ versioned_static('js/locations-map.js') }}" nonce="{{ csp_nonce }}"></script>
   <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCiUVShD6fwLGQ8_iF-sCclFkVQFCsazxc&callback=initMap&v=weekly"
-          defer></script>
+          defer nonce="{{ csp_nonce }}"></script>
   <script type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 
 {% endblock %}

--- a/templates/consulting/index.html
+++ b/templates/consulting/index.html
@@ -505,6 +505,6 @@
 
   {{ load_form("/consulting") | safe }}
 
-  <script src="{{ versioned_static('js/tabbed-content.js') }}"></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" nonce="{{ csp_nonce }}"></script>
 
 {% endblock %}

--- a/templates/data/index.html
+++ b/templates/data/index.html
@@ -625,7 +625,7 @@
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/tabbed-content.js') }}"></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" nonce="{{ csp_nonce }}"></script>
 
   {{ load_form("/data") | safe }}
 

--- a/templates/data/spark/index.html
+++ b/templates/data/spark/index.html
@@ -407,5 +407,5 @@
   <script type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/data/spark/support.html
+++ b/templates/data/spark/support.html
@@ -463,7 +463,7 @@
       </div>
     </div>
   </section>
-  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+  <script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
 
   {{ load_form("/data/spark/support") | safe }}
 

--- a/templates/docs/shared/_docs.html
+++ b/templates/docs/shared/_docs.html
@@ -192,7 +192,7 @@
     </div>
   </div>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // Allows the 'onchange' listener to be used on a select field, while still being accessible.
     (function() {
       var selectField = document.querySelector("#version-select");
@@ -242,9 +242,9 @@
       }
     }
   </script>
-  <script src="{{ versioned_static('js/side-navigation.js') }}"></script>
-  <script src="{{ versioned_static('js/modules/discourse-rad-parser/discourse-rad-parser.js')}}"></script>
-  <script>
+  <script src="{{ versioned_static('js/side-navigation.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script src="{{ versioned_static('js/modules/discourse-rad-parser/discourse-rad-parser.js')}}" nonce="{{ csp_nonce }}"></script>
+  <script nonce="{{ csp_nonce }}">
     drpNs.DiscourseRADParser();
   </script>
 {% endblock %}

--- a/templates/documentation/documentation-layout.html
+++ b/templates/documentation/documentation-layout.html
@@ -10,6 +10,6 @@
 
   {% block documentation_content %} {% endblock %}
 
-  <script src="{{ versioned_static('js/dist/active-nav-scroll.js') }}"></script>
+  <script src="{{ versioned_static('js/dist/active-nav-scroll.js') }}" nonce="{{ csp_nonce }}"></script>
   
 {% endblock %}

--- a/templates/dqlite/index.html
+++ b/templates/dqlite/index.html
@@ -206,5 +206,5 @@
   <script async defer
           src="https://cdn.jsdelivr.net/npm/github-buttons@2.32.0/dist/buttons.min.js"
           integrity="sha384-ZhcuGDV+Yp73dqAwwf9TcmQydIjkGkv+3oJxfQFaadDitRkt+COogTczHw8CTFgH"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 {% endblock content %}

--- a/templates/events/canonical-days.html
+++ b/templates/events/canonical-days.html
@@ -212,5 +212,5 @@
     ])
   }}
 
-  <script src="/static/js/dist/events.js"></script>
+  <script src="/static/js/dist/events.js" nonce="{{ csp_nonce }}"></script>
 {% endblock content %}

--- a/templates/events/index.html
+++ b/templates/events/index.html
@@ -180,5 +180,5 @@
     </div>
   </section>
 
-  <script src="/static/js/dist/events.js"></script>
+  <script src="/static/js/dist/events.js" nonce="{{ csp_nonce }}"></script>
 {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,7 +38,7 @@
 {% endblock body_class %}
 
 {% block content %}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // adds js-enabled to the body to show some elements
     document.body.classList.add('js-enabled');
     // adds aria-selected & aria-hidden to 
@@ -53,7 +53,7 @@
       });
     });
   </script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var a = String(Math.floor(Math.random() * 10000000000000000));
       new Image().src = 'https://pubads.g.doubleclick.net/activity;xsp=4822915;ord=' + a + '?';
@@ -1465,10 +1465,10 @@
   </section>
 
   {{ load_form("/") | safe }}
-  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
-  <script src="{{ versioned_static('js/dist/homepage_carousel.js') }}"></script>
-  <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
-  <script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer nonce="{{ csp_nonce }}"></script>
+  <script src="{{ versioned_static('js/dist/homepage_carousel.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script nonce="{{ csp_nonce }}">
     function loadScript(url) {
       const script = document.createElement('script');
       script.src = url;
@@ -1501,7 +1501,7 @@
   </script>
 
   {# djlint: off #}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#latest-articles",
       articleTemplateSelector: "#articles-template",

--- a/templates/jaas/index.html
+++ b/templates/jaas/index.html
@@ -720,10 +720,10 @@
 
   {{ load_form("/jaas") | safe }}
 
-  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer nonce="{{ csp_nonce }}"></script>
   <script async defer
           src="https://cdn.jsdelivr.net/npm/github-buttons@2.32.0/dist/buttons.min.js"
           integrity="sha384-ZhcuGDV+Yp73dqAwwf9TcmQydIjkGkv+3oJxfQFaadDitRkt+COogTczHw8CTFgH"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 
 {% endblock content %}

--- a/templates/juju/charmhub-community.html
+++ b/templates/juju/charmhub-community.html
@@ -396,5 +396,5 @@
   {% endcall -%}
 
   {{ load_form("/juju") | safe }}
-  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/juju/docs/search.html
+++ b/templates/juju/docs/search.html
@@ -58,7 +58,7 @@
             </li>
           {% endfor %}
         </ul>
-        <button id="load-more-button" class="p-button" onclick="loadMoreResults()">Load more results</button>
+        <button id="load-more-button" class="p-button">Load more results</button>
       </div>
     </section>
   {% else %}
@@ -91,14 +91,13 @@
     </section>
   {% endif %}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener("DOMContentLoaded", function() {
       let visibleResults = 10;
       const loadMoreButton = document.getElementById("load-more-button");
+      if (!loadMoreButton) return;
 
-      window.loadMoreResults = function() {
-        if (!loadMoreButton) return;
-
+      loadMoreButton.addEventListener("click", function () {
         loadMoreButton.innerText = "Loading...";
         loadMoreButton.disabled = true;
 
@@ -119,7 +118,7 @@
             loadMoreButton.disabled = false;
           }
         }, 500);
-      };
+      });
     });
   </script>
 {% endblock content %}

--- a/templates/juju/index.html
+++ b/templates/juju/index.html
@@ -1220,9 +1220,9 @@
 
   {{ load_form("/juju") | safe }}
 
-  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer nonce="{{ csp_nonce }}"></script>
   <script async defer
           src="https://cdn.jsdelivr.net/npm/github-buttons@2.32.0/dist/buttons.min.js"
           integrity="sha384-ZhcuGDV+Yp73dqAwwf9TcmQydIjkGkv+3oJxfQFaadDitRkt+COogTczHw8CTFgH"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/juju/juju-architecture.html
+++ b/templates/juju/juju-architecture.html
@@ -418,5 +418,5 @@
         {%- endif -%}
     {%- endcall -%}
 
-    <script src="{{ versioned_static('js/tabbed-content.js') }}"></script>
+    <script src="{{ versioned_static('js/tabbed-content.js') }}" nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/knowledge/_base_knowledge_markdown.html
+++ b/templates/knowledge/_base_knowledge_markdown.html
@@ -120,9 +120,9 @@
     })
   }}
   
-  <script src="{{ versioned_static('js/in-page-navigation.js') }}"></script>
-  <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
-  <script>
+  <script src="{{ versioned_static('js/in-page-navigation.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       imageClasses: ["p-image-container__image"],
       limit: "4",
@@ -137,7 +137,7 @@
   <script type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
   
   {% endblock %}
 

--- a/templates/knowledge/index.html
+++ b/templates/knowledge/index.html
@@ -84,7 +84,7 @@
       </div>
     </section>
 
-  <script src="{{ versioned_static('js/in-page-navigation.js') }}"></script>
+  <script src="{{ versioned_static('js/in-page-navigation.js') }}" nonce="{{ csp_nonce }}"></script>
 
   {% endblock %}
 {% endblock %}

--- a/templates/legal/_base_legal_markdown.html
+++ b/templates/legal/_base_legal_markdown.html
@@ -40,7 +40,7 @@
               <nav class="p-table-of-contents__nav" aria-label="Table of contents" id="table-of-contents"></nav>
             </div>
           </div>
-          <script src="{{ versioned_static('js/dist/table-of-contents.js') }}" defer></script>
+          <script src="{{ versioned_static('js/dist/table-of-contents.js') }}" defer nonce="{{ csp_nonce }}"></script>
         </div>
       </div>
     </div>

--- a/templates/legal/confidentiality-agreement.md
+++ b/templates/legal/confidentiality-agreement.md
@@ -6,13 +6,13 @@ context:
 ---
 
   <script type="text/javascript"
-          src="https://www.tfaforms.com/wForms/3.7/js/wforms.js"></script>
+          src="https://www.tfaforms.com/wForms/3.7/js/wforms.js" nonce="{{ csp_nonce }}"></script>
   <script type="text/javascript"
-          src="https://www.tfaforms.com/wForms/3.7/js/localization-en_GB.js"></script>
+          src="https://www.tfaforms.com/wForms/3.7/js/localization-en_GB.js" nonce="{{ csp_nonce }}"></script>
   <link href="https://www.tfaforms.com/css/form.css"
         rel="stylesheet"
         type="text/css" />
-  <script>
+  <script nonce="{{ csp_nonce }}">
     wFORMS.behaviors.prefill.skip = false;
   </script>
   <style type="text/css" media="screen">
@@ -57,7 +57,7 @@ context:
     }
 
   </style>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     /* make jslint happy */
     /*global base2, document, wFORMS, $, $$ */
 
@@ -112,7 +112,7 @@ context:
     };
 
   </script>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // hides US State selection field unless country is US
     document.addEventListener("DOMContentLoaded", function() {
       var countryInput = document.querySelector("#tfa_Country");

--- a/templates/legal/contributors/agreement.html
+++ b/templates/legal/contributors/agreement.html
@@ -23,11 +23,11 @@
     </section>
   </div>
   <noscript>You need to enable JavaScript to run this page.</noscript>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     window.CANONICAL_CLA_API_URL = '{{ canonical_cla_api_url }}';
     window.COUNTRIES_LIST = {{ get_countries_list() | tojson }};
   </script>
   <script src="{{ versioned_static('js/dist/canonical-cla.js') }}"
           type="module"
-          defer></script>
+          defer nonce="{{ csp_nonce }}"></script>
 {% endblock content %}

--- a/templates/legal/data-privacy/enquiry.md
+++ b/templates/legal/data-privacy/enquiry.md
@@ -6,8 +6,8 @@ context:
 ---
 
 <!-- javascript -->
-<script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
-<script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+<script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js" nonce="{{ csp_nonce }}"></script>
+<script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js" nonce="{{ csp_nonce }}"></script>
 
 # Data protection enquiries
 

--- a/templates/legal/open-source-licences.md
+++ b/templates/legal/open-source-licences.md
@@ -107,7 +107,7 @@ context:
   </table>
 </main>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   const elements = {
     content: document.getElementById("content"),
     empty: document.getElementById("empty"),
@@ -200,7 +200,7 @@ context:
   }
 </script>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   /**
   Toggles the expanded/collapsed classed on side navigation element.
 

--- a/templates/legal/terms-and-policies/contact-us.md
+++ b/templates/legal/terms-and-policies/contact-us.md
@@ -5,7 +5,7 @@ context:
   copydoc: "https://docs.google.com/document/d/1LU9eJrUSufbbcsvQQUecmrUcw316EfTYgFpFK9HRwJg/edit"
 ---
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ csp_nonce }}">
   // initialize our variables
   var captchaReady = 0;
   var wFORMSReady = 0;
@@ -113,8 +113,8 @@ context:
   };
 </script>
 <script src='https://www.google.com/recaptcha/api.js?onload=gCaptchaReadyCallback&render=explicit&hl=en_GB' async
-defer></script>
-<script type="text/javascript">
+defer nonce="{{ csp_nonce }}"></script>
+<script type="text/javascript" nonce="{{ csp_nonce }}">
   document.addEventListener("DOMContentLoaded", function() {
     var warning = document.getElementById("javascript-warning");
     if (warning != null) {
@@ -133,7 +133,7 @@ defer></script>
     }
   });
 </script>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ csp_nonce }}">
   document.addEventListener("DOMContentLoaded", function(){
     const FORM_TIME_START = Math.floor((new Date).getTime()/1000);
     let formElement = document.getElementById("tfa_0");
@@ -173,11 +173,11 @@ defer></script>
 
 <link href="https://www.tfaforms.com/wForms/3.4/css/blank/wforms.css" rel="stylesheet" type="text/css" />
 <link href="https://www.tfaforms.com/dist/form-builder/5.0.0/wforms-jsonly.css?v=9cab24f50ea39e2cd0e4eb3def0940a2b3cb2ad2" rel="alternate stylesheet" title="This stylesheet activated by javascript" type="text/css" />
-<script type="text/javascript" src="https://www.tfaforms.com/wForms/3.11/js/wforms.js?v=9cab24f50ea39e2cd0e4eb3def0940a2b3cb2ad2"></script>
-<script type="text/javascript">
+<script type="text/javascript" src="https://www.tfaforms.com/wForms/3.11/js/wforms.js?v=9cab24f50ea39e2cd0e4eb3def0940a2b3cb2ad2" nonce="{{ csp_nonce }}"></script>
+<script type="text/javascript" nonce="{{ csp_nonce }}">
   wFORMS.behaviors.prefill.skip = false;
 </script>
-<script type="text/javascript" src="https://www.tfaforms.com/wForms/3.11/js/localization-en_GB.js?v=9cab24f50ea39e2cd0e4eb3def0940a2b3cb2ad2"></script>
+<script type="text/javascript" src="https://www.tfaforms.com/wForms/3.11/js/localization-en_GB.js?v=9cab24f50ea39e2cd0e4eb3def0940a2b3cb2ad2" nonce="{{ csp_nonce }}"></script>
 
 <section class="p-strip u-no-padding--top">
   <div class="row">

--- a/templates/lxd/index.html
+++ b/templates/lxd/index.html
@@ -414,6 +414,6 @@
     </div>
   </section>
 
-  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+  <script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
 
 {% endblock %}

--- a/templates/lxd/install.html
+++ b/templates/lxd/install.html
@@ -248,8 +248,8 @@
     </div>
   </section>
 
-  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
-  <script src="{{ versioned_static('js/tabbed-content.js') }}"></script>
+  <script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" nonce="{{ csp_nonce }}"></script>
 
   {{ load_form("/lxd") | safe }}
 

--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -421,7 +421,7 @@ meta_copydoc %}
 
   {{ load_form("/lxd") | safe }}
 
-  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
-  <script src="{{ versioned_static('js/dist/active-nav-scroll.js') }}"></script>
+  <script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script src="{{ versioned_static('js/dist/active-nav-scroll.js') }}" nonce="{{ csp_nonce }}"></script>
 
 {% endblock %}

--- a/templates/maas/_blog.html
+++ b/templates/maas/_blog.html
@@ -20,9 +20,9 @@
   </template>
 </section>
 
-<script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
+<script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}" nonce="{{ csp_nonce }}"></script>
 {# djlint:off #}
-<script>
+<script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#maas-latest",

--- a/templates/maas/_tutorial.html
+++ b/templates/maas/_tutorial.html
@@ -138,7 +138,7 @@
   </div>
 
   <!-- end of tutorial feedback -->
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var tutorialFeedbackOptions = document.querySelector('.p-tutorial__feedback-options');
       var tutorialFeedbackIcons = document.querySelectorAll('.p-tutorial__feedback-icon');
@@ -162,7 +162,7 @@
     })();
   </script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       function setActiveLink(navigationItems) {
         [].forEach.call(navigationItems, function(item) {
@@ -210,7 +210,7 @@
     })();
   </script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var polls = document.querySelectorAll('.poll');
 
@@ -237,7 +237,7 @@
     })();
   </script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     (function() {
       var toggle = document.querySelector('.p-sidenav__toggle');
       var sidebarContent = document.querySelector('.p-sidenav__body');

--- a/templates/maas/docs/base_docs.html
+++ b/templates/maas/docs/base_docs.html
@@ -154,8 +154,8 @@
 </div>
 
 {% block js_extra %}
-  <script src="/static/js/highlight.pack.js"></script>
-  <script>
+  <script src="/static/js/highlight.pack.js" nonce="{{ csp_nonce }}"></script>
+  <script nonce="{{ csp_nonce }}">
   hljs.initHighlightingOnLoad();
   window.addEventListener("DOMContentLoaded", function() {
   // Based on Vanilla side navigation example
@@ -319,8 +319,8 @@
   });
   });
   </script>
-  <script src="/static/js/modules/discourse-rad-parser/discourse-rad-parser.js"></script>
-  <script>
+  <script src="/static/js/modules/discourse-rad-parser/discourse-rad-parser.js" nonce="{{ csp_nonce }}"></script>
+  <script nonce="{{ csp_nonce }}">
     drpNs.DiscourseRADParser();
   </script>
 {% endblock js_extra %}

--- a/templates/maas/features.html
+++ b/templates/maas/features.html
@@ -482,8 +482,8 @@ source and free to use, with commercial support available from Canonical.
         works&nbsp;&rsaquo;</a>
     {%- endif -%}
   {% endcall -%}
-    <script src="{{ versioned_static('js/modules/venobox/venobox.min.js') }}"></script>
-    <script defer>
+    <script src="{{ versioned_static('js/modules/venobox/venobox.min.js') }}" nonce="{{ csp_nonce }}"></script>
+    <script defer nonce="{{ csp_nonce }}">
       (function() {
         new VenoBox();
       })();

--- a/templates/maas/index.html
+++ b/templates/maas/index.html
@@ -781,5 +781,5 @@
   <script type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/maas/resources.html
+++ b/templates/maas/resources.html
@@ -326,8 +326,8 @@
       </article>
     </template>
 
-    <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
-    <script>
+    <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}" nonce="{{ csp_nonce }}"></script>
+    <script nonce="{{ csp_nonce }}">
       canonicalLatestNews.fetchLatestNews({
         articlesContainerSelector: "#latest-articles",
         articleTemplateSelector: "#articles-template",

--- a/templates/microcloud/index.html
+++ b/templates/microcloud/index.html
@@ -500,12 +500,12 @@
   {% endif %}
   {% endcall %}
   
-  <script src="/static/js/typer.js" defer></script>
-  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+  <script src="/static/js/typer.js" defer nonce="{{ csp_nonce }}"></script>
+  <script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
   <script type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 
   {{ load_form("/microcloud") | safe }}
 

--- a/templates/microcloud/resources.html
+++ b/templates/microcloud/resources.html
@@ -316,5 +316,5 @@
       </div>
     </div>
   </section>
-  <script src="{{ versioned_static('js/microcloud-slider.js') }}"></script>
+  <script src="{{ versioned_static('js/microcloud-slider.js') }}" nonce="{{ csp_nonce }}"></script>
 {% endblock content %}

--- a/templates/microcloud/what-is-microcloud.html
+++ b/templates/microcloud/what-is-microcloud.html
@@ -225,7 +225,7 @@
     ) -%}
   {% endcall -%}
 
-  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+  <script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
 
   {{ load_form("/microcloud") | safe }}
 {% endblock content %}

--- a/templates/microk8s/features/index.html
+++ b/templates/microk8s/features/index.html
@@ -63,7 +63,7 @@
 
   {{ load_form("/microk8s/features") | safe }}
 
-  <script src="{{ versioned_static('js/side-navigation.js') }}"></script>
-  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+  <script src="{{ versioned_static('js/side-navigation.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
 
 {% endblock %}

--- a/templates/microk8s/index.html
+++ b/templates/microk8s/index.html
@@ -374,7 +374,7 @@
       <div class="asciinema-container">
         <script id="asciicast-KUqQaDt7p3iNO5DP0xC7W4Ufj"
                 src="https://asciinema.org/a/KUqQaDt7p3iNO5DP0xC7W4Ufj.js"
-                async></script>
+                async nonce="{{ csp_nonce }}"></script>
       </div>
     </div>
   </section>
@@ -473,8 +473,8 @@
   <script async defer
           src="https://cdn.jsdelivr.net/npm/github-buttons@2.32.0/dist/buttons.min.js"
           integrity="sha384-ZhcuGDV+Yp73dqAwwf9TcmQydIjkGkv+3oJxfQFaadDitRkt+COogTczHw8CTFgH"
-          crossorigin="anonymous"></script>
-  <script src="{{ versioned_static('js/tabbed-content.js') }}"></script>
-  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
 
 {% endblock content %}

--- a/templates/microk8s/resources/index.html
+++ b/templates/microk8s/resources/index.html
@@ -85,8 +85,8 @@ is-paper
   </div>
 </section>
 
-<script src="{{ versioned_static('js/dist/active-nav-scroll.js') }}"></script>
-<script>
+<script src="{{ versioned_static('js/dist/active-nav-scroll.js') }}" nonce="{{ csp_nonce }}"></script>
+<script nonce="{{ csp_nonce }}">
   function toggleDropdown(toggle, open) {
     var parentElement = toggle.parentNode;
     var dropdown = document.getElementById(toggle.getAttribute('aria-controls'));

--- a/templates/mir/index.html
+++ b/templates/mir/index.html
@@ -370,5 +370,5 @@
   <script async defer
           src="https://cdn.jsdelivr.net/npm/github-buttons@2.32.0/dist/buttons.min.js"
           integrity="sha384-ZhcuGDV+Yp73dqAwwf9TcmQydIjkGkv+3oJxfQFaadDitRkt+COogTczHw8CTFgH"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/multipass/install.html
+++ b/templates/multipass/install.html
@@ -325,10 +325,10 @@
                 async
                 data-t="08"
                 data-autoplay="true"
-                data-speed="1.5"></script>
+                data-speed="1.5" nonce="{{ csp_nonce }}"></script>
       </div>
     </div>
   </div>
 
-  <script src="{{ versioned_static('js/tabbed-content.js') }}"></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" nonce="{{ csp_nonce }}"></script>
 {% endblock content %}

--- a/templates/open-source-adoption/index.html
+++ b/templates/open-source-adoption/index.html
@@ -609,5 +609,5 @@
 
   {{ load_form("/contact-us") | safe }}
 
-  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/openstack/compare/index.html
+++ b/templates/openstack/compare/index.html
@@ -706,7 +706,7 @@
       },
     ]) }}
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const toggleSwitch = document.querySelector('.p-switch');
     const toggleSwitchInput = document.querySelector('.p-switch__input');
     const table = document.getElementById('openstack-comparison-table');

--- a/templates/openstack/resources.html
+++ b/templates/openstack/resources.html
@@ -644,7 +644,7 @@
               </div>
             </div>
           </div>
-          <script>
+          <script nonce="{{ csp_nonce }}">
             document.getElementById('private-cloud-pricing-calculator').classList.remove('u-hide');
           </script>
         </div>
@@ -665,6 +665,6 @@
     {%- endif -%}
   {% endcall %}
 
-  <script src="{{ versioned_static('js/slider.js') }}" defer></script>
+  <script src="{{ versioned_static('js/slider.js') }}" defer nonce="{{ csp_nonce }}"></script>
 
 {% endblock %}

--- a/templates/partners/become-a-partner.html
+++ b/templates/partners/become-a-partner.html
@@ -494,7 +494,7 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const usStates = [{
       value: "AK",
       name: "Alaska"

--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -213,10 +213,10 @@
     </div>
   </section>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const partnersLength = {{ partners_length | tojson }};
   </script>
-  <script src="{{ versioned_static('js/side-navigation.js') }}"></script>
-  <script defer src="{{ versioned_static('js/find-a-partner.js') }}"></script>
+  <script src="{{ versioned_static('js/side-navigation.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script defer src="{{ versioned_static('js/find-a-partner.js') }}" nonce="{{ csp_nonce }}"></script>
 
 {% endblock %}

--- a/templates/partners/isv-program/index.html
+++ b/templates/partners/isv-program/index.html
@@ -966,6 +966,6 @@
   {%- endif -%}
   {% endcall -%}
 
-  <script defer src="{{ versioned_static('js/tabbed-content.js') }}"></script>
-  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
+  <script defer src="{{ versioned_static('js/tabbed-content.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js" nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/partners/request-login.html
+++ b/templates/partners/request-login.html
@@ -24,9 +24,9 @@
       <div class="col-6 col-start-large-1">
 
         <!-- MARKETO FORM -->
-        <script src="//assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
-        <script src="//assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
-        <script src="//assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>
+        <script src="//assets.ubuntu.com/v1/37b1db88-jquery.min.js" nonce="{{ csp_nonce }}"></script>
+        <script src="//assets.ubuntu.com/v1/d55f58bb-jquery.validate.js" nonce="{{ csp_nonce }}"></script>
+        <script src="//assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js" nonce="{{ csp_nonce }}"></script>
 
         <form action="https://pages.ubuntu.com/index.php/leadCapture/save"
               method="post"
@@ -106,7 +106,7 @@
                    name="retURL"
                    value="https://canonical.com/partners/thank-you" />
           </form>
-          <script>
+          <script nonce="{{ csp_nonce }}">
             $("#mktoForm_3339").validate({
               errorElement: "span",
               errorClass: "mktFormMsg mktError",

--- a/templates/public-sector/index.html
+++ b/templates/public-sector/index.html
@@ -28,7 +28,7 @@
   <script type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 {% endblock extra_metatags %}
 
 {% block content %}
@@ -706,6 +706,6 @@
     ]) }}
 
   {{ load_form("/public-sector") | safe }}
-  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
+  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js" nonce="{{ csp_nonce }}"></script>
 
 {% endblock content %}

--- a/templates/shared/_blog-card.html
+++ b/templates/shared/_blog-card.html
@@ -90,8 +90,8 @@
   </template>
   {% endif %}
 
-  <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
-  <script>
+  <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews(
       {
         articlesContainerSelector: "#horizontal-latest-articles",

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -276,7 +276,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   document.querySelector('form').addEventListener('submit', function(event) {
     dataLayer.push({
       'event': 'GAEvent',

--- a/templates/shared/forms/form-template.html
+++ b/templates/shared/forms/form-template.html
@@ -61,8 +61,8 @@
   {% include "/shared/forms/form-fields.html" %}
 {% endif %}
 
-<script defer src="{{ versioned_static('js/modals.js') }}"></script>
-<script>
+<script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
+<script nonce="{{ csp_nonce }}">
   document.querySelector('form').addEventListener('submit', function(event) {
     dataLayer.push({
       'event': 'GAEvent',

--- a/templates/solutions/ai/infrastructure/index.html
+++ b/templates/solutions/ai/infrastructure/index.html
@@ -520,6 +520,6 @@
 
   {{ load_form("/solutions/ai/infrastructure") | safe }}
 
-  <script defer src="{{ versioned_static('js/tabbed-content.js') }}"></script>
-  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
+  <script defer src="{{ versioned_static('js/tabbed-content.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js" nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/templates/solutions/automation/index.html
+++ b/templates/solutions/automation/index.html
@@ -943,6 +943,6 @@
   {% endcall -%}
 
   {{ load_form("/solutions/automation") | safe }}
-  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer nonce="{{ csp_nonce }}"></script>
 
 {% endblock content %}

--- a/templates/solutions/automotive/buyers-guide/index.html
+++ b/templates/solutions/automotive/buyers-guide/index.html
@@ -704,7 +704,7 @@
       filter: invert(100%);
     }
   </style>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     const mainContent = document.querySelector('#main-content');
     const featuredSections = document.querySelectorAll('.feature');
     const navigation = document.querySelector('#navigation');

--- a/templates/solutions/automotive/index.html
+++ b/templates/solutions/automotive/index.html
@@ -22,7 +22,7 @@
     <script type="module"
             src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
             integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
-            crossorigin="anonymous"></script>
+            crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 {% endblock extra_metatags %}
 
 {% block content %}

--- a/templates/solutions/cloud-native-development/index.html
+++ b/templates/solutions/cloud-native-development/index.html
@@ -502,6 +502,6 @@
 
   {{ load_form('/solutions/cloud-native-development') | safe }}
   
-  <script src="{{ versioned_static('js/tabbed-content.js') }}"></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" nonce="{{ csp_nonce }}"></script>
 
 {% endblock content %}

--- a/templates/solutions/education/index.html
+++ b/templates/solutions/education/index.html
@@ -547,9 +547,9 @@
 
   {{ load_form("/solutions/education") | safe }}
 
-  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
-  <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
-  <script>
+  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js" nonce="{{ csp_nonce }}"></script>
+  <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}" nonce="{{ csp_nonce }}"></script>
+  <script nonce="{{ csp_nonce }}">
     canonicalLatestNews.fetchLatestNews({
       imageClasses: ["p-image-container__image"],
       limit: "4",

--- a/templates/solutions/financial-services/index.html
+++ b/templates/solutions/financial-services/index.html
@@ -21,7 +21,7 @@
   <script type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 {% endblock extra_metatags %}
 
 {% block content %}
@@ -491,6 +491,6 @@
 
   {{ load_form("/solutions/financial-services") | safe }}
 
-  <script src="{{ versioned_static('js/tabbed-content.js') }}"></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" nonce="{{ csp_nonce }}"></script>
 
 {% endblock content %}

--- a/templates/solutions/index.html
+++ b/templates/solutions/index.html
@@ -1217,9 +1217,9 @@
 
   {{ load_form("/solutions") | safe }}
 
-  <script src="{{ versioned_static('js/dist/active-nav-scroll.js') }}"></script>
+  <script src="{{ versioned_static('js/dist/active-nav-scroll.js') }}" nonce="{{ csp_nonce }}"></script>
 
-  <script>
+  <script nonce="{{ csp_nonce }}">
     // This function toggles the expanded state of an element and its associated target.
     //
     // Parameters:

--- a/templates/solutions/infrastructure/edge-computing/index.html
+++ b/templates/solutions/infrastructure/edge-computing/index.html
@@ -738,7 +738,7 @@
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer nonce="{{ csp_nonce }}"></script>
 
   {{ load_form("/solutions/infrastructure/edge-computing") | safe }}
 

--- a/templates/solutions/infrastructure/private-cloud-pricing.html
+++ b/templates/solutions/infrastructure/private-cloud-pricing.html
@@ -286,7 +286,7 @@
   {{ load_form("/solutions/infrastructure/private-cloud-pricing", 6062) | safe }}
 
   {# djlint: off #}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     let pricingMetrics = {};
 
     /**

--- a/templates/solutions/infrastructure/sovereign-cloud.html
+++ b/templates/solutions/infrastructure/sovereign-cloud.html
@@ -902,6 +902,6 @@
   {% endcall -%}
 
   {{ load_form('/solutions/infrastructure/sovereign-cloud', 5906) | safe }}
-  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
+  <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js" nonce="{{ csp_nonce }}"></script>
 
 {% endblock content %}

--- a/templates/solutions/infrastructure/virtualization-solutions/index.html
+++ b/templates/solutions/infrastructure/virtualization-solutions/index.html
@@ -27,7 +27,7 @@ Canonical's open source virtualization solutions scale from a single laptop to m
   <script type="module"
           src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
           integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
-          crossorigin="anonymous"></script>
+          crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>
 {% endblock extra_metatags %}
 
 {% block content %}
@@ -430,7 +430,7 @@ Canonical's open source virtualization solutions scale from a single laptop to m
     </div>
   </section>
 
-  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" defer nonce="{{ csp_nonce }}"></script>
 
   {{ load_form("/solutions/infrastructure/virtualization-solutions") | safe }}
 

--- a/templates/solutions/open-source-security/index.html
+++ b/templates/solutions/open-source-security/index.html
@@ -650,8 +650,8 @@
       </div>
     </section>
 
-    <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
-    <script>
+    <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}" nonce="{{ csp_nonce }}"></script>
+    <script nonce="{{ csp_nonce }}">
       canonicalLatestNews.fetchLatestNews({
         // Make sure you add `p-image-container__image` to ensure the article image receives the correct styling.
         imageClasses: ["p-image-container__image"],

--- a/templates/solutions/telco/5g-core.html
+++ b/templates/solutions/telco/5g-core.html
@@ -583,7 +583,7 @@
     {%- endif -%}
   {% endcall -%}
 
-  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+  <script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
 
   {{ load_form("/solutions/telco/5g-core") | safe }}
 

--- a/templates/solutions/telco/5g-edge.html
+++ b/templates/solutions/telco/5g-edge.html
@@ -769,7 +769,7 @@
     </div>
   </div>
 
-  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+  <script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
 
   {{ load_form("/solutions/telco/5g-edge") | safe }}
 

--- a/templates/solutions/telco/index.html
+++ b/templates/solutions/telco/index.html
@@ -664,6 +664,6 @@
 
   {{ load_form('/solutions/telco') | safe }}
 
-  <script src="{{ versioned_static('js/tabbed-content.js') }}"></script>
+  <script src="{{ versioned_static('js/tabbed-content.js') }}" nonce="{{ csp_nonce }}"></script>
 
 {% endblock %}

--- a/templates/solutions/telco/open-ran.html
+++ b/templates/solutions/telco/open-ran.html
@@ -547,7 +547,7 @@ Our cloud infrastructure portfolio is modular, allowing telecom customers to cho
       </div>
     </section>
 
-    <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+    <script defer src="{{ versioned_static('js/modals.js') }}" nonce="{{ csp_nonce }}"></script>
   
     {{ load_form("/solutions/telco/open-ran") | safe }}
 

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -1,3 +1,6 @@
+import secrets
+
+import flask
 from canonicalwebteam.flask_base.env import get_flask_env
 
 CSP = {
@@ -10,6 +13,7 @@ CSP = {
     ],
     "script-src-elem": [
         "'self'",
+        "'strict-dynamic'",
         "assets.ubuntu.com",
         "www.google-analytics.com",
         "www.googletagmanager.com",
@@ -39,8 +43,6 @@ CSP = {
         "api.livechatinc.com",
         "secure.livechatinc.com",
         "www.tfaforms.com",
-        # This is necessary for Google Tag Manager to function properly.
-        "'unsafe-inline'",
     ],
     "font-src": [
         "'self'",
@@ -53,8 +55,6 @@ CSP = {
         "'self'",
         "blob:",
         "'unsafe-eval'",
-        "'unsafe-hashes'",
-        "'unsafe-inline'",
     ],
     "connect-src": [
         "'self'",
@@ -130,8 +130,18 @@ CSP = {
     ],
 }
 
+NONCED_DIRECTIVES = ("script-src", "script-src-elem")
+
 
 def init_handlers(app):
+
+    @app.before_request
+    def set_csp_nonce():
+        flask.g.csp_nonce = secrets.token_urlsafe(16)
+
+    @app.context_processor
+    def inject_csp_nonce():
+        return {"csp_nonce": getattr(flask.g, "csp_nonce", "")}
 
     @app.after_request
     def add_headers(response):
@@ -151,14 +161,20 @@ def init_handlers(app):
         resources.
         """
 
-        def get_csp_as_str(csp={}):
+        def get_csp_as_str(csp={}, nonce=None):
             csp_str = ""
             for key, values in csp.items():
-                csp_value = " ".join(values)
+                directive_values = list(values)
+                if nonce and key in NONCED_DIRECTIVES:
+                    directive_values.append(f"'nonce-{nonce}'")
+                csp_value = " ".join(directive_values)
                 csp_str += f"{key} {csp_value}; "
             return csp_str.strip()
 
-        response.headers["Content-Security-Policy"] = get_csp_as_str(CSP)
+        nonce = getattr(flask.g, "csp_nonce", None)
+        response.headers["Content-Security-Policy"] = get_csp_as_str(
+            CSP, nonce=nonce
+        )
 
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Cross-Origin-Embedder-Policy"] = "unsafe-none"


### PR DESCRIPTION
  ## Done
  - Added per-request `csp_nonce` generation in `webapp/handlers.py` (`before_request` + `context_processor`) and inject it into `script-src` / `script-src-elem` via a new
  `NONCED_DIRECTIVES` constant.
  - Added `'strict-dynamic'` to `script-src-elem` and removed `'unsafe-inline'` / `'unsafe-hashes'` from `script-src` and `script-src-elem`.
  - Added `nonce="{{ csp_nonce }}"` to every inline and external `<script>` tag across ~95 templates so they continue to execute under the tighter policy.
  - Refactored two inline scripts that could not stay as global function declarations under CSP:
    - `templates/careers/application/index.html` — `showInput()` rewritten as an IIFE wired up with `addEventListener('change', …)`; paired with removal of
  `onchange="showInput()"` in `_withdrawal-form.html`.
    - `templates/juju/docs/search.html` — `window.loadMoreResults = function() {…}` rewritten as `loadMoreButton.addEventListener('click', …)`; paired with removal of
  `onclick="loadMoreResults()"` on the button.
  
  ## QA
  - DevTools console should show **no CSP violations** on a sampling of pages: homepage, `/careers`, `/careers/<role>`, `/careers/application/<id>` (if accessible),
  `/juju/docs`, `/juju/docs/search?q=foo`, `/maas/features`, `/blog`, any legal page.
  - Reload twice and confirm the `nonce-…` value in the `Content-Security-Policy` response header changes per request, and that the `nonce=` attribute on inline `<script>`
  tags matches the header.
  - On `/careers/application/<id>` (or its withdrawal form): selecting "Other" as the withdrawal reason still shows the free-text input and marks it required; selecting any
  other option hides it again.
  - On `/juju/docs/search?q=<query>`: the "Load more results" button still reveals the next 10 results and switches to "Loading…" briefly.
  - Check Network → Headers: `Content-Security-Policy` no longer contains `'unsafe-inline'` (in `script-src` / `script-src-elem`) or `'unsafe-hashes'`, and contains
  `'strict-dynamic'` in `script-src-elem`.

