### PR TITLE
WD-36600: fix jinja whitespace in templates touched by CSP work

### DIFF
--- a/templates/blog/filters.html
+++ b/templates/blog/filters.html
@@ -4,16 +4,16 @@
   </div>
   <div class="col-6 col-medium-4">
     <select class="js-submit-on-change" id="filter" name="content" aria-label="Filter by content type">
-      <option {% if not category %}selected="selected"{% endif %} value="/blog/{{topic}}#posts-list">All content types</option>
-      <option {% if category and category.slug == 'articles' %}selected="selected"{% endif %} value="/blog/{{topic}}?category=articles#posts-list">Articles</option>
-      <option {% if category and category.slug == 'case-studies' %}selected="selected"{% endif %} value="/blog/{{topic}}?category=case-studies#posts-list">Case studies</option>
-      <option {% if category and category.slug == 'news' %}selected="selected"{% endif %} value="/blog/{{topic}}?category=news#posts-list">News</option>
-      <option {% if category and category.slug == 'videos' %}selected="selected"{% endif %} value="/blog/{{topic}}?category=videos#posts-list">Videos</option>
-      <option {% if category and category.slug == 'webinars' %}selected="selected"{% endif %} value="/blog/{{topic}}?category=webinars#posts-list">Webinars</option>
-      <option {% if category and category.slug == 'white-papers' %}selected="selected"{% endif %} value="/blog/{{topic}}?category=white-papers#posts-list">White papers</option>
+      <option {% if not category %}selected="selected"{% endif %} value="/blog/{{ topic }}#posts-list">All content types</option>
+      <option {% if category and category.slug == 'articles' %}selected="selected"{% endif %} value="/blog/{{ topic }}?category=articles#posts-list">Articles</option>
+      <option {% if category and category.slug == 'case-studies' %}selected="selected"{% endif %} value="/blog/{{ topic }}?category=case-studies#posts-list">Case studies</option>
+      <option {% if category and category.slug == 'news' %}selected="selected"{% endif %} value="/blog/{{ topic }}?category=news#posts-list">News</option>
+      <option {% if category and category.slug == 'videos' %}selected="selected"{% endif %} value="/blog/{{ topic }}?category=videos#posts-list">Videos</option>
+      <option {% if category and category.slug == 'webinars' %}selected="selected"{% endif %} value="/blog/{{ topic }}?category=webinars#posts-list">Webinars</option>
+      <option {% if category and category.slug == 'white-papers' %}selected="selected"{% endif %} value="/blog/{{ topic }}?category=white-papers#posts-list">White papers</option>
     </select>
     <input type="submit" value="Send Request" class="u-hide">
-    <input type="hidden" name="topic" value="{{topic}}">
+    <input type="hidden" name="topic" value="{{ topic }}">
   </div>
 </form>
   

--- a/templates/careers/_search.html
+++ b/templates/careers/_search.html
@@ -1,6 +1,6 @@
 {% if vacancies %}
 <div class="js-search-jobs-form p-search-roles">
-  <form action="/careers/all" class="p-search-roles__form" {% if form_styles %}style="{{form_styles}}"{% endif %}>
+  <form action="/careers/all" class="p-search-roles__form" {% if form_styles %}style="{{ form_styles }}"{% endif %}>
     <div class="p-search-roles__group">
       <label class="u-off-screen" for="search">Search</label>
       <div class="p-search-roles__control u-clearfix u-no-padding--right">

--- a/templates/careers/application/_interview-card-done.html
+++ b/templates/careers/application/_interview-card-done.html
@@ -1,11 +1,11 @@
 <div class="col-5">
   <div class="u-float-right"><i class="p-icon--success u-align--right">Passed</i></div>
   <h5 class="p-heading--4 p-card__title u-no-margin--bottom">{{ interview["interview"]["name"] }}</h5>
-  {% if interview["stage_name"]  == "Talent Interview" %}
+  {% if interview["stage_name"] == "Talent Interview" %}
   <p class="p-card__content u-sv1">Talent team interview to discuss your CV history, choices and decisions you have made throughout your career and to discuss your behavioural assessment.</p>
   {% endif %}
   <p class="p-card__content u-sv2">{{ interview["start"]["datetime"].strftime('%d %B') }}, with {% for interviewer in interview["interviewers"] %}{% if loop.index > 1 %}, {% endif %}{{ interviewer["name"] }}{% endfor %}</p>
-  {% if interview["stage_name"]  == "Talent Interview" %}
+  {% if interview["stage_name"] == "Talent Interview" %}
   <p class="p-card__content u-sv1">Once completed, your behavioural assessment will be available in the <a href="#assessment" onclick="showProgressDetail('assessment');">Assessment</a> section.</p>
   {% endif %}
 


### PR DESCRIPTION
## Done
  - `templates/blog/filters.html`: `{{topic}}` → `{{ topic }}` (8 occurrences).
  - `templates/careers/_search.html`: `{{form_styles}}` → `{{ form_styles }}`.
  - `templates/careers/application/_interview-card-done.html`: removed accidental double-space in `interview["stage_name"]  == "Talent Interview"` (2 occurrences).

  ## QA
  - Pure whitespace changes inside `{{ … }}` expressions and one Jinja `{% if %}` — rendered output should be byte-identical to `main`.
  - `/blog` and `/blog/<topic>`: the content-type filter dropdown still navigates to the correct `?category=…` URL on change.
  - `/careers/all` (or wherever `_search.html` is included with `form_styles`): the search form renders with the same inline style.
  - `/careers/application/<id>` with a "Talent Interview" stage: the Talent Interview blurb and the "Assessment" link still appear; with any other stage, they don't.
