### PR TITLE
WD-36600: migrate inline GA tracking handlers to CSP-safe data-* attributes

### DIFF
--- a/static/js/csp-event-handlers.js
+++ b/static/js/csp-event-handlers.js
@@ -1,0 +1,67 @@
+(function () {
+  "use strict";
+
+  function ready(fn) {
+    if (document.readyState !== "loading") {
+      fn();
+    } else {
+      document.addEventListener("DOMContentLoaded", fn);
+    }
+  }
+
+  function pushDataLayer(el) {
+    if (typeof window.dataLayer === "undefined") {
+      window.dataLayer = [];
+    }
+    var category = el.getAttribute("data-ga-category");
+    var action = el.getAttribute("data-ga-action");
+    var label = el.getAttribute("data-ga-label");
+    var extra = el.getAttribute("data-ga-extra-category");
+    var extraAction = el.getAttribute("data-ga-extra-action");
+    var extraLabel = el.getAttribute("data-ga-extra-label");
+    if (category && action) {
+      window.dataLayer.push({
+        event: "GAEvent",
+        eventCategory: category,
+        eventAction: action,
+        eventLabel: label || undefined,
+        eventValue: undefined,
+      });
+    }
+    if (extra && extraAction) {
+      window.dataLayer.push({
+        event: "GAEvent",
+        eventCategory: extra,
+        eventAction: extraAction,
+        eventLabel: extraLabel || undefined,
+        eventValue: undefined,
+      });
+    }
+  }
+
+  ready(function () {
+    document.querySelectorAll("[data-ga-category]").forEach(function (el) {
+      el.addEventListener("click", function () {
+        pushDataLayer(el);
+      });
+    });
+
+    document
+      .querySelectorAll("[data-ga-submit-category]")
+      .forEach(function (form) {
+        form.addEventListener("submit", function () {
+          if (typeof window.dataLayer === "undefined") {
+            window.dataLayer = [];
+          }
+          window.dataLayer.push({
+            event: "GAEvent",
+            eventCategory: form.getAttribute("data-ga-submit-category"),
+            eventAction: form.getAttribute("data-ga-submit-action"),
+            eventLabel:
+              form.getAttribute("data-ga-submit-label") || undefined,
+            eventValue: undefined,
+          });
+        });
+      });
+  });
+})();

--- a/static/js/csp-event-handlers.js
+++ b/static/js/csp-event-handlers.js
@@ -1,3 +1,15 @@
+/**
+ * CSP-safe GA event tracking.
+ *
+ * Replaces inline `onclick="dataLayer.push(...)"` handlers (disallowed under
+ * our Content Security Policy) by binding listeners to elements that declare
+ * their GA event via `data-ga-*` attributes:
+ *   - data-ga-category / data-ga-action / data-ga-label  (click events)
+ *   - data-ga-extra-category / -action / -label          (secondary click event on same element)
+ *   - data-ga-submit-category / -action / -label         (form submit events)
+ *
+ * Each handler pushes a `GAEvent` to window.dataLayer for Google Tag Manager.
+ */
 (function () {
   "use strict";
 
@@ -9,40 +21,33 @@
     }
   }
 
-  function pushDataLayer(el) {
+  function pushGAEvent(category, action, label) {
+    if (!category || !action) return;
     if (typeof window.dataLayer === "undefined") {
       window.dataLayer = [];
     }
-    var category = el.getAttribute("data-ga-category");
-    var action = el.getAttribute("data-ga-action");
-    var label = el.getAttribute("data-ga-label");
-    var extra = el.getAttribute("data-ga-extra-category");
-    var extraAction = el.getAttribute("data-ga-extra-action");
-    var extraLabel = el.getAttribute("data-ga-extra-label");
-    if (category && action) {
-      window.dataLayer.push({
-        event: "GAEvent",
-        eventCategory: category,
-        eventAction: action,
-        eventLabel: label || undefined,
-        eventValue: undefined,
-      });
-    }
-    if (extra && extraAction) {
-      window.dataLayer.push({
-        event: "GAEvent",
-        eventCategory: extra,
-        eventAction: extraAction,
-        eventLabel: extraLabel || undefined,
-        eventValue: undefined,
-      });
-    }
+    window.dataLayer.push({
+      event: "GAEvent",
+      eventCategory: category,
+      eventAction: action,
+      eventLabel: label || undefined,
+      eventValue: undefined,
+    });
   }
 
   ready(function () {
     document.querySelectorAll("[data-ga-category]").forEach(function (el) {
       el.addEventListener("click", function () {
-        pushDataLayer(el);
+        pushGAEvent(
+          el.getAttribute("data-ga-category"),
+          el.getAttribute("data-ga-action"),
+          el.getAttribute("data-ga-label"),
+        );
+        pushGAEvent(
+          el.getAttribute("data-ga-extra-category"),
+          el.getAttribute("data-ga-extra-action"),
+          el.getAttribute("data-ga-extra-label"),
+        );
       });
     });
 
@@ -50,17 +55,11 @@
       .querySelectorAll("[data-ga-submit-category]")
       .forEach(function (form) {
         form.addEventListener("submit", function () {
-          if (typeof window.dataLayer === "undefined") {
-            window.dataLayer = [];
-          }
-          window.dataLayer.push({
-            event: "GAEvent",
-            eventCategory: form.getAttribute("data-ga-submit-category"),
-            eventAction: form.getAttribute("data-ga-submit-action"),
-            eventLabel:
-              form.getAttribute("data-ga-submit-label") || undefined,
-            eventValue: undefined,
-          });
+          pushGAEvent(
+            form.getAttribute("data-ga-submit-category"),
+            form.getAttribute("data-ga-submit-action"),
+            form.getAttribute("data-ga-submit-label"),
+          );
         });
       });
   });

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -138,6 +138,7 @@
 
           <script defer src="{{ versioned_static('js/dist/navigation.js') }}"></script>
           <script src="{{ versioned_static('js/dist/forms.js') }}"></script>
+          <script defer src="{{ versioned_static('js/csp-event-handlers.js') }}" nonce="{{ csp_nonce }}"></script>
           <script>
             (function() {
               // Form submission notification

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -1,5 +1,6 @@
 <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_4960"
-  onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
+  data-ga-submit-category="Newsletter" data-ga-submit-action="Signup"
+  data-ga-submit-label="New homepage newsletter signup">
   <p>Get the latest Canonical news and updates in your inbox.</p>
   <label class="is-required" for="email">Work email:</label>
   <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />

--- a/templates/careers/includes/_fast-track-jobs.html
+++ b/templates/careers/includes/_fast-track-jobs.html
@@ -233,7 +233,7 @@
             <p>
               <a class="p-featured__url p-card--content"
                  href="/careers/{{ job.id }}"
-                 onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Featured job', 'eventAction' : 'Click', 'eventLabel' : '{{ job.title }}', 'eventValue' : undefined });">
+                 data-ga-category="Featured job" data-ga-action="Click" data-ga-label="{{ job.title }}">
                 {{ job.title }}
               </a>
 

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -79,12 +79,7 @@
   <div class="col-6">
     <hr class="p-rule"/>
     <h3 class="p-heading--5">Apply for this role</h3>
-    <form id="job-apply-form" action="/careers/{{ job.id }}" method="POST" enctype="multipart/form-data" class="js-roles-list--form" onsubmit="dataLayer.push({
-          'event': 'GAEvent',
-          'eventCategory': 'Form',
-          'eventAction': 'job application: {{ job.id }}',
-          'eventLabel': 'Submit Application',
-          'eventValue': undefined });" >
+    <form id="job-apply-form" action="/careers/{{ job.id }}" method="POST" enctype="multipart/form-data" class="js-roles-list--form" data-ga-submit-category="Form" data-ga-submit-action="job application: {{ job.id }}" data-ga-submit-label="Submit Application" >
       <fieldset style="border: none; margin-bottom: 0; padding: 0;">
         <p class="required-legend u-align-text--right ">Required</p>
         <input type="hidden" name="id" value="{{ job.id }}" />

--- a/templates/maas/features.html
+++ b/templates/maas/features.html
@@ -56,7 +56,7 @@ source and free to use, with commercial support available from Canonical.
         "description_html": '<p><abbr title="Preboot eXecution Environment">PXE</abbr> boot your servers and containers and they will be automatically discovered and enlisted in MAAS.</p>
           <p><abbr title="Intelligent Platform Management Interface">IPMI</abbr> enabled machines work seamlessly with MAAS.</p>',
         "cta_html": '<a href="/maas/docs/how-to-manage-machines" 
-          onclick="dataLayer.push({&quot;event&quot;: &quot;GAEvent&quot;, &quot;eventCategory&quot;: &quot;Feature&quot;, &quot;eventAction&quot;: &quot;Click&quot;, &quot;eventLabel&quot;: &quot;Automation&quot; });" 
+          data-ga-category="Feature" data-ga-action="Click" data-ga-label="Automation" 
           aria-label="Link to adding nodes page on MAAS documentation">
             Learn more about adding new nodes to MAAS&nbsp;&rsaquo;
           </a>'
@@ -76,7 +76,7 @@ source and free to use, with commercial support available from Canonical.
             <li>Attached switch fabrics</li>
           </ul>',
         "cta_html": '<a href="/maas/docs/about-maas-networking"
-          onclick="dataLayer.push({&quot;event&quot;: &quot;GAEvent&quot;, &quot;eventCategory&quot;: &quot;Feature&quot;, &quot;eventAction&quot;: &quot;Click&quot;, &quot;eventLabel&quot;: &quot;Network management&quot; });"
+          data-ga-category="Feature" data-ga-action="Click" data-ga-label="Network management"
           aria-label="Link to the configuring networking page on MAAS documentation">Find out more about MAAS
           networking&nbsp;&rsaquo;</a>'
       },
@@ -87,7 +87,7 @@ source and free to use, with commercial support available from Canonical.
           description="device discovery page",
         ),
         "description_html": '<p class="u-no-margin--bottom">MAAS can discover new <a href="/maas/docs/about-maas-networking"
-              onclick="dataLayer.push({&quot;event&quot;: &quot;GAEvent&quot;, &quot;eventCategory&quot;: &quot;Interested in feature&quot;, &quot;eventAction&quot;: &quot;Click&quot;, &quot;eventLabel&quot;: &quot;Learn more about interfaces&quot; });"
+              data-ga-category="Interested in feature" data-ga-action="Click" data-ga-label="Learn more about interfaces"
               aria-label="Link to device discovery page on MAAS documentation">devices and network interfaces</a>:
           </p>
           <ul>
@@ -96,7 +96,7 @@ source and free to use, with commercial support available from Canonical.
             <li>Periodically</li>
           </ul>',
         "cta_html": '<a href="/maas/docs/about-maas-networking"
-          onclick="dataLayer.push({&quot;event&quot;: &quot;GAEvent&quot;, &quot;eventCategory&quot;: &quot;Feature&quot;, &quot;eventAction&quot;: &quot;Click&quot;, &quot;eventLabel&quot;: &quot;Automation&quot; }); dataLayer.push({&quot;event&quot;: &quot;GAEvent&quot;, &quot;eventCategory&quot;: &quot;Interested in feature&quot;, &quot;eventAction&quot;: &quot;Click&quot;, &quot;eventLabel&quot;: &quot;Learn more about device discovery and subnet mapping&quot; });"
+          data-ga-category="Feature" data-ga-action="Click" data-ga-label="Automation" data-ga-extra-category="Interested in feature" data-ga-extra-action="Click" data-ga-extra-label="Learn more about device discovery and subnet mapping"
           aria-label="Link to the configuring networking page on MAAS documentation">Learn more about device discovery and
           subnet mapping&nbsp;&rsaquo;</a>'
       },
@@ -127,7 +127,7 @@ source and free to use, with commercial support available from Canonical.
           <li>Assign to physical <a href="/maas/docs/how-to-manage-machine-groups#p-19384-manage-availability-zones">zones</a></li>
         </ul>',
         "cta_html": '<a href="/maas/docs/how-to-manage-machines"
-          onclick="dataLayer.push({&quot;event&quot;: &quot;GAEvent&quot;, &quot;eventCategory&quot;: &quot;Feature&quot;, &quot;eventAction&quot;: &quot;Click&quot;, &quot;eventLabel&quot;: &quot;Fast deployment&quot; });"
+          data-ga-category="Feature" data-ga-action="Click" data-ga-label="Fast deployment"
           aria-label="Link to machine lifecycle page on MAAS documentation">Learn more about the node actions&nbsp;&rsaquo;</a>'
       },
       {
@@ -147,7 +147,7 @@ source and free to use, with commercial support available from Canonical.
         </ul>
         <p>Import, update or sync the images or connect to an onsite mirror to work offline.</p>',
         "cta_html": '<a href="/maas/docs/how-to-manage-images"
-          onclick="dataLayer.push({&quot;event&quot;: &quot;GAEvent&quot;, &quot;eventCategory&quot;: &quot;Feature&quot;, &quot;eventAction&quot;: &quot;Click&quot;, &quot;eventLabel&quot;: &quot;Learn more about images&quot; });"
+          data-ga-category="Feature" data-ga-action="Click" data-ga-label="Learn more about images"
           aria-label="Link to the install config images page on MAAS documentation">Learn more about images&nbsp;&rsaquo;</a>'
       },
       {
@@ -162,7 +162,7 @@ source and free to use, with commercial support available from Canonical.
             <li>Press 'deploy'</li>
           </ol>",
         "cta_html": '<a href="/maas/docs/how-to-manage-machines#p-9078-deploy-machines"
-          onclick="dataLayer.push({&quot;event&quot;: &quot;GAEvent&quot;, &quot;eventCategory&quot;: &quot;Feature&quot;, &quot;eventAction&quot;: &quot;Click&quot;, &quot;eventLabel&quot;: &quot;Fast deployment&quot; });"
+          data-ga-category="Feature" data-ga-action="Click" data-ga-label="Fast deployment"
           aria-label="Link to the install and config page of node deployment on MAAS documentation">Learn more about
           deployment&nbsp;&rsaquo;</a>'
       },
@@ -228,7 +228,7 @@ source and free to use, with commercial support available from Canonical.
       </p>
       <p>
         <a href="/maas/docs/reference-hardware-test-scripts"
-          onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Keep an eye on your hardware feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about hardware testing' });"
+          data-ga-category="Feature" data-ga-action="Click" data-ga-label="Machine configuration" data-ga-extra-category="Keep an eye on your hardware feature" data-ga-extra-action="Click" data-ga-extra-label="Learn more about hardware testing"
           aria-label="Link to hardware testing on MAAS documentation">Learn more about hardware testing&nbsp;&rsaquo;</a>
       </p>
     {% endif %}
@@ -259,7 +259,7 @@ source and free to use, with commercial support available from Canonical.
           <li>Static routes and more&hellip;</li>
         </ul>',
         "cta_html": '<a href="/maas/docs/how-to-manage-networks"
-          onclick="dataLayer.push({&quot;event&quot;: &quot;GAEvent&quot;, &quot;eventCategory&quot;: &quot;Feature&quot;, &quot;eventAction&quot;: &quot;Click&quot;, &quot;eventLabel&quot;: &quot;Machine configuration&quot; });dataLayer.push({&quot;event&quot;: &quot;GAEvent&quot;, &quot;eventCategory&quot;: &quot;Interested in feature&quot;, &quot;eventAction&quot;: &quot;Click&quot;, &quot;eventLabel&quot;: &quot;Learn more about interfaces&quot; });"
+          data-ga-category="Feature" data-ga-action="Click" data-ga-label="Machine configuration" data-ga-extra-category="Interested in feature" data-ga-extra-action="Click" data-ga-extra-label="Learn more about interfaces"
           aria-label="Link to the install config and commission nodes page on MAAS documentation">Learn more about
           interfaces&nbsp;&rsaquo;</a>'
       },
@@ -282,7 +282,7 @@ source and free to use, with commercial support available from Canonical.
           </li>
         </ul>',
         "cta_html": '<a href="/maas/docs/reference-maas-storage"
-          onclick="dataLayer.push({&quot;event&quot;: &quot;GAEvent&quot;, &quot;eventCategory&quot;: &quot;Feature&quot;, &quot;eventAction&quot;: &quot;Click&quot;, &quot;eventLabel&quot;: &quot;Machine configuration&quot; });dataLayer.push({&quot;event&quot;: &quot;GAEvent&quot;, &quot;eventCategory&quot;: &quot;Feature&quot;, &quot;eventAction&quot;: &quot;Click&quot;, &quot;eventLabel&quot;: &quot;Learn more about storage&quot; });"
+          data-ga-category="Feature" data-ga-action="Click" data-ga-label="Machine configuration" data-ga-extra-category="Feature" data-ga-extra-action="Click" data-ga-extra-label="Learn more about storage"
           aria-label="Link to install and configure storage on MAAS documentation">Learn more about storage&nbsp;&rsaquo;</a>'
       },
     ]
@@ -325,7 +325,7 @@ source and free to use, with commercial support available from Canonical.
       </ul>
       <div class="p-cta-block">
         <a href="/maas/docs/how-to-manage-network-services"
-          onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about DHCP in MAAS' });"
+          data-ga-category="Feature" data-ga-action="Click" data-ga-label="Learn more about DHCP in MAAS"
           class="u-sv2" aria-label="Link to install and configure network dhcp page on MAAS documentation">Learn more about
           <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> in MAAS&nbsp;&rsaquo;</a>
       </div>
@@ -338,52 +338,52 @@ source and free to use, with commercial support available from Canonical.
       <ul>
         <li>
           <abbr title="Internet Protocol version 4">IPv4</abbr> and <a href="/maas/docs/about-maas-networking"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"
+            data-ga-category="Feature" data-ga-action="Click" data-ga-label="Network management"
             aria-label="Link to install and configure network Internet Protocol version 6 on MAAS documentation"><abbr
               title="Internet Protocol version 6">IPv6</abbr></a>
         </li>
         <li>
           <a href="/maas/docs/how-to-manage-networks#p-9070-manage-subnets"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"
+            data-ga-category="Feature" data-ga-action="Click" data-ga-label="Network management"
             aria-label="Link to install and configure network subnet management on MAAS documentation">Subnets</a>
         </li>
         <li>
           <a href="/maas/docs/reference-maas-glossary#p-9410-v"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"
+            data-ga-category="Feature" data-ga-action="Click" data-ga-label="Network management"
             aria-label="Link to intro concepts about virtual local area networks on MAAS documentation"><abbr
               title="Virtual local area network">VLAN</abbr></a>
         </li>
         <li>
           <a href="/maas/docs/reference-maas-glossary#p-9410-f"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"
+            data-ga-category="Feature" data-ga-action="Click" data-ga-label="Network management"
             aria-label="Link to intro concepts about fabrics on MAAS documentation">Fabrics</a>
         </li>
         <li>
           <a href="/maas/docs/reference-maas-glossary#p-9410-s"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"
+            data-ga-category="Feature" data-ga-action="Click" data-ga-label="Network management"
             aria-label="Link to intro concepts about spaces on MAAS documentation">Spaces</a>
         </li>
         <li>
           <a href="/maas/docs/how-to-manage-networks"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"
+            data-ga-category="Feature" data-ga-action="Click" data-ga-label="Network management"
             aria-label="Link to install and configure network ntp on MAAS documentation"><abbr
               title="Network Time Protocol">NTP</abbr></a>
         </li>
         <li>
           <a href="/maas/docs/how-to-enhance-maas-security#p-9102-use-tls-termination-maas-33"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"
+            data-ga-category="Feature" data-ga-action="Click" data-ga-label="Network management"
             aria-label="Link to install and configure secure sockets layer on MAAS documentation"><abbr
               title="Secure sockets layer">SSL</abbr></a>
         </li>
         <li>
           <a href="/maas/docs/how-to-manage-networks"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"
+            data-ga-category="Feature" data-ga-action="Click" data-ga-label="Network management"
             aria-label="Link to install and configure spanning tree protocol on MAAS documentation"><abbr
               title="Spanning tree protocol">STP</abbr></a>
         </li>
         <li>
           <a href="/maas/docs/how-to-manage-networks"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"
+            data-ga-category="Feature" data-ga-action="Click" data-ga-label="Network management"
             aria-label="Link to install and configure network proxy on MAAS documentation">Proxy</a>
         </li>
       </ul>
@@ -455,7 +455,7 @@ source and free to use, with commercial support available from Canonical.
             "item": {
               "type": "text",
               "content": '<a href="/maas/docs/maas"
-                onclick="dataLayer.push({&quot;event&quot;: &quot;GAEvent&quot;, &quot;eventCategory&quot;: &quot;Feature&quot;, &quot;eventAction&quot;: &quot;Click&quot;, &quot;eventLabel&quot;: &quot;REST API, CLI&quot; });"
+                data-ga-category="Feature" data-ga-action="Click" data-ga-label="REST API, CLI"
                 aria-label="Link to manage command line interface page on MAAS documentation">Get started with the MAAS CLI&nbsp;&rsaquo;</a>',
             }
           },
@@ -464,7 +464,7 @@ source and free to use, with commercial support available from Canonical.
             "item": {
               "type": "text",
               "content": '<a href="/maas/docs/api"
-                  onclick="dataLayer.push({&quo;event&quo;: &quo;GAEvent&quo;, &quo;eventCategory&quo;: &quo;Feature&quo;, &quo;eventAction&quo;: &quo;Click&quo;, &quo;eventLabel&quo;: &quo;REST API, CLI&quo; });"
+                  data-ga-category="Feature" data-ga-action="Click" data-ga-label="REST API, CLI"
                   aria-label="Link to application programming interface page on MAAS documentation">See the API documentation to automate and extend MAAS&nbsp;&rsaquo;</a>',
             }
           },

--- a/templates/partners/become-a-partner.html
+++ b/templates/partners/become-a-partner.html
@@ -81,7 +81,8 @@
         <form action="https://ubuntu.com/marketo/submit"
               method="post"
               id="mktoForm_1260"
-              onsubmit="ga('send', 'Become a partner', 'Signup', 'Become a partner application');">
+              data-ga-submit-category="Become a partner" data-ga-submit-action="Signup"
+              data-ga-submit-label="Become a partner application">
           <label for="firstName">First name</label>
           <input required id="firstName" name="firstName" maxlength="255" type="text" />
 

--- a/templates/shared/_blog-card.html
+++ b/templates/shared/_blog-card.html
@@ -24,7 +24,7 @@
     {% else %}
       <h2 class="{% if heading_class %}{{ heading_class }}{% else %}p-heading--3{% endif %}">
     {% endif %}
-    <a href="/blog{% if tag_name %}/tag/{{ tag_name }}{% endif %}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : 'canonical.com{% if tag_name %}/{{ tag_name }}{% else %} homepage{% endif %}', 'eventValue' : undefined });">
+    <a href="/blog{% if tag_name %}/tag/{{ tag_name }}{% endif %}" data-ga-category="blog" data-ga-action="clicks blog feed link" data-ga-label="canonical.com{% if tag_name %}/{{ tag_name }}{% else %} homepage{% endif %}">
       {% if heading_topic %}
         {{ heading_topic }}&nbsp;&rsaquo;
       {% else %}

--- a/templates/shared/_fast_track_jobs.html
+++ b/templates/shared/_fast_track_jobs.html
@@ -11,7 +11,7 @@
       <div class="p-card p-featured__role u-no-margin--bottom">
         <a class="p-featured__role-url"
            href="/careers/{{ job.id }}"
-           onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Fast track job', 'eventAction' : 'Click', 'eventLabel' : '{{ job.title }}', 'eventValue' : undefined });">{{ job.title }}</a>
+           data-ga-category="Fast track job" data-ga-action="Click" data-ga-label="{{ job.title }}">{{ job.title }}</a>
       </div>
     </div>
   {% endfor %}

--- a/templates/shared/_featured_jobs.html
+++ b/templates/shared/_featured_jobs.html
@@ -12,7 +12,7 @@
               <p>
                 <a class="p-featured__url p-card--content"
                    href="/careers/{{ job.id }}"
-                   onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Featured job', 'eventAction' : 'Click', 'eventLabel' : '{{ job.title }}', 'eventValue' : undefined });">{{ job.title }}</a>
+                   data-ga-category="Featured job" data-ga-action="Click" data-ga-label="{{ job.title }}">{{ job.title }}</a>
               </p>
             </div>
           </div>

--- a/templates/shared/_promoted_roles.html
+++ b/templates/shared/_promoted_roles.html
@@ -22,7 +22,7 @@
                 <p>
                   <a class="p-featured__url p-card--content"
                      href="/careers/{{ job.id }}"
-                     onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Featured job', 'eventAction' : 'Click', 'eventLabel' : '{{ job.title }}', 'eventValue' : undefined });">{{ job.title }}</a>
+                     data-ga-category="Featured job" data-ga-action="Click" data-ga-label="{{ job.title }}">{{ job.title }}</a>
                 </p>
               </div>
             {% endif %}

--- a/templates/solutions/automotive/buyers-guide/_form.html
+++ b/templates/solutions/automotive/buyers-guide/_form.html
@@ -107,7 +107,7 @@
           <li class="p-list__item">
             <button type="submit"
                     class="p-button--positive"
-                    onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'Download automotive buyers guide', 'eventLabel' : '{{ interested_feature }}', 'eventValue' : undefined });">
+                    data-ga-category="Form" data-ga-action="Download automotive buyers guide" data-ga-label="{{ interested_feature }}">
               Submit
             </button>
           </li>


### PR DESCRIPTION
## Done
  - Added `static/js/csp-event-handlers.js` with two handlers wired up on `DOMContentLoaded`:
    - `[data-ga-category]` click → pushes `GAEvent` to `window.dataLayer` (including the optional `data-ga-extra-*` second event).
    - `[data-ga-submit-category]` form submit → pushes `GAEvent` on submit.
  - Loaded the new script from `templates/base_index.html` with a nonce.
  - Replaced inline `onclick="dataLayer.push({…})"` / `onsubmit="dataLayer.push({…})"` with `data-ga-*` attributes across 10 templates: `blog/newsletter-form.html`,
  `careers/includes/_fast-track-jobs.html`, `careers/job-detail.html`, `maas/features.html` (~20 elements), `partners/become-a-partner.html`, `shared/_blog-card.html`,
  `shared/_fast_track_jobs.html`, `shared/_featured_jobs.html`, `shared/_promoted_roles.html`, `solutions/automotive/buyers-guide/_form.html`.
  
  ## QA
  - With GTM debug / GA debug enabled (or a `dataLayer` console spy), confirm `GAEvent` payloads continue to fire for:
    - Clicks on featured/promoted/fast-track job cards (event category `Featured job` / `Fast track job`).
    - Click on the "blog feed link" in `_blog-card`.
    - Submitting the partner signup form on `/partners/become-a-partner`.
    - Submitting the application form on a `/careers/<id>` job page (event category `Form`, action `job application: <id>`).
    - Submitting the automotive buyers-guide form.
    - Clicking each "Click" link on `/maas/features` — especially ones with a second `data-ga-extra-*` payload (e.g. Machine configuration → hardware testing); confirm both
  events fire.
  - DevTools → Network: no inline `onclick="dataLayer.push…"` left in the rendered HTML on the above pages.
  - DevTools console: no CSP violation when these events fire.

