### PR TITLE
copyupdate /ceph/support WD-36739

### DIFF
--- a/templates/ceph/support.html
+++ b/templates/ceph/support.html
@@ -113,15 +113,15 @@
     blocks=[
       {
         "stat": "1 hour",
-        "headline": "Response time SLA for severity 1 issues.",
+        "description": "Response time SLA for severity 1 issues.",
       },
       {
         "stat": "24/7/365",
-        "headline": "Access to phone and ticket support.",
+        "description": "Access to phone and ticket support.",
       },
       {
         "stat": "Up to 15 years",
-        "headline": "Security fixes and support with Ubuntu Pro.",
+        "description": "Security fixes and support with Ubuntu Pro.",
       },
     ],
   ) }}


### PR DESCRIPTION
## Done

Change the font of the descriptions under the stats of the "Enterprise-grade Ceph support" section in /ceph/support.

copydoc: https://docs.google.com/document/d/1HFtvu3abhwL5ulgWZzZGpElJNqMVAW3qeeEs7APvZRA/edit?tab=t.jijjhiya0no5

## QA

- Open the [DEMO](https://canonical-com-2550.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Go to /ceph/support.
- Make sure that the font of the descriptions under the stats of the "Enterprise-grade Ceph support" section match those under the stats of the "Canonical Ceph: Proven and Trusted" section in /ceph. See the screenshots for clarificaition

## Issue / Card

WD-36739

Fixes [WD-36739](https://warthogs.atlassian.net/browse/WD-36739)

## Screenshots

Required

<img width="2574" height="304" alt="image" src="https://github.com/user-attachments/assets/148af8cf-1596-4f0c-949b-13594cf113cd" />
<img width="2588" height="332" alt="image" src="https://github.com/user-attachments/assets/8e640e84-4e01-4f58-9222-afb9c1e1b88a" />

Before 
<img width="1762" height="241" alt="image" src="https://github.com/user-attachments/assets/096d554e-2ca0-4a95-9cdd-8c923c184b4b" />


After

<img width="1762" height="241" alt="image" src="https://github.com/user-attachments/assets/f2d8f069-a91c-473b-ba16-a6ed78d139ef" />



[WD-36739]: https://warthogs.atlassian.net/browse/WD-36739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ