### PR TITLE
Change key value from 'event' to 'roadshow'

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -271,7 +271,7 @@ class TestViews(unittest.TestCase):
             call_args = mock_engage_docs.get_index.call_args
             self.assertEqual(call_args[1]["tag_value"], "roadshow")
             self.assertEqual(call_args[1]["key"], "type")
-            self.assertEqual(call_args[1]["value"], "event")
+            self.assertEqual(call_args[1]["value"], "roadshow")
 
     @patch("webapp.views.flask.render_template")
     def test_canonical_days_filters_incomplete_events(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -254,7 +254,7 @@ def build_canonical_days_index(engage_docs):
             active_count,
             current_total,
         ) = engage_docs.get_index(
-            limit, offset=None, tag_value="roadshow", key="type", value="event"
+            limit, offset=None, tag_value="roadshow", key="type", value="roadshow"
         )
         total_pages = math.ceil(current_total / limit)
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -254,7 +254,11 @@ def build_canonical_days_index(engage_docs):
             active_count,
             current_total,
         ) = engage_docs.get_index(
-            limit, offset=None, tag_value="roadshow", key="type", value="roadshow"
+            limit, 
+            offset=None, 
+            tag_value="roadshow", 
+            key="type", 
+            value="roadshow"
         )
         total_pages = math.ceil(current_total / limit)
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -254,10 +254,10 @@ def build_canonical_days_index(engage_docs):
             active_count,
             current_total,
         ) = engage_docs.get_index(
-            limit, 
-            offset=None, 
-            tag_value="roadshow", 
-            key="type", 
+            limit,
+            offset=None,
+            tag_value="roadshow",
+            key="type",
             value="roadshow"
         )
         total_pages = math.ceil(current_total / limit)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -258,7 +258,7 @@ def build_canonical_days_index(engage_docs):
             offset=None,
             tag_value="roadshow",
             key="type",
-            value="roadshow"
+            value="roadshow",
         )
         total_pages = math.ceil(current_total / limit)
 


### PR DESCRIPTION
## Done

- update roadshow event type query param

## QA

- Open the [DEMO](https://canonical-com-2551.demos.haus/events/canonical-days)
- Check you can see the roadshow events. Example:
<img width="1375" height="376" alt="image" src="https://github.com/user-attachments/assets/6ed4e4cf-81d3-48af-89f4-e1ab318245c5" />



