### PR TITLE
feat(WD-36512): Implement custom video section macro for case studies

### DIFF
--- a/templates/case-study/unibap-space-computing.html
+++ b/templates/case-study/unibap-space-computing.html
@@ -7,7 +7,15 @@
 {% from "macros/_macros-highlights.jinja" import highlights %}
 {% from "macros/_macros-text.jinja" import text %}
 {% from "macros/_macros-image.jinja" import image_wrapper %}
+{% from 'macros/_macros-case-study-video.jinja' import case_study_video %}
 {% from "macros/_macros-cta.jinja" import cta %}
+
+{% block extra_metatags %}
+  <script type="module"
+          src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+          integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+          crossorigin="anonymous"></script>
+{% endblock extra_metatags %}
 
 {% block title %}Unibap powers robust and accessible space computing with Ubuntu{% endblock %}
 
@@ -246,6 +254,14 @@
     hide_image_small=True
     )
     -%}
+  {%- endcall -%}
+
+  {%- call(slot) case_study_video(top_rule_variant="muted", title="Optional video section title", video_id="i9oDHGPBlwo", video_title="Trusted open source for everyone", caption="Optional video caption goes here") -%}
+    {%- if slot == "content" -%}
+      <p>
+        Optional paragraph text: To meet these challenges, Canonical deployed its Kubernetes and Ceph distributions across data centres located at ESA’s European Space Operations Centre in Darmstadt, Germany. Canonical assisted ESA in the architecture, design and deployment of Kubernetes across hundreds of VMs and dozens of clusters, all connected to physical clusters of Ceph storage, as part of its Managed Services offering. Canonical are also working on the deployment of PostgreSQL and Kafka, which will also be a Managed Service, allowing ESA to focus more on supporting mission operations.
+      </p>
+    {%- endif -%}
   {%- endcall -%}
 
 {% endblock %}

--- a/templates/macros/_macros-case-study-video.jinja
+++ b/templates/macros/_macros-case-study-video.jinja
@@ -1,0 +1,41 @@
+# This macro is used to add videos to case studies.
+
+# Params
+# top_rule_variant(optional): Variant of the top rule to use (One of "default", "highlighted", "muted", "none". Default is "muted")
+# title(optional): Title of the video section
+# video_id (required): ID of the YouTube video to embed
+# video_title (required): Title of the video for accessibility
+# caption(optional): Caption for the video
+
+# Slots
+# content: Main content of the video section
+
+{% from 'macros/_macros-lite-video.jinja' import lite_video %}
+{% from '_macros/shared/vf_section_top_rule.jinja' import vf_section_top_rule %}
+
+{%- macro case_study_video(video_id, video_title, top_rule_variant="muted", title="", caption="") -%}
+  {%- set paragraph_content = caller('content') -%}
+  {%- set has_paragraph_content = paragraph_content|trim|length > 0 %}
+
+  <section class="p-section">
+    <div class="grid-row">
+      <div class="grid-col-start-large-3 grid-col-6">
+        {{ vf_section_top_rule(top_rule_variant=top_rule_variant) }}
+        {%- if title -%}
+          <h2 class="p-section--shallow">{{ title }}</h2>
+        {%- else -%}
+          <h2 class="u-off-screen">{{ video_title }}</h2>
+        {%- endif -%}
+        {%- if video_id and video_title -%}
+          <div class="u-sv-3">{{ lite_video(video_id=video_id, video_title=video_title) }}</div>
+        {%- endif -%}
+        {%- if caption -%}
+          <p class="u-text--muted">{{ caption }}</p>
+        {%- endif -%}
+        {%- if has_paragraph_content -%}
+          {{ paragraph_content | safe }}
+        {%- endif -%}
+      </div>
+    </div>
+  </section>
+{%- endmacro -%}


### PR DESCRIPTION
## Done

- Add `macros/_macros-case-study-video.jinja` macro
- Showcase this custom macro in `unibap-space-computing` case study **(To be reverted before merging)**
- UX Features:
  - Display youtube video thumbnail
  - No autoplay
  - Use video's actual title for screen readers if section title not provided
  - Optional params: top rule variant, section title, caption text, paragraph text

## QA

- Open the [DEMO](https://canonical-com-2552.demos.haus/case-study/unibap-space-computing)
- Alternatively, check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/case-study/unibap-space-computing
- Scroll to the bottom until you find `Optional video section title` section
- Verify the macro matches [figma](https://www.figma.com/design/rEDsQqLe8SfnvoxCcXJYLr/canonical.com-case-study---Sites?node-id=2088-4972&t=7QMxVyAb7xH4AtrH-1)

## Issue / Card

Fixes [WD-36512](https://warthogs.atlassian.net/browse/WD-36512)

## Screenshots

With title: <br />
<img width="1073" height="979" alt="image" src="https://github.com/user-attachments/assets/d02f96aa-c7f2-4621-ac1a-4f3203795130" />
<br />
Without title: <br />
**Note for UX: If no section title is provided, the video's title from youtube will be used as a title by screen readers.**
<img width="1069" height="875" alt="image" src="https://github.com/user-attachments/assets/72d4568a-8303-4391-bf11-7ce6747329f7" />
<br/>
<img width="1639" height="807" alt="image" src="https://github.com/user-attachments/assets/83d34c9f-d911-44de-a930-9aeb5dbb3439" />
<br/>
No title and top rule:<br/>
<img width="1074" height="857" alt="image" src="https://github.com/user-attachments/assets/9d6356f6-872b-4127-aa77-5bdf42138f15" />



[WD-36512]: https://warthogs.atlassian.net/browse/WD-36512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
