### PR TITLE
fix: SSRF vulnerability in CLA API proxy (F07)

### DIFF
--- a/webapp/canonical_cla/views.py
+++ b/webapp/canonical_cla/views.py
@@ -175,6 +175,19 @@ def canonical_cla_api_proxy():
     # is in the allowed endpoints list
     # Parse the URL to extract just the path for validation
     parsed_url = urlparse.urlparse(request_url)
+    canonical_cla_api_host = urlparse.urlparse(
+        CANONICAL_CLA_API_URL
+    ).hostname
+
+    if parsed_url.netloc and parsed_url.hostname != canonical_cla_api_host:
+        error_response = flask.make_response(
+            {"detail": "Endpoint not allowed"}
+        )
+        error_response.headers["Content-Type"] = "application/json"
+        error_response.status_code = 403
+        error_response.cache_control.no_store = True
+        return error_response
+
     request_path = parsed_url.path
 
     if request_path not in ALLOWED_ENDPOINTS:

--- a/webapp/canonical_cla/views.py
+++ b/webapp/canonical_cla/views.py
@@ -175,11 +175,8 @@ def canonical_cla_api_proxy():
     # is in the allowed endpoints list
     # Parse the URL to extract just the path for validation
     parsed_url = urlparse.urlparse(request_url)
-    canonical_cla_api_host = urlparse.urlparse(
-        CANONICAL_CLA_API_URL
-    ).hostname
 
-    if parsed_url.netloc and parsed_url.hostname != canonical_cla_api_host:
+    if parsed_url.netloc:
         error_response = flask.make_response(
             {"detail": "Endpoint not allowed"}
         )


### PR DESCRIPTION
## Context
`canonical_cla_api_proxy` currently validates only the path of the decoded `request_url` against an allowlist. An attacker could supply an absolute URL (e.g. http://attacker.example/github/login) which would pass the path check but cause `urljoin` to send the request, including the victim's session cookies, to the attacker's host, with the response reflected back under the canonical.com origin.

## Done

- Reject any request_url whose netloc does not match CANONICAL_CLA_API_URL's host

## QA

- Not currently sure how to QA this, suggestions welcome.


