### PR TITLE
fix: use correct custom field name for candidate dashboard "other applications" links

### DIFF
--- a/templates/careers/application/index.html
+++ b/templates/careers/application/index.html
@@ -112,7 +112,7 @@
             {% for app in application["candidate"]["applications"] %}
               {% if app["status"] != 'rejected' and app["id"] != application["id"] and app["jobs"]|length > 0 and app["jobs"][0]["id"] != second_look_req_id %}
                 <li class="p-inline-list__item">
-                  <a href='{{ app["custom_fields"]["canonical_com_application_page"] }}'>{{ app["jobs"][0]["name"] }}</a>
+                  <a href='{{ app["custom_fields"]["canonical_com_application_dashboard"] }}'>{{ app["jobs"][0]["name"] }}</a>
                 </li>
               {% endif %}
             {% endfor %}


### PR DESCRIPTION
## Done

- Updated "other applications" links to utilise correct custom field name for candidate dashboard (was changed in Greenhouse). This was causing the "other applications" links to silently fallback to the same page the candidate was viewing, thus breaking the functionality entirely. With this fix the links get their proper `href`s and go to the correct page.


