### PR TITLE
chore(WD-36821): update old case studies and macros to the new 8-column grid

### DIFF
--- a/templates/case-study/episensor.html
+++ b/templates/case-study/episensor.html
@@ -59,8 +59,8 @@
   {%- endcall %}
   {%- call(slot) image_wrapper(caption="Screenshot of the EpiSensor Edge interface showing how snaps are integrated into the software.") -%}
     {%- if slot == 'image_content' %}
-      <div class="row">
-        <div class="col-start-large-4 col-9">
+      <div class="grid-row">
+        <div class="grid-col-start-large-3 grid-col-6">
           {{ image(url="https://assets.ubuntu.com/v1/26633280-edge%20screenshot%201.png",
                     alt="",
                     width="2748",
@@ -174,8 +174,8 @@
   {%- endcall -%}
 
   <section class="p-section">
-    <div class="row">
-      <div class="col-start-large-4 col-9">
+    <div class="grid-row">
+      <div class="grid-col-start-large-3 grid-col-6">
 
         <p>
           Unlike other packaging systems that require the developer to either write granular rules or grant unlimited privileges for their containers, snaps use predefined <a href="https://snapcraft.io/docs/supported-interfaces">interfaces</a> maintained by Canonical. These interfaces allow secure and controlled access to resources such as Zigbee, GPIO pins, network interfaces, the $HOME directory and more. This simplifies resource management and improves usability for confined applications. 
@@ -191,8 +191,8 @@
   </section>
   {%- call(slot) image_wrapper(caption="Screenshot of the EpiSensor Edge interface showing the Ollama snap being added to the device.") -%}
     {%- if slot == 'image_content' %}
-      <div class="row">
-        <div class="col-start-large-4 col-9">
+      <div class="grid-row">
+        <div class="grid-col-start-large-3 grid-col-6">
           {{ image(url="https://assets.ubuntu.com/v1/a0aea0f9-edge%20screenshot%202.png",
                     alt="",
                     width="2748",

--- a/templates/case-study/managed-kafka-for-smart-safety.html
+++ b/templates/case-study/managed-kafka-for-smart-safety.html
@@ -186,8 +186,8 @@
   {%- endcall -%}
 
   <div class="p-section">
-    <div class="row">
-      <div class="col-start-large-4 col-9">
+    <div class="grid-row">
+      <div class="grid-col-start-large-3 grid-col-6">
         <hr class="p-rule--muted">
         <p class="u-text--muted">
           Apache&reg;, Apache Kafka, Kafka&reg;, and the Kafka logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.

--- a/templates/case-study/oediv-de.html
+++ b/templates/case-study/oediv-de.html
@@ -10,18 +10,18 @@
 
 {%- macro de_quote(quote_text, name, title, organisation) -%}
   <div class="p-section--shallow">
-    <div class="row">
-      <div class="col-9 col-start-large-4 col-medium-4 col-start-medium-3">
+    <div class="grid-row">
+      <div class="grid-col-start-large-3 grid-col-6 grid-col-medium-3 grid-col-start-medium-2">
         <hr class="p-rule--muted" />
-        <div class="row">
-          <div class="col-6">
+        <div class="grid-row">
+          <div class="grid-col-4">
             <div class="p-section--shallow">
               <p class="p-heading--4">
                 <i>&#8222;{{ quote_text|safe }}&#8220;</i>
               </p>
             </div>
           </div>
-          <div class="col-3">
+          <div class="grid-col-2">
             <hr class="p-rule--muted u-hide--large" />
             <p>
               <strong>{{ name }}</strong>

--- a/templates/case-study/unibap-space-computing.html
+++ b/templates/case-study/unibap-space-computing.html
@@ -106,8 +106,8 @@
   {%- endcall -%}
 
   <section class="p-section">
-    <div class="row">
-      <div class="col-start-large-4 col-9">
+    <div class="grid-row">
+      <div class="grid-col-start-large-3 grid-col-6">
         <p>
           Unibap's hardware is pre-built with the components needed to perform complicated operations that we take for granted on the earth's surface, whilst also being designed for maximum compatibility with restrictive satellite hardware. However, they needed to identify the operating system that would best complement their hardware and achieve the same, optimal balance between robustness and versatility.
         </p>
@@ -151,8 +151,8 @@
   {%- endcall -%}
 
   <section class="p-section">
-    <div class="row">
-      <div class="col-start-large-4 col-9">
+    <div class="grid-row">
+      <div class="grid-col-start-large-3 grid-col-6">
         <p>
           Ubuntu is an open source operating system, published by Canonical, that is used by organizations to innovate across a whole host of industries. In the State of Open Source 2024, it was ranked as the #1 favorite Linux distribution amongst enterprise developers. Its accessibility and versatility lowered the barrier to entry for Unibap's customers, but the fact remains that satellite hardware will continue to age. Unibap needed to demonstrate to customers that Ubuntu was robust and would last the distance, especially considering that satellite projects are intended to run for years on end.
         </p>
@@ -207,8 +207,8 @@
   {%- endcall -%}
 
   <section class="p-section">
-    <div class="row">
-      <div class="col-start-large-4 col-9">
+    <div class="grid-row">
+      <div class="grid-col-start-large-3 grid-col-6">
         <p>
           Ubuntu's versatility has also meant that Unibap hardware has been at the forefront of some of the most exciting space projects. In collaboration with the European Space Agency, Unibap has undertaken three missions in which they allowed developers to book testing slots aboard the host satellite. Over the missions, Ubuntu was used to test over 40 applications involving real-time processing for agriculture, natural disasters, traffic and bush fires.
         </p>
@@ -228,8 +228,8 @@
   {%- endcall -%}
 
   <section class="p-section">
-    <div class="row">
-      <div class="col-start-large-4 col-9">
+    <div class="grid-row">
+      <div class="grid-col-start-large-3 grid-col-6">
         <p>
           Unibap is planning to move ahead with further space projects in both the public and private sectors. With more than 30 launches planned during 2025, Unibap will continue to work hard to bring new innovations to space computing, and empower those who want to run transformative projects.
         </p>

--- a/templates/macros/_macros-cta.jinja
+++ b/templates/macros/_macros-cta.jinja
@@ -7,8 +7,8 @@
   {% if hide_wrapper != True %}
     <hr class="p-rule is-fixed-width" />
     <section class="p-strip is-deep">
-      <div class="row">
-        <div class="col-start-large-4 col-9">
+      <div class="grid-row">
+        <div class="grid-col-start-large-3 grid-col-6">
           <p class="p-heading--2">
             <a href="{{ link }}"
             {% if has_modal %}class="js-invoke-modal" aria-controls="case-study-contact-modal"{% endif %}>

--- a/templates/macros/_macros-highlights.jinja
+++ b/templates/macros/_macros-highlights.jinja
@@ -37,7 +37,7 @@
         <div class="grid-col-6">
           <hr class="p-rule--muted" />
           <div class="grid-row">
-            <div class="col-2">
+            <div class="grid-col-2">
               <h2 class="p-text--small-caps">Highlights</h2>
             </div>
             <div class="grid-col-4">

--- a/templates/macros/_macros-highlights.jinja
+++ b/templates/macros/_macros-highlights.jinja
@@ -6,14 +6,14 @@
 {%- macro highlights(num_items) -%}
   <section class="p-section">
     {% if num_items <= 4 %}
-      <div class="row">
+      <div class="grid-row">
         {% if num_items == 4 %}<h2 class="p-text--small-caps">Highlights</h2>{% endif %}
         <hr class="p-rule--muted" />
       </div>
       <ul class="p-list u-no-margin--bottom">
-        <div class="row">
+        <div class="grid-row">
           {% if num_items < 4 %}
-            <div class="col-3">
+            <div class="grid-col-2">
               <h2 class="p-text--small-caps">Highlights</h2>
             </div>
           {% endif %}
@@ -23,7 +23,7 @@
             {%- set has_highlights_item_content = highlights_item_content|trim|length > 0 -%}
 
             {%- if has_highlights_item_content -%}
-              <div class="col-3 u-text-max-width">
+              <div class="grid-col-2 u-text-max-width">
                 <li class="p-list__item is-ticked">
                   <p class="u-text-max-width u-no-padding--top">{{ highlights_item_content }}</p>
                 </li>
@@ -33,16 +33,16 @@
         </div>
       </ul>
     {% else %}
-      <div class="row">
-        <div class="col-9">
+      <div class="grid-row">
+        <div class="grid-col-6">
           <hr class="p-rule--muted" />
-          <div class="row">
-            <div class="col-3">
+          <div class="grid-row">
+            <div class="col-2">
               <h2 class="p-text--small-caps">Highlights</h2>
             </div>
-            <div class="col-6">
+            <div class="grid-col-4">
               <ul class="p-list--divided u-text-max-width">
-                <div class="row">
+                <div class="grid-row">
                   {% for number in range (1, num_items+1) %}
                     {%- set highlights_item_content = caller('highlights_item_content_' + number|string) -%}
                     {%- set has_highlights_item_content = highlights_item_content|trim|length > 0 -%}

--- a/templates/macros/_macros-image.jinja
+++ b/templates/macros/_macros-image.jinja
@@ -8,15 +8,15 @@
   {%- set image_content = caller('image_content') -%}
   {%- set has_image = image_content|trim|length>0 -%}
   <section class="p-section">
-    <div class="row">
-      {% if right_align %}<div class="col-start-large-4 col-9">{% endif %}
+    <div class="grid-row">
+      {% if right_align %}<div class="grid-col-start-large-3 grid-col-6">{% endif %}
       {% if has_image %}
         <div class="p-image-container u-align--{% if right_align %}right{% else %}center{% endif %} u-vertically-center u-no-padding--bottom">
           {{ image_content }}
         </div>      
       {% endif %}
       {% if caption %}
-      <div class="col-start-large-4 col-9">
+      <div class="grid-col-start-large-3 grid-col-6">
         <p class="u-text--muted u-no-max-width">{{ caption }}</p>
       </div>
       {% endif %}

--- a/templates/macros/_macros-quote-wrapper.jinja
+++ b/templates/macros/_macros-quote-wrapper.jinja
@@ -97,17 +97,17 @@
       {#- Optional heading -#}
       <div class="p-section--shallow">
         <hr class="p-rule--highlight is-fixed-width" />
-        <div class="row">
+        <div class="grid-row">
           {%- if has_title %}
             {#- Optional heading text -#}
-            <div class="col-3 col-medium-2">
+            <div class="grid-col-2">
               <h2 class="p-muted-heading">{{ title_text }}</h2>
             </div>
           {%- endif -%}
 
           {%- if has_heading_link %}
             {#- Optional heading link  -#}
-            <div class="col-3 col-medium-4 col-start-large-10 col-start-medium-3">
+            <div class="grid-col-2 grid-col-start-large-7">
               <p class="p-text--default">{{ heading_link_content }}</p>
             </div>
           {% endif -%}
@@ -118,7 +118,7 @@
 
   <div class="p-section{% if is_shallow %}--shallow{% endif %}">
     {{- _heading_block() -}}
-    <div class="row">
+    <div class="grid-row">
       {% if has_signpost_image -%}
         {% if not has_heading_row %}
           {#-
@@ -128,18 +128,18 @@
           <hr class="p-rule u-hide--medium u-hide--large {% if hide_image_small %}u-hide--small{% endif %}" />
         {% endif %}
         {#- Optional signpost image -#}
-        <div class="col-3 col-medium-2 {% if hide_image_small %}u-hide--small{% endif %}">
+        <div class="grid-col-2 grid-col-medium-1 {% if hide_image_small %}u-hide--small{% endif %}">
           <div class="p-section--shallow">{{ signpost_image_content }}</div>
         </div>
       {% endif -%}
 
-      <div class="col-9 col-start-large-4 col-medium-4 col-start-medium-3">
+      <div class="grid-col-6 grid-col-start-large-3 grid-col-medium-3 grid-col-start-medium-2">
         <hr class="p-rule--muted" />
         {% if has_citation -%}
           {#-  When a citation is present, wrap the quote and citation in a nested grid to space them properly  -#}
-          <div class="row">
-            <div class="col-6">{{ _quote_body() }}</div>
-            <div class="col-3">
+          <div class="grid-row">
+            <div class="grid-col-4">{{ _quote_body() }}</div>
+            <div class="grid-col-2">
               <hr class="p-rule--muted u-hide--large" />
               {{ _citation_block() }}
             </div>

--- a/templates/macros/_macros-text-list.jinja
+++ b/templates/macros/_macros-text-list.jinja
@@ -5,8 +5,8 @@
 
 {%- macro text_list(title) -%}
   <section class="p-section">
-    <div class="row">
-      <div class="col-start-large-4 col-9">
+    <div class="grid-row">
+      <div class="grid-col-start-large-3 grid-col-6">
         <hr class="p-rule--muted" />
         <h2 class="p-section--shallow">{{ title }}</h2>
         <ul class="p-list--divided u-text-max-width u-no-margin--bottom">

--- a/templates/macros/_macros-text.jinja
+++ b/templates/macros/_macros-text.jinja
@@ -5,8 +5,8 @@
 
 {%- macro text(title) -%}
   <section class="p-section">
-    <div class="row">
-      <div class="col-start-large-4 col-9">
+    <div class="grid-row">
+      <div class="grid-col-start-large-3 grid-col-6">
         {% if title %}
           <hr class="p-rule--muted"/>
           <h2 class="p-section--shallow">{{ title }}</h2>


### PR DESCRIPTION
## Done

- Replaced legacy 12 column grid on case studies with new 8 column grid

## QA

- Open the [DEMO](https://canonical-com-2557.demos.haus/case-study)
- Alternatively, check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/case-study
- Open different case studies and verify they look the same as before, on different screen sizes.

## Issue / Card

Fixes [WD-36821](https://warthogs.atlassian.net/browse/WD-36821)


[WD-36821]: https://warthogs.atlassian.net/browse/WD-36821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
