### PR TITLE
chore: Update multipass release information

### DIFF
--- a/static/files/latest-multipass-releases.json
+++ b/static/files/latest-multipass-releases.json
@@ -1,11 +1,11 @@
 {
-  "version": "1.16.2",
-  "title": "Multipass 1.16.2 release",
+  "version": "1.16.3",
+  "title": "Multipass 1.16.3 release",
   "description": "Fully open source, custom image launch, GUI improvements, and many fixes.",
   "download_url": "https://canonical.com/multipass/install",
-  "release_url": "https://github.com/canonical/multipass/releases/tag/v1.16.2",
+  "release_url": "https://github.com/canonical/multipass/releases/tag/v1.16.3",
   "installer_urls": {
-    "windows": "https://github.com/canonical/multipass/releases/download/v1.16.2/multipass-1.16.2+win-win64.msi",
-    "macos": "https://github.com/canonical/multipass/releases/download/v1.16.2/multipass-1.16.2+mac-Darwin.pkg"
+    "windows": "https://github.com/canonical/multipass/releases/download/v1.16.3/multipass-1.16.3+win-win64.msi",
+    "macos": "https://github.com/canonical/multipass/releases/download/v1.16.3/multipass-1.16.3+mac-Darwin.pkg"
   }
 }


### PR DESCRIPTION
## Done

- Update release information based on linked github issue

## QA

- Open the [DEMO](https://canonical-com-2562.demos.haus/multipass/install)
- Click on the Windows tab -> "Download Multipass for Windows" and see that the version downloaded is `1.16.3`
- Do the same for Windows

## Issue / Card

Fixes https://github.com/canonical/canonical.com/issues/2556 , https://warthogs.atlassian.net/browse/WD-36836
