### PR TITLE
Update deployment branch and Rockcraft revision

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - main
+      - test-build
   workflow_dispatch:
     inputs:
       environment:
@@ -73,7 +73,7 @@ jobs:
         uses: canonical/setup-lxd@main
 
       - name: Setup Rockcraft
-        run: sudo snap install rockcraft --classic --channel=latest/stable
+        run: sudo snap install rockcraft --classic --revision 4542
 
       - name: Pack Rock
         run: rockcraft pack

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - test-build
+      - main
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
Changed the deployment branch from 'main' to 'test-build' and updated the Rockcraft installation to a specific revision.

## Done

- Reverted to the previous rockcraft revision, as the current update was causing the rockcraft build to [fail](https://github.com/canonical/canonical.com/actions/runs/26566654526/job/78457472155) with
```bash
Building flask-framework/runtime
Failed to cut requested chisel slices: ca-certificates_data
Detailed information: :: error: cannot fetch from archive: expected digest 746a4c7fc22db25b6fa3b853c062a64dde3087ddbcaebaaf1b411c322062ed11, got 23f2de79c1992585f869e09c063b091f67c6f21c65c3b7b4021747a1a17d8d0b
Failed to run rockcraft in instance
Full execution log: '/home/runner/.local/state/rockcraft/log/rockcraft-20260529-073147.878059.log'
Error: Process completed with exit code 1.
```

## QA

- See that checks pass (deploy branch to be changed before merge)
- Playwright check is unrelated to this PR


