### PR TITLE
feat: Remove needs security-check from Percy workflow

### DIFF
--- a/.github/workflows/percy-fork-pr.yaml
+++ b/.github/workflows/percy-fork-pr.yaml
@@ -21,7 +21,6 @@ jobs:
   snapshot:
     name: Take Percy snapshots
     runs-on: ubuntu-latest
-    needs: security-check
     # Ensure we only run for forks (internal PRs use a different workflow)
     if: github.event.pull_request.head.repo.full_name != github.repository
 


### PR DESCRIPTION
## Done

Removed dependency on security-check for Percy snapshots.

Percy has a separate workflow for PRs made on forks, which had an unneeded dependency on a job that didn't exist.

## QA

- See that checks pass, including percy checks.

