### PR TITLE
chore: update graduate job link

### DIFF
--- a/templates/careers/includes/_fast-track-jobs.html
+++ b/templates/careers/includes/_fast-track-jobs.html
@@ -194,7 +194,7 @@
         <small>Solve open source challenges</small>
       </p>
 
-      <a href="/careers/7814327">Graduate</a>
+      <a href="/careers/7957239">Graduate</a>
       <p class="u-no-padding--top">
         <small>Kick-start your career in a team matching your skillset</small>
       </p>


### PR DESCRIPTION
## Done

- updated graduate job link

## QA

- Go to the Eng Careers page: https://canonical-com-2568.demos.haus/careers/engineering
- Click on the graduate job link and ensure it takes you to the one with the new ID (`7957239`)


