### PR TITLE
Fix failing links on /what-is-kubeflow & sitemap.xml

### DIFF
--- a/templates/mlops/kubeflow/what-is-kubeflow.html
+++ b/templates/mlops/kubeflow/what-is-kubeflow.html
@@ -318,7 +318,7 @@
           <div class="grid-col-2 grid-col-medium-1 grid-col-start-medium-2 grid-col-order-medium-1">
             <h3 class="p-heading--5">KServe for inference serving</h3>
             <p>
-              <a href="https://www.kubeflow.org/docs/components/serving/kfserving/">KServe</a> is a multi-framework model deployment tool with serverless inferencing, canary roll-outs, pre & post-processing and explainability. <a href="https://ubuntu.com/blog/what-is-kfserving">Learn more&nbsp;&rsaquo;</a>
+              <a href="https://www.kubeflow.org/docs/ecosystem/kserve/">KServe</a> is a multi-framework model deployment tool with serverless inferencing, canary roll-outs, pre & post-processing and explainability. <a href="https://ubuntu.com/blog/what-is-kfserving">Learn more&nbsp;&rsaquo;</a>
             </p>
           </div>
           <div class="grid-col-2 grid-col-medium-1 grid-col-order-medium-2">

--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -22,9 +22,6 @@
     <loc>https://canonical.com/dqlite/docs/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/mir/docs/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
     <loc>https://canonical.com/maas/docs/sitemap.xml</loc>
   </sitemap>
 </sitemapindex>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -96,8 +96,8 @@ DYNAMIC_SITEMAPS = [
     "knowledge",
     "microk8s/docs",
     "dqlite/docs",
-    "mir/docs",
     "maas/docs",
+    "tests",
 ]
 
 


### PR DESCRIPTION
## Done
- Fix failing link in https://canonical-com-2570.demos.haus/mlops/kubeflow/what-is-kubeflow page and added the update to [copydoc](https://docs.google.com/document/d/1m-96RlGkbzFa1KaGAxYFpY0ztIlsTuViCjXSAlErQlg/edit?tab=t.0)
- Addes `tests/` folder sitemap generation exclusion

## QA

- Open the [DEMO](https://canonical-com-2570.demos.haus/mlops/kubeflow/what-is-kubeflow) and check that the `KServe` section has the correct link
- Check that https://canonical-com-2570.demos.haus/sitemap.xml does not have mir docs
  - and compare with that of prod https://canonical.com/sitemap.xml
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
