### PR TITLE
fix: run live-links check on weekdays only

### DIFF
--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -2,7 +2,7 @@ name: Links on canonical.com live
 
 on:
   schedule:
-    - cron: "20 7 * * *"
+    - cron: "20 7 * * 1-5"
 
 jobs:
   check-links:


### PR DESCRIPTION
## Done

- Updated the `live-links.yaml` workflow cron schedule from `20 7 * * *` to `20 7 * * 1-5` so the check runs Monday–Friday only.
- **Why:** Running on Saturday and Sunday is pointless — there's no one around over the weekend to check and fix any broken links, so the alerts just pile up as noise in the channel. Restricting to weekdays keeps the alerts actionable.

## QA

- This is a CI scheduling change, so there's nothing to QA on the running site.
- Confirm the cron expression `20 7 * * 1-5` is valid and resolves to 07:20 UTC, Monday through Friday (e.g. via [crontab.guru](https://crontab.guru/#20_7_*_*_1-5)).

## Issue / Card

Fixes [WD-36934](https://warthogs.atlassian.net/browse/WD-36934)

## Screenshots

N/A

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-36934]: https://warthogs.atlassian.net/browse/WD-36934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ