### PR TITLE
fix: change overflow property from hidden to clip for scroll sections

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -984,7 +984,7 @@ html {
   right: 0;
   bottom: 0;
   opacity: 0;
-  overflow: hidden;
+  overflow: clip;
   height: max-content;
   transform: translateY(100px);
   pointer-events: none;


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Open the [DEMO](https://canonical-com-2579.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]

