### PR TITLE
chore: gate Percy snapshots to visual-affecting changes

### DIFF
--- a/.github/PERCY.md
+++ b/.github/PERCY.md
@@ -1,0 +1,78 @@
+# Percy snapshots
+
+This repo runs visual regression tests via [Percy](https://percy.io/). Three workflows orchestrate it:
+
+- `.github/workflows/percy-pr.yaml` — PRs from this repo targeting `main`
+- `.github/workflows/percy-fork-pr.yaml` — PRs from forks targeting `main` (uses `pull_request_target` with an approval gate)
+- `.github/workflows/percy-baseline.yaml` — pushes to `main` (refreshes the baseline that PRs compare against)
+
+The shared gate logic lives in `.github/actions/percy-gate/action.yml`.
+
+## When Percy runs
+
+For PRs (both internal and fork) the `decide` job evaluates, in order:
+
+1. **`run-percy` label present on the PR?** → RUN.
+2. **Author is `dependabot[bot]` or `renovate[bot]`?** → SKIP (bots must use the label to opt in).
+3. **Diff touches a watched path?** → RUN.
+4. **Otherwise** → SKIP.
+
+For pushes to `main` (baseline):
+
+1. **Workflow manually dispatched?** → RUN.
+2. **Push diff touches a watched path?** → RUN.
+3. **Otherwise** → SKIP.
+
+When the gate decides to skip, the `snapshot` job is skipped but the workflow exits successfully — branch protection (which treats `skipped` as `success` for required checks) is unaffected.
+
+## Watched paths
+
+Defined once in `.github/actions/percy-gate/action.yml`:
+
+- `static/sass/**`
+- `static/js/**`
+- `templates/**`
+- `navigation.yaml`
+- `secondary-navigation.yaml`
+- `snapshots.js`
+- `test-links.yaml`
+- `package.json`
+- `yarn.lock`
+
+To extend the list, edit the `filters:` block in `.github/actions/percy-gate/action.yml`. The change applies to all three workflows automatically.
+
+## How to force a Percy run
+
+### On a PR
+
+Add the `run-percy` label. Adding the label fires a `labeled` event, the gate re-evaluates, and the snapshot job runs.
+
+Reach for this when:
+
+- The PR changes visuals via a path we don't watch (e.g. a Python view that swaps template variables).
+- A Renovate or Dependabot PR bumps a visual-affecting dependency (e.g. `vanilla-framework`) and you want a snapshot.
+- You want a one-off sanity-check snapshot on any PR.
+
+### On `main` (refresh the baseline manually)
+
+Go to **Actions → Update Percy Baseline → Run workflow**, select `main`, click Run.
+
+Reach for this when:
+
+- A merged PR's change wasn't caught by the path filter and visual drift later surfaces in production.
+- You want a fresh baseline before a release.
+
+## Rapid pushes are de-duplicated
+
+PR workflows declare a `concurrency` group with `cancel-in-progress: true`, so pushing several commits in quick succession only completes the latest run — earlier in-flight Percy runs for the same PR are cancelled. The baseline workflow does not cancel itself (every `main` push completes its baseline independently).
+
+## Troubleshooting
+
+**"Percy didn't run on my PR with a CSS change."**
+Check the watched-paths list above. If the path is genuinely visual-affecting and not covered, add it to `.github/actions/percy-gate/action.yml`. For a one-off run, add the `run-percy` label.
+
+**"The `Take Percy snapshots` check shows as skipped."**
+Expected when the gate decided to skip. The `Decide whether to run Percy` job ran to completion and reported success — branch protection is satisfied.
+
+**"Percy ran on a PR that didn't change visuals."**
+Check whether the diff touches any watched path — `package.json` and `yarn.lock` will match any dependency bump. Bots are blocked by default, but a human PR touching these triggers a run.

--- a/.github/actions/percy-gate/action.yml
+++ b/.github/actions/percy-gate/action.yml
@@ -1,0 +1,80 @@
+name: Percy Gate
+description: >
+  Decides whether a Percy snapshot run should proceed. Combines a path filter
+  with a label override and a bot-author skip for PR contexts, and a
+  workflow_dispatch override for baseline (push) contexts.
+
+inputs:
+  mode:
+    description: >
+      'pr' for PR workflows (checks label, bot author, then paths). 'baseline'
+      for the main-push workflow (checks workflow_dispatch, then paths).
+    required: true
+
+outputs:
+  should_run:
+    description: 'true if the calling workflow should proceed to take snapshots'
+    value: ${{ steps.evaluate.outputs.should_run }}
+
+runs:
+  using: composite
+  steps:
+    - name: Filter changed paths
+      id: filter
+      uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+      with:
+        filters: |
+          visual:
+            - 'static/sass/**'
+            - 'static/js/**'
+            - 'templates/**'
+            - 'navigation.yaml'
+            - 'secondary-navigation.yaml'
+            - 'snapshots.js'
+            - 'test-links.yaml'
+            - 'package.json'
+            - 'yarn.lock'
+
+    - name: Evaluate gate
+      id: evaluate
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-percy') }}
+        ACTOR: ${{ github.event.pull_request.user.login }}
+        VISUAL_CHANGED: ${{ steps.filter.outputs.visual }}
+        DISPATCHED: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        set -e
+        if [ "$MODE" = "baseline" ]; then
+          if [ "$DISPATCHED" = "true" ]; then
+            echo "RUN: manually dispatched"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$VISUAL_CHANGED" = "true" ]; then
+            echo "RUN: visual-affecting files changed on this push"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "SKIP: no visual-affecting changes on this push"
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if [ "$HAS_LABEL" = "true" ]; then
+          echo "RUN: run-percy label present"
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if [ "$ACTOR" = "dependabot[bot]" ] || [ "$ACTOR" = "renovate[bot]" ]; then
+          echo "SKIP: bot author ($ACTOR) without run-percy label"
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if [ "$VISUAL_CHANGED" = "true" ]; then
+          echo "RUN: visual-affecting files changed"
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "SKIP: no visual-affecting changes and no run-percy label"
+        echo "should_run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/percy-baseline.yaml
+++ b/.github/workflows/percy-baseline.yaml
@@ -1,5 +1,5 @@
-# This workflow updates the Percy baseline on every push to main.
-# This allows pull requests to be compared against baseline test results.
+# Updates the Percy baseline on pushes to main that touch visual-affecting files.
+# See .github/PERCY.md for when this runs, the watched-paths list, and how to refresh manually.
 
 name: Update Percy Baseline
 
@@ -7,11 +7,35 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
+  decide:
+    name: Decide whether to update baseline
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions/percy-gate
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - id: gate
+        uses: ./.github/actions/percy-gate
+        with:
+          mode: baseline
+
   snapshot:
     name: Take Percy snapshots
     runs-on: ubuntu-latest
+    needs: decide
+    if: needs.decide.result == 'success' && needs.decide.outputs.should_run == 'true'
+    permissions:
+      contents: read
     steps:
       - name: Checkout SCM
         uses: actions/checkout@v4

--- a/.github/workflows/percy-fork-pr.yaml
+++ b/.github/workflows/percy-fork-pr.yaml
@@ -1,3 +1,5 @@
+# See .github/PERCY.md for when Percy runs, the watched-paths list, and how to force a run.
+
 name: Percy testing on PRs from forks
 run-name: "Testing Percy on fork PR #${{ github.event.pull_request.number }}"
 # This workflow handles Percy testing for PRs from forks securely
@@ -12,18 +14,42 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - labeled
+      - unlabeled
 
 permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: percy-fork-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
+  decide:
+    name: Decide whether to run Percy
+    runs-on: ubuntu-latest
+    # Only run for forks; internal PRs use percy-pr.yaml
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions/percy-gate
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - id: gate
+        uses: ./.github/actions/percy-gate
+        with:
+          mode: pr
+
   snapshot:
     name: Take Percy snapshots
     runs-on: ubuntu-latest
-    needs: security-check
-    # Ensure we only run for forks (internal PRs use a different workflow)
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    needs: decide
+    if: needs.decide.result == 'success' && needs.decide.outputs.should_run == 'true'
 
     # The environment "percy-testing" handles the approval gate
     environment: percy-testing

--- a/.github/workflows/percy-pr.yaml
+++ b/.github/workflows/percy-pr.yaml
@@ -1,3 +1,4 @@
+# See .github/PERCY.md for when Percy runs, the watched-paths list, and how to force a run.
 
 name: Percy testing on PRs from same repo
 run-name: Testing Percy on branch ${{ github.head_ref }}
@@ -12,12 +13,42 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - labeled
+      - unlabeled
+
+concurrency:
+  group: percy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
+  decide:
+    name: Decide whether to run Percy
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions/percy-gate
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - id: gate
+        uses: ./.github/actions/percy-gate
+        with:
+          mode: pr
+
   snapshot:
     name: Take Percy snapshots
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: decide
+    if: needs.decide.result == 'success' && needs.decide.outputs.should_run == 'true'
+    permissions:
+      contents: read
     steps:
       - name: Checkout SCM
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ PERCY_BROWSER_EXECUTABLE=/Applications/Chromium.app/Contents/MacOS/Chromium
 PERCY_POSTINSTALL_BROWSER=false
 ```
 
+In CI, Percy snapshots only run when a PR (or push to `main`) touches files that can affect rendered output (SCSS, JS, templates, nav YAMLs, snapshot config, `package.json`/`yarn.lock`). See [.github/PERCY.md](.github/PERCY.md) for the full behaviour, watched-paths list, and how to force a run via the `run-percy` label.
+
 ## Environment variables
 
 Environment variables are read from the available shell. For the charm, these are prepended with the prefix `FLASK_`, which we strip before re-inserting them into the environment.


### PR DESCRIPTION
## Done

- Add a `percy-gate` composite action (`.github/actions/percy-gate/`) that decides whether to take snapshots: path filter + `run-percy` label override + bot-author skip (PRs), and `workflow_dispatch` override (baseline).
- Split each Percy workflow into a `decide` + `snapshot` job so snapshots only run on visual-affecting changes (SCSS, JS, templates, nav YAMLs, snapshot config, `package.json`/`yarn.lock`):
  - `percy-pr.yaml`, `percy-fork-pr.yaml`: added `labeled`/`unlabeled` events + `concurrency` (cancel in-progress).
  - `percy-baseline.yaml`: added `workflow_dispatch`; baseline only refreshes on visual-affecting pushes to `main`.
- Drive-by: `percy-fork-pr.yaml` had `needs: security-check` referencing a job that doesn't exist — repointed to `needs: decide`.
- Docs: add `.github/PERCY.md` (behaviour, watched paths, how to force a run) and link it from the README Percy section.

Mirrors the gating shipped in ubuntu.com (canonical/ubuntu.com#16400), adapted to this repo's layout.

## QA

- Open a PR that touches no visual paths (e.g. a `.md` or Python-only change) → `Take Percy snapshots` is **skipped**, `Decide whether to run Percy` succeeds.
- Open a PR touching `static/sass/**` (or any watched path) → snapshots run.
- Add the `run-percy` label to any PR → snapshots run regardless of paths.
- **Actions → Update Percy Baseline → Run workflow** on `main` → baseline runs on demand.

## Issue / Card

[WD-36959](https://warthogs.atlassian.net/browse/WD-36959)
https://warthogs.atlassian.net/browse/WD-36734

## Screenshots

N/A


[WD-36959]: https://warthogs.atlassian.net/browse/WD-36959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ