### PR TITLE
fix: restore CSP-broken interactions on candidate dashboard

### DIFF
--- a/static/js/csp-event-handlers.js
+++ b/static/js/csp-event-handlers.js
@@ -87,5 +87,34 @@
           }
         });
       });
+    
+    // toggle the progress detail sections (candidate dashboard "Show more"/"Show less")
+    document
+      .querySelectorAll("[data-js-progress-show]")
+      .forEach(function (link) {
+        link.addEventListener("click", function (event) {
+          event.preventDefault();
+          showProgressDetail(link.getAttribute("data-js-progress-show"));
+        });
+      });
+
+    document
+      .querySelectorAll("[data-js-progress-hide]")
+      .forEach(function (link) {
+        link.addEventListener("click", function (event) {
+          event.preventDefault();
+          hideProgressDetail(link.getAttribute("data-js-progress-hide"));
+        });
+      });
+
+    // reveal a progress detail section while still letting the link's href
+    // anchor navigate (candidate dashboard)
+    document
+      .querySelectorAll("[data-js-progress-show-nav]")
+      .forEach(function (link) {
+        link.addEventListener("click", function () {
+          showProgressDetail(link.getAttribute("data-js-progress-show-nav"));
+        });
+      });
   });
 })();

--- a/templates/careers/application/_interview-card-done.html
+++ b/templates/careers/application/_interview-card-done.html
@@ -6,7 +6,7 @@
   {% endif %}
   <p class="p-card__content u-sv2">{{ interview["start"]["datetime"].strftime('%d %B') }}, with {% for interviewer in interview["interviewers"] %}{% if loop.index > 1 %}, {% endif %}{{ interviewer["name"] }}{% endfor %}</p>
   {% if interview["stage_name"] == "Talent Interview" %}
-  <p class="p-card__content u-sv1">Once completed, your behavioural assessment will be available in the <a href="#assessment" onclick="showProgressDetail('assessment');">Assessment</a> section.</p>
+  <p class="p-card__content u-sv1">Once completed, your behavioural assessment will be available in the <a href="#assessment" data-js-progress-show-nav="assessment">Assessment</a> section.</p>
   {% endif %}
 
 </div>

--- a/templates/careers/application/partial/_assessment.html
+++ b/templates/careers/application/partial/_assessment.html
@@ -85,7 +85,7 @@
                   </footer>
                 </div>
               </section>
-              <script async src="{{ versioned_static('js/applications/get-report.js') }}"></script>
+              <script async src="{{ versioned_static('js/applications/get-report.js') }}" nonce="{{ csp_nonce }}"></script>
             </div>
             <div class="u-hide">
               <p style="padding-left: 2.5rem;" class="u-no-margin--bottom">


### PR DESCRIPTION
## Done

- Fixed the "Get Report" button for psychometric assessment. Was doing nothing previously because it was missing a CSP nonce.
- Fixed the "Show more" button for Assessment milestone. inline `onclick` was blocked by CSP. now moved to the `data-js-progress-*` handler.

## QA

- Open the [DEMO](https://canonical-com-2594.demos.haus/)
- Alternatively, check out this feature branch, run the site with `dotrun` and then view the site locally in your web browser at: http://0.0.0.0:8002/
- Go to the example candidate dashboard that was experiencing issues (ask me for the link)
- Ensure the "Show more" button under the Assessment milestone works now (previously was just refreshing the page).
- Ensure the "Get report" button takes action. Use a fake email and ensure you see an error about the incorrect email rather than no action at all (as was happening previously).
