### PR TITLE
ci: automate copilot assignment to action

### DIFF
--- a/.github/workflows/assign-copilot.yaml
+++ b/.github/workflows/assign-copilot.yaml
@@ -1,0 +1,18 @@
+name: Auto-assign Copilot
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  assign-copilot:
+    if: contains(github.event.label.name, 'copilot')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign issue to Copilot
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_PAT }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --add-assignee "copilot" \
+            --repo ${{ github.repository }}


### PR DESCRIPTION
## Done

- Added GH workflow for automated copilot assignment to issues with `copilot` labels

## QA

- Create an issue and add `copilot` label
- See that the issue is assigned to copilot

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]

