### PR TITLE
[WD-37089] Update links to docs in /lxd/install

### DIFF
--- a/templates/lxd/install.html
+++ b/templates/lxd/install.html
@@ -142,7 +142,7 @@
         </div>
         <hr class="p-rule u-hide--small" />
         <p>
-          For other installation options, please <a href="https://documentation.ubuntu.com/lxd/en/latest/installing/">check our documentation</a>.
+          For other installation options, please <a href="https://canonical.com/lxd/docs/default/installing/">check our documentation</a>.
         </p>
       </div>
     </div>
@@ -163,7 +163,7 @@
               You might see issues with your firewall blocking network access for your instances, or connectivity issues because you run LXD and Docker on the same host.
             </p>
             <p>
-              <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/howto/network_bridge_firewalld/#network-bridge-firewall">Access documentation about how to resolve these issues&nbsp;&rsaquo;</a>
+              <a href="https://canonical.com/lxd/docs/default/howto/network_bridge_firewalld/#network-bridge-firewall">Access documentation about how to resolve these issues&nbsp;&rsaquo;</a>
             </p>
           </div>
           <div class="col-3 u-hide--small u-hide--medium u-aspect-ratio--3-2 p-image-wrapper u-vertically-center">
@@ -194,7 +194,7 @@
           <div class="col-6 col-medium-4">
             <p>LXD supports two types of instances: system containers and virtual machines.</p>
             <p>
-              <a href="https://documentation.ubuntu.com/lxd/en/latest/explanation/containers_and_vms/">Learn more about containers and VMs&nbsp;&rsaquo;</a>
+              <a href="https://canonical.com/lxd/docs/default/explanation/instances/">Learn more about containers and VMs&nbsp;&rsaquo;</a>
             </p>
           </div>
           <hr class="p-rule col-9 col-medium-6" />
@@ -206,7 +206,7 @@
               Security is at the forefront of everything we do and there are various things to consider to keep your LXD installation secure.
             </p>
             <p>
-              <a href="https://documentation.ubuntu.com/lxd/en/latest/explanation/containers_and_vms/">Learn more about LXD and security&nbsp;&rsaquo;</a>
+              <a href="https://canonical.com/lxd/docs/default/explanation/security/">Learn more about LXD and security&nbsp;&rsaquo;</a>
             </p>
           </div>
           <hr class="p-rule col-9 col-medium-6" />
@@ -216,7 +216,7 @@
           <div class="col-6 col-medium-4">
             <p>LXD uses an image-based workflow, providing images for a large number of Linux distributions.</p>
             <p>
-              <a href="https://documentation.ubuntu.com/lxd/en/latest/image-handling/">Learn more about common operations with images&nbsp;&rsaquo;</a>
+              <a href="https://canonical.com/lxd/docs/default/images/">Learn more about common operations with images&nbsp;&rsaquo;</a>
             </p>
           </div>
           <hr class="p-rule col-9 col-medium-6" />
@@ -227,7 +227,7 @@
             <p>We welcome and value contributions from the community.</p>
             <div class="p-strip--shallow">
               <p>
-                <a href="https://documentation.ubuntu.com/lxd/en/latest/contributing">How to contribute to LXD&nbsp;&rsaquo;</a>
+                <a href="https://canonical.com/lxd/docs/default/contributing/">How to contribute to LXD&nbsp;&rsaquo;</a>
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Done

- Updates links in `/lxd/install` to point to the new LXD docs site

## QA

- Open the [DEMO](__DEMO_URL__/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

- Implements [WD-37089](https://warthogs.atlassian.net/browse/WD-37089)
- [Copydoc](https://docs.google.com/document/d/1LKlXAc39dy69dSCc7PE6WqV2qkCSeXmicKGS4lFicDE/edit?tab=t.0)

[WD-37089]: https://warthogs.atlassian.net/browse/WD-37089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ