### PR TITLE
chore: add wordpress-k8s-charm to sitemap

### DIFF
--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -24,4 +24,7 @@
   <sitemap>
     <loc>https://canonical.com/maas/docs/sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://canonical.com/juju/docs/wordpress-k8s-charm/latest/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

Update the sitemap reference for the WordPress charm documentation.

## QA

- Open the [DEMO](__DEMO_URL__/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
