### PR TITLE
Update links on lxd/manage

### DIFF
--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -66,7 +66,7 @@ meta_copydoc %}
           subcommands.
         </p>
         <p>
-          <a href="https://documentation.ubuntu.com/lxd/en/stable-5.21/explanation/lxd_lxc/">Get started with the LXD
+          <a href="https://canonical.com/lxd/docs/default/explanation/lxd_lxc/">Get started with the LXD
           CLI&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -88,7 +88,7 @@ meta_copydoc %}
           needed. LXD implements a single REST API for both local and remote access.
         </p>
         <p>
-          <a href="https://documentation.ubuntu.com/lxd/en/stable-5.21/rest-api/">Learn more about the LXD REST
+          <a href="https://canonical.com/lxd/docs/default/rest-api/">Learn more about the LXD REST
           API&nbsp;&rsaquo;</a>
         </p>
       </div>
@@ -308,7 +308,7 @@ meta_copydoc %}
               </li>
             </ul>
             <p>
-              To manage LXD in Ansible, you need a LXD server (see <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/getting_started/">"Getting started"</a>).
+              To manage LXD in Ansible, you need a LXD server (see <a href="https://canonical.com/lxd/docs/default/getting_started/">"Getting started"</a>).
             </p>
           </div>
         </div>
@@ -338,7 +338,7 @@ meta_copydoc %}
               LXD</a> for more information.
             </p>
             <p>
-              To manage LXD in Terraform, you need a LXD server (see <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/getting_started">"Getting started"</a>).
+              To manage LXD in Terraform, you need a LXD server (see <a href="https://canonical.com/lxd/docs/default/getting_started/">"Getting started"</a>).
             </p>
           </div>
         </div>
@@ -365,7 +365,7 @@ meta_copydoc %}
               Documentation on LXD</a>.
             </p>
             <p>
-              To manage LXD in Puppet Bolt, you need a LXD server (see <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/getting_started/">"Getting started"</a>).
+              To manage LXD in Puppet Bolt, you need a LXD server (see <a href="https://canonical.com/lxd/docs/default/getting_started/">"Getting started"</a>).
             </p>
           </div>
         </div>
@@ -395,11 +395,11 @@ meta_copydoc %}
               more information.
             </p>
             <p>
-              Additionally our guides about <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/images/">images</a> and <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/howto/instances_configure/">instance
+              Additionally our guides about <a href="https://canonical.com/lxd/docs/default/images/">images</a> and <a href="https://canonical.com/lxd/docs/default/howto/instances_configure/">instance
               configuration</a> might contain useful information regarding image choice, configuration options etc.
             </p>
             <p>
-              To create LXD images in Packer, you need a LXD server (see <a href="https://canonical-lxd.readthedocs-hosted.com/en/latest/getting_started/">"Getting started"</a>).
+              To create LXD images in Packer, you need a LXD server (see <a href="https://canonical.com/lxd/docs/default/getting_started/">"Getting started"</a>).
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Updated LXD documentation URLs

## QA

- Check out this feature branch
- Run the site using `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/lxd/manage
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check to ensure that links are properly updated

## Issue / Card

Fixes: https://warthogs.atlassian.net/browse/WD-37090
Copydoc: https://docs.google.com/document/d/1doGyKYSTOsX8dHvQ6W9W2U_pHQY6yfiq1bqSAJyredQ/edit?tab=t.0
