### PR TITLE
fix: remove white hyperlink on hover

### DIFF
--- a/static/sass/_pattern_homepage.scss
+++ b/static/sass/_pattern_homepage.scss
@@ -141,10 +141,6 @@
     align-items: center;
   }
 
-  a {
-    text-decoration-color: #fff;
-  }
-
   .p-homepage-blog-card {
     background-color: #202020; /* dark background */
     border: 1px solid rgb(255 255 255 / 10%); /* subtle border */


### PR DESCRIPTION
## Done

- Remove white hyperlink text decoration


## QA
- QA on different browsers: Safari, Chrome
- Go to https://canonical-com-2605.demos.haus/solutions/ai or any other page with hyperlinks
- Hover over a link, see that the link colour is blue as expected and not white
- Test again on homepage

## Issue / Card

Fixes [WD-37063](https://warthogs.atlassian.net/browse/WD-37063)

## Screenshots

[if relevant, include a screenshot]


[WD-37063]: https://warthogs.atlassian.net/browse/WD-37063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ