### PR TITLE
ci: add copilot issue assignment workflow

### DIFF
--- a/.github/workflows/copilot-assignment.yaml
+++ b/.github/workflows/copilot-assignment.yaml
@@ -1,0 +1,30 @@
+name: Assign Issue to Copilot
+# This workflow is triggered when an issue is labeled
+on:
+  issues:
+    types:
+      - labeled
+
+# This workflow needs permission to modify issues
+permissions:
+  issues: write
+
+# This workflow contains one job: assign_copilot_user
+jobs:
+  assign_copilot_user:
+    name: Assign issue to copilot
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'copilot'
+    steps:
+      # This step assigns the issue to the copilot user
+      - name: Assign issue to copilot
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: ['copilot']
+            });


### PR DESCRIPTION
## Done

- Add workflow to assign copilot to labelled issues

## QA

- This workflow is triggered on issue creation, so it cannot be QA-ed on a PR
- After merge, add copilot label manually to [this issue](https://github.com/canonical/canonical.com/issues/2607)
  - Note: The labels are added when the issue is created, but I removed it for the sake of QA
- See that it triggers the workflow

## Issue / Card

Fixes [WD-37067](https://warthogs.atlassian.net/browse/WD-37067)

## Screenshots

[if relevant, include a screenshot]



[WD-37067]: https://warthogs.atlassian.net/browse/WD-37067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ