### PR TITLE
fix: fix page titles for WCAG 2.4.2 compliance

### DIFF
--- a/templates/academy/exam-content/index.html
+++ b/templates/academy/exam-content/index.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Canonical Academy -- Exam content{% endblock %}
+{% block title %}Exam content | Academy{% endblock %}
 
 {% block meta_description %}
   The Canonical Academy Exam Content page prepares you to take Canonical Academy exams that count toward achieving professional certifications like the SysAdmin Qualification.

--- a/templates/academy/exam-guide.html
+++ b/templates/academy/exam-guide.html
@@ -1,5 +1,5 @@
 {% extends 'base_index.html' %} 
-{% block title %}Canonical Academy -- Exam Guide{% endblock %}
+{% block title %}Exam guide | Academy{% endblock %}
 
 {% block meta_description %}
   The Canonical Academy Exam Guide prepares you to take Canonical Academy exams that count toward achieving professional certifications like the SysAdmin Qualification.

--- a/templates/academy/index.html
+++ b/templates/academy/index.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Canonical Academy{% endblock %}
+{% block title %}Academy{% endblock %}
 
 {% block meta_description %}
   Get Linux certifications. Take real-world, industry relevant exams from the publisher of Ubuntu.

--- a/templates/academy/self-study.html
+++ b/templates/academy/self-study.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Canonical Academy -- Self-study resources{% endblock %}
+{% block title %}Self-study resources | Academy{% endblock %}
 
 {% block meta_description %}
   The Canonical Academy Study Guide prepares you to take Canonical Academy exams that count toward achieving professional certifications like the SysAdmin Qualification.

--- a/templates/anbox-cloud/index.html
+++ b/templates/anbox-cloud/index.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Anbox Cloud - Scalable Android in the cloud{% endblock %}
+{% block title %}Anbox Cloud{% endblock %}
 
 {% block meta_description %}
   Scale Android in the cloud on any hardware. Canonical partners with providers and manufacturers to accelerate your time to market with long-term enterprise-grade support.

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -22,10 +22,7 @@
           <meta property="og:url" content="{{ request.url }}" />
           <meta property="og:site_name" content="Canonical" />
           
-          <title>
-
-            {% block title %}Canonical | Trusted open source for enterprises{% endblock %}
-          </title>
+          <title>{% block title %}Trusted open source for enterprises{% endblock %} | Canonical</title>
           {% if self.title() %}
             <meta name="twitter:title" content="{{ self.title() }} | Canonical" />
             <meta property="og:title" content="{{ self.title() }} | Canonical" />

--- a/templates/blog/archives.html
+++ b/templates/blog/archives.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}Archives{% endblock %}
+{% block title %}Archives | Blog{% endblock %}
 
 {% block content %}
   <section class="p-strip--suru is-shallow">

--- a/templates/blog/archives.html
+++ b/templates/blog/archives.html
@@ -33,7 +33,7 @@
                 <a href="/blog/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
               </h3>
               <div class="p-media-object__content">
-                <p>By <a href="/blog/author/{{article.author.slug}}" title="More about {{ article.author.name }}">{{ article.author.name }}</a>, {{ article.date }}</p>
+                <p>By <a href="/blog/author/{{ article.author.slug }}" title="More about {{ article.author.name }}">{{ article.author.name }}</a>, {{ article.date }}</p>
 
                 <p>{{ article.excerpt.raw.replace("[…]", "")|truncate(162) }}</p>
               </div>
@@ -48,11 +48,11 @@
         <ul class="p-list">
           {% for year in descending_years(2006) %}
             <li class="p-list__item">
-              <h5><a class="p-link--soft" href="/blog/archives?year={{year}}">{{year}}</a></h5>
+              <h5><a class="p-link--soft" href="/blog/archives?year={{ year }}">{{ year }}</a></h5>
 
               <ul class="p-inline-list--middot">
                 {% for month in months_list(year) %}
-                  <li class="p-inline-list__item"><a class="p-link--soft" href="/blog/archives?year={{year}}&amp;month={{month.number}}{% if group %}&group={{group.slug}}{% endif %}">{{ month.name }}</a></li>
+                  <li class="p-inline-list__item"><a class="p-link--soft" href="/blog/archives?year={{ year }}&amp;month={{ month.number }}{% if group %}&group={{ group.slug }}{% endif %}">{{ month.name }}</a></li>
                 {% endfor %}
               </ul>
             </li>
@@ -69,5 +69,4 @@
       {% include "shared/_pagination.html" %}
     {% endwith %}
   </section>
-</section>
 {% endblock %}

--- a/templates/blog/author.html
+++ b/templates/blog/author.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}Blog posts written by {{ author.name }}{% endblock %}
+{% block title %}{{ author.name }} | Blog{% endblock %}
 
 {% block description %}
   {% if author.id == 217 %}

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -1,5 +1,5 @@
 {% extends "base_index.html" %}
-{% block title %}Canonical Blog{% endblock %}
+{% block title %}Blog{% endblock %}
 
 {% block extra_metatags %}
   <link rel="alternate" type="application/rss+xml"  href="/blog/feed" title="Canonical.com's Blog RSS feed">

--- a/templates/blog/tag.html
+++ b/templates/blog/tag.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}{{ tag.name|title }} | Blog{% endblock %}
+{% block title %}{{ tag.name }} | Blog{% endblock %}
 
 {% block body_class %}is-paper{% endblock body_class %}
 

--- a/templates/blog/tag.html
+++ b/templates/blog/tag.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}Blog posts tagged "{{ tag.name }}"{% endblock %}
+{% block title %}{{ tag.name|title }} | Blog{% endblock %}
 
 {% block body_class %}is-paper{% endblock body_class %}
 

--- a/templates/blog/topic.html
+++ b/templates/blog/topic.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}{{ request.view_args.get('slug')|replace('-', ' ')|title }} | Blog{% endblock %}
+{% block title %}{{ request.view_args.get('slug')|replace('-', ' ') }} | Blog{% endblock %}
 
 {% block content %}
   <div class="p-strip--suru is-dark is-shallow">

--- a/templates/blog/topic.html
+++ b/templates/blog/topic.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}{{  request.view_args.get('slug') }}{% endblock %}
+{% block title %}{{ request.view_args.get('slug')|replace('-', ' ')|title }} | Blog{% endblock %}
 
 {% block content %}
   <div class="p-strip--suru is-dark is-shallow">

--- a/templates/careers/alliances-and-channels.html
+++ b/templates/careers/alliances-and-channels.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1ZzfhOZkGD802LI0g80CvC4seiT4__Gutpv4LVKkOIbM/edit?tab=t.0
 {% endblock meta_copydoc %}
 
-{% block title %}Alliances & Channels | Careers{% endblock %}
+{% block title %}Alliances & channels | Careers{% endblock %}
 
 {% block meta_description %}
   Shape the future of enterprise technology by ensuring brands, services integrators and channel partners can operate business at scale with Canonical offerings.

--- a/templates/careers/career-explorer.html
+++ b/templates/careers/career-explorer.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1JEJaOghggrocxnRCoTrJMCg_z_xD9n6xBSnovcX3HMg/edit{% endblock %}
 
-{% block title %}Find your perfect career{% endblock %}
+{% block title %}Find your perfect career | Careers{% endblock %}
 
 {% block meta_description %}What kind of excellent are you? Pick five of your strengths and ambitions and we will find the best Canonical careers for you.{% endblock %}
 

--- a/templates/careers/commercial-operations.html
+++ b/templates/careers/commercial-operations.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1zLFku18ZAMVStgkIO3bCoKEXW6ShwMEkB0w9d_nCx9U{% endblock meta_copydoc %}
 
-{% block title %}Commercial Operations | Careers{% endblock %}
+{% block title %}Commercial operations | Careers{% endblock %}
 
 {% block meta_description %}Excellence in operations enables Canonical to scale efficiently. We look for people who are passionate about tools and efficiency.{% endblock %}
 {% block body_class %}is-paper{% endblock body_class %}

--- a/templates/careers/company-culture/diversity.html
+++ b/templates/careers/company-culture/diversity.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1l1UGJToc0ErHUMN9W8hELvF5sDyVRO7N0xDzncqA2SQ
 {% endblock meta_copydoc %}
 
-{% block title %}Careers | Diversity at Canonical - a truly global team{% endblock %}
+{% block title %}Diversity | Company culture | Careers{% endblock %}
 
 {% block meta_description %}
   Diversity is part of our strength. At Canonical, we believe your identity has no intrinsic bearing on your ability. We hire in every corner of the world and make every appointment based on merit.

--- a/templates/careers/company-culture/identity.html
+++ b/templates/careers/company-culture/identity.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1_-EhhObUF8vl95CypcJEpFcMdvDU4N8ak9kCLvZMtyw
 {% endblock meta_copydoc %}
 
-{% block title %}Personal identity at Canonical{% endblock %}
+{% block title %}Personal identity | Company culture | Careers{% endblock %}
 
 {% block meta_description %}{% endblock %}
 

--- a/templates/careers/company-culture/index.html
+++ b/templates/careers/company-culture/index.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1PAeP_ZO4JzSBCi-fRp6F7SYtSSRY-4DcWLUf9HJaMxs/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Company Culture | Careers{% endblock %}
+{% block title %}Company culture | Careers{% endblock %}
 
 {% block meta_description %}
   Canonical's work culture is built on trust and enriched by our commitment to excellence. If you value teamwork and are committed to being a good counterpart to colleagues around the world, you will love working here.

--- a/templates/careers/company-culture/progression.html
+++ b/templates/careers/company-culture/progression.html
@@ -8,7 +8,7 @@
 
 {% block meta_image %}https://assets.ubuntu.com/v1/abb4038f-DSC_2776.jpg{% endblock %}
 
-{% block title %}Careers | Progression{% endblock %}
+{% block title %}Progression | Company culture | Careers{% endblock %}
 
 {% block meta_description %}
   Career progression at Canonical can take shape in many ways &ndash; and we celebrate growth and development in many forms. We value people who love to learn and have an early careers program, ideal for new professionals.

--- a/templates/careers/company-culture/remote-work.html
+++ b/templates/careers/company-culture/remote-work.html
@@ -6,7 +6,7 @@
   https://docs.google.com/document/d/1391OL7xQec1SY9HFkv80DFwACbdndCIk-N_sFzAXkPU
 {% endblock meta_copydoc %}
 
-{% block title %}Careers | Remote work and company culture{% endblock %}
+{% block title %}Remote work | Company culture | Careers{% endblock %}
 
 {% block meta_description %}
   Canonical is a remote-first company. Our policy means we can work with the best talent in the world. We meet in-person at least twice a year at company wide sprints, which take place in exciting locations around the world. Learn about remote work at Canonical. 

--- a/templates/careers/company-culture/sustainability.html
+++ b/templates/careers/company-culture/sustainability.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1wwSOXczrGS45e1DiXbt4GMsHKolniRlywxV_CNHHdCA/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Sustainability | Careers{% endblock %}
+{% block title %}Sustainability | Company culture | Careers{% endblock %}
 
 {% block meta_description %}
   Sustainability initiatives at Canonical aim to optimise how we operate as a business and deliver products designed with sustainability in mind.

--- a/templates/careers/hiring-process/index.html
+++ b/templates/careers/hiring-process/index.html
@@ -6,7 +6,7 @@
   https://docs.google.com/document/d/1j-G0LCapJ1zRnNgQeoC0_rh15N6ICdpDy7M1tubQuoo/edit
 {% endblock %}
 
-{% block title %}Canonical hiring process{% endblock %}
+{% block title %}Hiring process | Careers{% endblock %}
 
 {% block meta_description %}
   Learn about Canonical's hiring process &ndash; Understand how we hire and what you can expect from our process.

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1o8ind3Zav-kwrUDWgiMJnkw2QLpniKgdlWrw9byIvlE/edit#heading=h.ov7lrxgwh2dv
 {% endblock meta_copydoc %}
 
-{% block title %}Canonical Careers{% endblock %}
+{% block title %}Careers{% endblock %}
 
 {% block meta_description %}
   Looking for a career in open source? Be where the cutting edge is established and amplify the impact of open source. Browse careers at Canonical.

--- a/templates/careers/project-management.html
+++ b/templates/careers/project-management.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1hc5olKZcPIHFtxYAHvYFS_c-NZIYy3ZT8WqG7r021MI/{% endblock meta_copydoc %}
 
-{% block title %}Project Management | Careers{% endblock %}
+{% block title %}Project management | Careers{% endblock %}
 
 {% block meta_description %}Canonical's Engagement Project Management Office team owns, drives and communicates delivery excellence by providing strong Project process guidelines, project continuity and data analytics.{% endblock %}
 {% block body_class %}is-paper{% endblock body_class %}

--- a/templates/careers/results.html
+++ b/templates/careers/results.html
@@ -1,6 +1,6 @@
 {% extends '/careers/base.html' %}
 
-{% block title %}Jobs{% endblock %}
+{% block title %}Job search | Careers{% endblock %}
 
 {% block meta_description %}
   Canonical offers a truly distributed workplace for exceptional colleagues who are

--- a/templates/careers/support-engineering.html
+++ b/templates/careers/support-engineering.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1hc5olKZcPIHFtxYAHvYFS_c-NZIYy3ZT8WqG7r021MI/{% endblock meta_copydoc %}
 
-{% block title %}Support Engineering | Careers{% endblock %}
+{% block title %}Support engineering | Careers{% endblock %}
 {% block body_class %}is-paper{% endblock body_class %}
 {% block content %}
 {% with 

--- a/templates/careers/thank-you.html
+++ b/templates/careers/thank-you.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1nsZWk9osMxoMlSnSNIXZCFCV8-Ho4PeLXo0qD-vF_Bk/edit#{% endblock meta_copydoc %}
 
-{% block title %}Thank you{% endblock %}
+{% block title %}Thank you | Careers{% endblock %}
 
 {% block meta_description %}Thanks for taking the time to apply for our position. We appreciate your interest in Canonical.{% endblock %}
 

--- a/templates/case-study/esa.html
+++ b/templates/case-study/esa.html
@@ -8,7 +8,7 @@
 {% from "macros/_macros-text.jinja" import text %}
 {% from "macros/_macros-image.jinja" import image_wrapper %}
 
-{% block title %}Canonical deploys infrastructure solutions and managed IT services for critical space mission operations{% endblock %}
+{% block title %}Infrastructure solutions and managed IT services for critical space mission operations{% endblock %}
 {% block meta_description %}Thanks to Canonical, the ESA has unlocked cost savings, easier operations, and more confidence in providing infrastructure in their roadmap for  doubling  their number of space missions by 2030.{% endblock %}
 {% block meta_company_name %}European Space Agency{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1jc5DY4-9pDYQC04Egdt0If4_jrYn1mIBDwhJfILO46w/edit{% endblock %}

--- a/templates/case-study/index.html
+++ b/templates/case-study/index.html
@@ -2,7 +2,7 @@
 
 {% extends "case-study/base_case-study.html" %}
 
-{% block title %}Case Studies{% endblock %}
+{% block title %}Case studies{% endblock %}
 
 {% block meta_description %}Ubuntu Case Studies{% endblock %}
 

--- a/templates/case-study/lucid-aws-fedramp-compliance-case-study.html
+++ b/templates/case-study/lucid-aws-fedramp-compliance-case-study.html
@@ -9,7 +9,7 @@
 {% from "macros/_macros-image.jinja" import image_wrapper %}
 {% from "macros/_macros-cta.jinja" import cta %}
 
-{% block title %}FedRAMP compliance case study: Lucid FIPS 140-2 for AWS{% endblock %}
+{% block title %}FedRAMP compliance case study | Lucid FIPS 140-2 for AWS{% endblock %}
 
 {% block meta_description %}
   Learn how Ubuntu Pro allowed Lucid to meet FedRAMP compliance and provide its visualization &amp; work management tools to US Federal agencies.

--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -11,9 +11,7 @@
   https://docs.google.com/document/d/112DDIEC7yQYzT1EqiPEdFBcGZtGaFUnpQWkTY6MW9eI/edit?tab=t.jijjhiya0no5
 {% endblock %}
 
-{% block title %}
-  Canonical Ceph
-{% endblock %}
+{% block title %}Ceph{% endblock %}
 
 {% block meta_description %}
   Canonical Ceph is an open source, enterprise ready multi-protocol software-defined storage solution for all on-premises workloads.

--- a/templates/ceph/support.html
+++ b/templates/ceph/support.html
@@ -5,7 +5,7 @@
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 {% from "_macros/vf_data-spotlight.jinja" import vf_data_spotlight %}
 
-{% block title %}Canonical Ceph support{% endblock %}
+{% block title %}Support | Ceph{% endblock %}
 {% block body_class %}is-paper{% endblock %}
 
 {% block meta_description %}

--- a/templates/cloud-marketplace/index.html
+++ b/templates/cloud-marketplace/index.html
@@ -12,7 +12,7 @@
   https://docs.google.com/document/d/18D8Ir-fQooR8FA_952tik_mzwAuiFynOCjUXBmbgYr4/edit
 {% endblock %}
 
-{% block title %}Canonical’s cloud marketplace solutions{% endblock %}
+{% block title %}Cloud marketplace solutions{% endblock %}
 
 {% block meta_description %}
   Find Canonical’s managed data and AI applications on cloud marketplaces. Effortlessly run your favourite open source databases and big data tools on the cloud of your choice.

--- a/templates/company/index.html
+++ b/templates/company/index.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/19TIwT-GU5wADQmohicj14MnpHEqNqp0422WLunFsbJU
 {% endblock meta_copydoc %}
 
-{% block title %}Canonical - company information{% endblock %}
+{% block title %}Company information{% endblock %}
 
 {% block meta_description %}
   About Canonical |The publisher of Ubuntu and provider of open source security, support and services

--- a/templates/data/cassandra/index.html
+++ b/templates/data/cassandra/index.html
@@ -10,7 +10,7 @@
   https://docs.google.com/document/d/16_W5PIiK4mg2b5IYyAzmQvwMf7GA6yLiVOkzZ21nPP4/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Enterprise-grade services for your Apache Cassandra clusters{% endblock %}
+{% block title %}Apache Cassandra{% endblock %}
 
 {% block meta_description %}
     Get enterprise-grade Apache Cassandra support from Canonical. Enjoy security, automation, and SLA-backed expertise for your clusters across private and public clouds. 

--- a/templates/data/etcd/index.html
+++ b/templates/data/etcd/index.html
@@ -10,7 +10,7 @@
   https://docs.google.com/document/d/1vZaVT4t9D0x_ltKi9Cf3Q__YbXMbMNja24qSA4r97r8
 {% endblock meta_copydoc %}
 
-{% block title %}Enterprise-grade solutions for your etcd deployments{% endblock %}
+{% block title %}etcd{% endblock %}
 
 {% block meta_description %}
   Get enterprise-grade etcd support from Canonical. Enjoy security, automation, and SLA-backed expertise for your etcd clusters across private and public clouds.

--- a/templates/data/index.html
+++ b/templates/data/index.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Canonical open source data platform solutions{% endblock %}
+{% block title %}Open source data platform solutions{% endblock %}
 
 {% block canonical_url %}{{ request.host_url }}data{% endblock %}
 

--- a/templates/data/kafka/index.html
+++ b/templates/data/kafka/index.html
@@ -12,7 +12,7 @@
   https://docs.google.com/document/d/1bfo97XdFdKlzrMcMoRxiTdzt_bPVndx6j55IPsapuAE/edit
 {% endblock meta_copydoc %}
 
-{% block title %}An advanced, enterprise-grade Apache Kafka solution from Canonical{% endblock %}
+{% block title %}Apache Kafka{% endblock %}
 
 {% block meta_description %}
   Charmed Kafka delivers up to 15 years of support and security maintenance for Apache Kafka. Get enterprise-grade Kafka as an integrated, turnkey solution with advanced management features.

--- a/templates/data/kafka/managed.html
+++ b/templates/data/kafka/managed.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1bfo97XdFdKlzrMcMoRxiTdzt_bPVndx6j55IPsapuAE/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Managed Kafka services by Canonical, the industry leaders in open source operations{% endblock %}
+{% block title %}Managed services | Apache Kafka{% endblock %}
 
 {% block meta_description %}
   Learn about Canonical's managed services for Apache Kafka, the industry leading open source event streaming platform.

--- a/templates/data/kafka/support.html
+++ b/templates/data/kafka/support.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1eM-xPqx1CtoxSg4aOHlY3QRPu5L3o-jQPkc_q1CAr10/edit?tab=t.0
 {% endblock meta_copydoc %}
 
-{% block title %}Get support for Apache Kafka, an open source event streaming platform.{% endblock %}
+{% block title %}Support | Apache Kafka{% endblock %}
 
 {% block meta_description %}
   Get support for Apache Kafka, from Canonical. 24/7 or weekday support and up to fifteen years security patching per release track.

--- a/templates/data/kafka/what-is-kafka.html
+++ b/templates/data/kafka/what-is-kafka.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1IThZcfKZcv-ArqU_0n8A181AGkQPUn_Iq1O4sqk5GTs/edit?tab=t.0
 {% endblock meta_copydoc %}
 
-{% block title %}Learn about Apache Kafka, an open source event streaming platform.{% endblock %}
+{% block title %}Overview | Apache Kafka{% endblock %}
 
 {% block meta_description %}
   Apache Kafka is a free, open source event streaming platform that enables you to continuously process data at web scale.

--- a/templates/data/lakehouse/index.html
+++ b/templates/data/lakehouse/index.html
@@ -7,7 +7,7 @@
     https://docs.google.com/document/d/1iG9Fcg1w9FWyWO84Gj6RFFYdu5xzEDFBMxnjAAQFW34/edit
 {% endblock meta_copydoc %}
 
-{% block title %}What is a data lakehouse?{% endblock %}
+{% block title %}What is a data lakehouse? | Data platform{% endblock %}
 
 {% block meta_description %}
     Learn about data lakehouses – what are they, how you can benefit from them, and how to implement one with Apache Spark and Apache Kafka.

--- a/templates/data/mongodb/index.html
+++ b/templates/data/mongodb/index.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1mCztOFZYbC3TeUM7j7pGfSoxKzBs20W1pJHZhdLqKs8/edit
 {% endblock meta_copydoc %}
 
-{% block title %}An enterprise solution for MongoDB from Canonical{% endblock %}
+{% block title %}MongoDB{% endblock %}
 
 {% block meta_description %}
   Charmed MongoDB delivers up to 15 years of support and security maintenance for MongoDB as an integrated, turnkey solution with advanced management features.

--- a/templates/data/mongodb/managed.html
+++ b/templates/data/mongodb/managed.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1ZkJA6le_PfFZK8WBDgoUksKlQzX8HgUNL8HNJwWKhv0/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Managed MongoDB services by Canonical{% endblock %}
+{% block title %}Managed services | MongoDB{% endblock %}
 
 {% block meta_description %}
   Learn about Canonical's managed services for MongoDB, the industry leading NoSQL database.

--- a/templates/data/mongodb/support.html
+++ b/templates/data/mongodb/support.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1XjFTw--fDl7ZpI6LI--UBKkAV4Yiz-gEoo2gcLuVdeA/edit
 {% endblock meta_copydoc %}
 
-{% block title %}MongoDB support from Canonical{% endblock %}
+{% block title %}Support | MongoDB{% endblock %}
 
 {% block meta_description %}
   Get support for MongoDB, from Canonical. 24/7 or weekday support and up to ten years security patching per release track.

--- a/templates/data/mongodb/what-is-mongodb.html
+++ b/templates/data/mongodb/what-is-mongodb.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1hET-ylqXq96mOfj4hovqilX5Nl0J8FLw1gkRMJkIjp8/edit
 {% endblock meta_copydoc %}
 
-{% block title %}What is MongoDB?{% endblock %}
+{% block title %}Overview | MongoDB{% endblock %}
 
 {% block meta_description %}
   MongoDB is a NoSQL database management application. Organisations use MongoDB because it aligns with modern application development needs, offering flexibility, scalability and high performance. It has a rich set of features that support complex and evolving business requirements.

--- a/templates/data/mysql/index.html
+++ b/templates/data/mysql/index.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1KQmCfb4ITlYHOAEoHUwxHExf73qkMSWsLHnFPwFWFag/edit
 {% endblock meta_copydoc %}
 
-{% block title %}An advanced, enterprise-grade MySQL solution from Canonical{% endblock %}
+{% block title %}MySQL{% endblock %}
 
 {% block meta_description %}
   Enterprise-grade MySQL with up to 10 years of support and security maintenance. It helps you secure and automate the deployment, maintenance and upgrades of your MySQL databases across private and public clouds.

--- a/templates/data/mysql/managed.html
+++ b/templates/data/mysql/managed.html
@@ -7,7 +7,7 @@
   https://docs.google.com/document/d/14GVPv7DKHBMpgW6NL0yK6rOsTdI9OREN5ZaY20YsKb4
 {% endblock meta_copydoc %}
 
-{% block title %}Managed MySQL services by Canonical{% endblock %}
+{% block title %}Managed services | MySQL{% endblock %}
 
 {% block meta_description %}
   Learn about Canonical’s managed services for MySQL, one of the world's most popular open source database management systems.

--- a/templates/data/mysql/support.html
+++ b/templates/data/mysql/support.html
@@ -6,7 +6,7 @@
   https://docs.google.com/document/d/1scPktUiI2XRVoYcR4L6qUZ91iZ0upZA-FaqyJN7uMJg/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Get support for MySQL, one of the most popular DBMS.{% endblock %}
+{% block title %}Support | MySQL{% endblock %}
 
 {% block meta_description %}
   Get support for MySQL from Canonical, the experts in open source. We provide ticket, phone and screen sharing support for up to ten years per release track.

--- a/templates/data/opensearch/index.html
+++ b/templates/data/opensearch/index.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1nVdoKoPrXw8lsvHEtMichlPNfxYU9Uj1zmKowcUXQ_w/edit
 {% endblock meta_copydoc %}
 
-{% block title %}An enterprise solution for OpenSearch from Canonical{% endblock %}
+{% block title %}OpenSearch{% endblock %}
 
 {% block canonical_url %}{{ request.host_url }}data/opensearch{% endblock %}
 

--- a/templates/data/opensearch/managed.html
+++ b/templates/data/opensearch/managed.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/19gcIoKEibXTvZCsmtYCSQBMnBUmNUJI6RaLoMHL2_TA/edit
 {% endblock %}
 
-{% block title %}Managed OpenSearch services by Canonical{% endblock %}
+{% block title %}Managed services | OpenSearch{% endblock %}
 
 {% block meta_description %}
   Learn about Canonical’s managed services for OpenSearch, the industry leading open source search engine, analytics tool and vector database.

--- a/templates/data/opensearch/support.html
+++ b/templates/data/opensearch/support.html
@@ -1,8 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}
-  Get support for OpenSearch, an open source search engine, analytics tool and vector database.
-{% endblock %}
+{% block title %}Support | OpenSearch{% endblock %}
 
 {% block meta_description %}
   Get support for OpenSearch, from Canonical. 24/7 or weekday support and up to fifteen years security patching per release

--- a/templates/data/opensearch/what-is-opensearch.html
+++ b/templates/data/opensearch/what-is-opensearch.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}What is OpenSearch{% endblock %}
+{% block title %}Overview | OpenSearch{% endblock %}
 
 {% block meta_description %}
   OpenSearch is an open source search and analytics suite. Developers can build solutions for search, data observability,

--- a/templates/data/postgresql/index.html
+++ b/templates/data/postgresql/index.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1GxineF4WLt0YlShaYkrzqWjIOkXjLJEfsnUdWVfWnz4/edit
 {% endblock meta_copydoc %}
 
-{% block title %}An advanced, enterprise-grade PostgreSQL solution from Canonical{% endblock %}
+{% block title %}PostgreSQL{% endblock %}
 
 {% block meta_description %}
   Charmed PostgreSQL comes with up to 10 years of support and security maintenance for PostgreSQL. It helps you secure and automate the deployment, maintenance and upgrades of your PostgreSQL databases across private and public clouds.

--- a/templates/data/postgresql/managed.html
+++ b/templates/data/postgresql/managed.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/10YAubAK42OWeaAXY2Ib9OE1q65xyP741R4bnnAA9GCk/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Managed PostgreSQL services by Canonical{% endblock %}
+{% block title %}Managed services | PostgreSQL{% endblock %}
 
 {% block meta_description %}
   Learn about Canonical’s managed services for PostgreSQL, the world's most acclaimed open source database management system.

--- a/templates/data/postgresql/support.html
+++ b/templates/data/postgresql/support.html
@@ -4,7 +4,7 @@
 https://docs.google.com/document/d/1scPktUiI2XRVoYcR4L6qUZ91iZ0upZA-FaqyJN7uMJg/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Get support for PostgreSQL, the world's most acclaimed DBMS.{% endblock %}
+{% block title %}Support | PostgreSQL{% endblock %}
 
 {% block meta_description %}
 Get support for PostgreSQL from Canonical, the experts in open-source. We provide ticket, phone or screen sharing support 24/7 for up to ten years per release track.

--- a/templates/data/postgresql/what-is-postgresql.html
+++ b/templates/data/postgresql/what-is-postgresql.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1GPCEnZgCfYvvPXn57iKL673PfNDkXkpY9fcGTxhNefg/edit
 {% endblock meta_copydoc %}
 
-{% block title %}What is PostgreSQL?{% endblock %}
+{% block title %}Overview | PostgreSQL{% endblock %}
 
 {% block meta_description %}
   PostgreSQL is the world's most acclaimed open source database management system. Explore PostgreSQL, its ecosystem, its internal architecture and how it compares to other databases.

--- a/templates/data/relational-databases/index.html
+++ b/templates/data/relational-databases/index.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}What is a relational database?{% endblock %}
+{% block title %}What is a relational database? | Data platform{% endblock %}
 
 {% block meta_description %}
   Enterprise-grade database offering with built-in high availability, backup, monitoring and

--- a/templates/data/spark-on-kubernetes.html
+++ b/templates/data/spark-on-kubernetes.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1N399Pym7aTEuTf_OAJiFrYcbtsy3iUHV-f82afSplcI/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Run production-grade Apache Spark on Kubernetes{% endblock %}
+{% block title %}Apache Spark on Kubernetes | Apache Spark{% endblock %}
 
 {% block meta_description %}
   Charmed Spark simplifies provisioning and maintenance for Apache Spark on Kubernetes on any Public & Private Cloud

--- a/templates/data/spark/index.html
+++ b/templates/data/spark/index.html
@@ -7,7 +7,7 @@
   https://docs.google.com/document/d/1sM8pgyM-N8VK8fyHgMsW21PdXUiqYrdRkPkipIljNd0/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Solution for Apache Spark on Kubernetes{% endblock %}
+{% block title %}Apache Spark{% endblock %}
 
 {% block canonical_url %}{{ request.host_url }}data/spark{% endblock %}
 

--- a/templates/data/spark/managed.html
+++ b/templates/data/spark/managed.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1fHeYFVZhSgEwerFzEhNtotR0e25UeItYArVr3LpTwVI/edit?tab=t.0#heading=h.myk2f07cm3hi
 {% endblock meta_copydoc %}
 
-{% block title %}Managed Spark services by Canonical{% endblock %}
+{% block title %}Managed services | Apache Spark{% endblock %}
 
 {% block meta_description %}
   Learn about Canonical’s managed services for Apache Spark, the industry-leading open source analytics engine used for big data workloads

--- a/templates/data/spark/support.html
+++ b/templates/data/spark/support.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1EcgdnMdW5jfZLLhcisUNMMtsPT-4alaPm3zirtvXEMk/edit?tab=t.0#heading=h.3ppydbf0tgen
 {% endblock meta_copydoc %}
 
-{% block title %}Get support for Apache Spark, an open parallel, distributed data processing framework.{% endblock %}
+{% block title %}Support | Apache Spark{% endblock %}
 
 {% block meta_description %}
   Get support for Apache Spark, from Canonical. 24/7 or weekday support and up to ten years security patching per release track.

--- a/templates/data/spark/what-is-spark.html
+++ b/templates/data/spark/what-is-spark.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1pyX-BOXmIZY6_8imIft1SAp1-S0i8bGYWEo5zoVEgQw/edit?tab=t.0
 {% endblock meta_copydoc %}
 
-{% block title %}What is Apache Spark?{% endblock %}
+{% block title %}Overview | Apache Spark{% endblock %}
 
 {% block meta_description %}
   Apache Spark is a free, open source parallel distributed processing framework that enables you to process all kinds of data at massive scale.

--- a/templates/data/streaming/index.html
+++ b/templates/data/streaming/index.html
@@ -6,9 +6,7 @@
     https://docs.google.com/document/d/1SMYf92QesxoUN6GLMiM0qWmLPMpTl6CYC3852fFA0Xo/edit
 {% endblock meta_copydoc %}
 
-{% block title %}
-    What is data streaming? Learn about data streaming - examples, technologies and use cases
-{% endblock %}
+{% block title %}What is data streaming? | Data platform{% endblock %}
 
 {% block meta_description %}
     Get an introduction to data streaming - what it is, how you can benefit from it and how to implement it with Apache Spark and Apache Kafka.

--- a/templates/data/valkey/index.html
+++ b/templates/data/valkey/index.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1zu_5LIjlcTwyJzJfX3jveX2HfMO8XxkXg5A7E5ZjE6g/
 {% endblock meta_copydoc %}
 
-{% block title %}Get security maintenance and support for Valkey, an open source, in-memory data store{% endblock %}
+{% block title %}Valkey{% endblock %}
 
 {% block meta_description %}
   Get support for Valkey, from Canonical. 24/7 or weekday support and up to 15 years security patching per release track.

--- a/templates/data/valkey/what-is-valkey.html
+++ b/templates/data/valkey/what-is-valkey.html
@@ -4,7 +4,7 @@
 https://docs.google.com/document/d/17mMgHu6z68QS9VSLSlLLcvsE62lartn-9MreX6IyQ60/
 {% endblock meta_copydoc %}
 
-{% block title %}What is Valkey?{% endblock %}
+{% block title %}Overview | Valkey{% endblock %}
 {% block meta_description %}Valkey is an open source, in-memory data store{% endblock %}
 {% block body_class %}is-paper{% endblock body_class %}
 

--- a/templates/data/warehouse/index.html
+++ b/templates/data/warehouse/index.html
@@ -8,7 +8,7 @@
   https://docs.google.com/document/d/15XNmiCI8x4lom0FgMmSD5YnW7IjtKjy8vq8NZQzsB7k/edit
 {% endblock meta_copydoc %}
 
-{% block title %}What is an enterprise data warehouse?{% endblock %}
+{% block title %}What is a data warehouse? | Data platform{% endblock %}
 
 {% block meta_description %}
   Learn about enterprise data warehouses – what they are, what they’re for, and how you can implement one with Canonical

--- a/templates/documentation/open-documentation-academy.html
+++ b/templates/documentation/open-documentation-academy.html
@@ -2,7 +2,7 @@
 
 {% extends 'documentation/documentation-layout.html' %}
 
-{% block title %}Documentation Practice - Open Documentation Academy{% endblock %}
+{% block title %}Open Documentation Academy | Documentation{% endblock %}
 
 {% block meta_copydoc %}
   https://docs.google.com/document/d/1nhy653-SOfTmGCIiSZHuGBCrwZlzEZJaA4kFBsw-5dc/edit

--- a/templates/dqlite/index.html
+++ b/templates/dqlite/index.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}Dqlite{% endblock title %}
+{% block title %}dqlite{% endblock title %}
 
 {% block meta_description %}
   Dqlite is a fast, embedded, persistent SQL database with Raft consensus that is perfect for fault-tolerant IoT and Edge devices.

--- a/templates/dqlite/index.html
+++ b/templates/dqlite/index.html
@@ -1,8 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}
-  Canonical Dqlite
-{% endblock title %}
+{% block title %}Dqlite{% endblock title %}
 
 {% block meta_description %}
   Dqlite is a fast, embedded, persistent SQL database with Raft consensus that is perfect for fault-tolerant IoT and Edge devices.

--- a/templates/events/canonical-days.html
+++ b/templates/events/canonical-days.html
@@ -5,9 +5,7 @@
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 {% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
 
-{% block title %}
-  Canonical Events
-{% endblock title %}
+{% block title %}Canonical Days | Events{% endblock title %}
 
 {% block meta_description %}
   Meet local open source experts at the Canonical Days

--- a/templates/events/index.html
+++ b/templates/events/index.html
@@ -3,9 +3,7 @@
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 {% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
 
-{% block title %}
-  Canonical Events
-{% endblock title %}
+{% block title %}Events{% endblock title %}
 
 {% block meta_description %}  
 {% endblock meta_description %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,7 @@
 {% endblock meta_copydoc %}
 
 {% block meta_title %}
-  Canonical | Trusted open source for enterprises
+  Trusted open source for enterprises | Canonical
 {% endblock meta_title %}
 
 {% block meta_description %}

--- a/templates/jaas/index.html
+++ b/templates/jaas/index.html
@@ -2,7 +2,7 @@
 
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 
-{% block title %}Manage large scale Juju deployments with Jaas{% endblock %}
+{% block title %}JAAS{% endblock %}
 
 {% block meta_description %}
   JAAS (Juju as a service) provides a single location to interact, manage and audit your Juju infrastructure using a dashboard or the Juju CLI commands.

--- a/templates/juju/charmhub-community.html
+++ b/templates/juju/charmhub-community.html
@@ -4,7 +4,7 @@
 {% from "_macros/vf_equal-heights.jinja" import vf_equal_heights %}
 {% from "_macros/vf_cta-section.jinja" import vf_cta_section %}
 
-{% block title %}Juju | The simplest way to deploy and maintain applications in the cloud{% endblock %}
+{% block title %}Charmhub community | Juju{% endblock %}
 
 {% block meta_description %}
   Juju is an open source orchestration engine for software operators that enables the deployment, integration and lifecycle management of applications at any scale, on any infrastructure.

--- a/templates/juju/charms-architecture.html
+++ b/templates/juju/charms-architecture.html
@@ -3,7 +3,7 @@
 {% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Charms architecture{% endblock %}
+{% block title %}Charms architecture | Juju{% endblock %}
 
 {% block meta_keywords %}Software operators{% endblock %}
 

--- a/templates/juju/docs/search.html
+++ b/templates/juju/docs/search.html
@@ -5,7 +5,7 @@
   <meta name="robots" content="noindex" />
 {% endblock %}
 
-{% block title %}Juju documentation search results{% endblock %}
+{% block title %}Documentation search | Juju{% endblock %}
 
 {% block meta_title %}Juju documentation search results{% endblock %}
 

--- a/templates/juju/index.html
+++ b/templates/juju/index.html
@@ -5,9 +5,7 @@
 {% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
 {% from "_macros/vf_rich-vertical-list.jinja" import vf_rich_vertical_list %}
 
-{% block title %}
-  Automate software operations with Juju and charms
-{% endblock title %}
+{% block title %}Juju{% endblock title %}
 
 {% block meta_copydoc %}
   https://docs.google.com/document/d/1IFnKQ3GQth7HSo1VlDy4nRyoFYPL9fjJN8jNuY8Nr2Q/edit?tab=t.0

--- a/templates/juju/integrations.html
+++ b/templates/juju/integrations.html
@@ -3,7 +3,7 @@
 {% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Juju integrations explained{% endblock %}
+{% block title %}Integrations | Juju{% endblock %}
 
 {% block meta_keywords %}Software operators{% endblock %}
 

--- a/templates/juju/juju-architecture.html
+++ b/templates/juju/juju-architecture.html
@@ -3,7 +3,7 @@
 {% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Juju architecture{% endblock %}
+{% block title %}Architecture | Juju{% endblock %}
 
 {% block meta_keywords %}Software operators{% endblock %}
 

--- a/templates/juju/model-driven-operations-manifesto.html
+++ b/templates/juju/model-driven-operations-manifesto.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Juju | The simplest way to deploy and maintain applications in the cloud{% endblock %}
+{% block title %}Model-driven operations manifesto | Juju{% endblock %}
 
 {% block meta_description %}
   Juju is an open source orchestration engine for software operators that enables the deployment, integration and lifecycle management of applications at any scale, on any infrastructure.

--- a/templates/juju/why-juju.html
+++ b/templates/juju/why-juju.html
@@ -3,7 +3,7 @@
 {% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Why use Juju? (open source orchestration engine for software operators){% endblock %}
+{% block title %}Why Juju? | Juju{% endblock %}
 
 {% block meta_keywords %}Software operators{% endblock %}
 

--- a/templates/knowledge/_base_knowledge_markdown.html
+++ b/templates/knowledge/_base_knowledge_markdown.html
@@ -5,7 +5,7 @@
 {% from "_macros/vf_cta-section.jinja" import vf_cta_section %}
 {% from "_macros/vf_newsletter-signup.jinja" import vf_newsletter_signup %}
 
-{% block title %}{{ title }}{% endblock title %}
+{% block title %}{{ title }} | Knowledge{% endblock title %}
 {% block head_extra %}{{ head_extra }}{% endblock head_extra %}
 
 {% block meta_description %}{{ description }}{% endblock meta_description %}

--- a/templates/legal/ubuntu-pro-service-terms/_base_uast_markdown.html
+++ b/templates/legal/ubuntu-pro-service-terms/_base_uast_markdown.html
@@ -1,5 +1,5 @@
 {% extends "templates/base.html" %}
-{% block title %}{{ title }}{% endblock title %}
+{% block title %}{{ title }} | Ubuntu Pro{% endblock title %}
 {% block meta_description %}{{ description }}{% endblock meta_description %}
 {% block meta_copydoc %}{{ copydoc }}{% endblock meta_copydoc %}
 

--- a/templates/lxd/index.html
+++ b/templates/lxd/index.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1LJ6ajHYAmKdxSNDaD5kbriDod1t7RcmIwVJtevAeKFQ{% endblock %}
 
-{% block title %}Canonical LXD{% endblock %}
+{% block title %}LXD{% endblock %}
 
 {% block meta_description %}
   Low-touch virtual infrastructure with LXD at any scale. Built on top of Linux containers,

--- a/templates/lxd/install.html
+++ b/templates/lxd/install.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1LKlXAc39dy69dSCc7PE6WqV2qkCSeXmicKGS4lFicDE/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Install LXD{% endblock %}
+{% block title %}Install | LXD{% endblock %}
 
 {% block meta_description %}Run system containers with LXD{% endblock %}
 

--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -5,7 +5,7 @@
 {% endblock
 meta_copydoc %}
 
-{% block title %}LXD - Manage{% endblock %}
+{% block title %}Manage | LXD{% endblock %}
 
 {% block meta_description %}
   When using LXD, you have several ways to manage your server configuration and your instances: with a simple command line tool, directly through the REST API, through the web UI or by using third-party tools and integrations.

--- a/templates/maas/features.html
+++ b/templates/maas/features.html
@@ -6,7 +6,7 @@
 {% from "_macros/vf_divided-section.jinja" import vf_divided_section %}
 {% from "_macros/vf_cta-section.jinja" import vf_cta_section %}
 
-{% block title %}Features{% endblock %}
+{% block title %}Features | MAAS{% endblock %}
 
 {% block meta_copydoc %}
     https://docs.google.com/document/d/1KcYwNK0pJyiDVEDq4vTpv6BX_rpSDnxUxtAvAnsRKyw/edit

--- a/templates/maas/how-maas-works.html
+++ b/templates/maas/how-maas-works.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}How MAAS works{% endblock %}
+{% block title %}How it works | MAAS{% endblock %}
 
 {% block meta_copydoc %}
     https://docs.google.com/document/d/16tkFyk2W-AkoJYeE9qoFjwzHBlH4diazN9tlqRsV3XA/edit

--- a/templates/maas/index.html
+++ b/templates/maas/index.html
@@ -9,7 +9,7 @@
 {% from "_macros/vf_equal-heights.jinja" import vf_equal_heights %}
 {% from 'macros/_macros-lite-video.jinja' import lite_video %}
 
-{% block title %}MAAS | Bare metal automation for your data center{% endblock %}
+{% block title %}MAAS{% endblock %}
 
 {% block meta_copydoc %}
   https://docs.google.com/document/d/1qKlG2z0PWUmoWQRURKYMD4AQYULweqrEwLku9_p4VAI/edit

--- a/templates/maas/resources.html
+++ b/templates/maas/resources.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}Understand MAAS:Resources{% endblock %}
+{% block title %}Resources | MAAS{% endblock %}
 
 {% block meta_description %}
   A collection of useful and educational links to articles and information about

--- a/templates/maas/support.html
+++ b/templates/maas/support.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}Bare metal support{% endblock %}
+{% block title %}Support | MAAS{% endblock %}
 
 {% block meta_description %}
     Get help for all your bare metal needs with Canonical, from enterprise bare metal support to training and professional services.

--- a/templates/maas/tutorials.html
+++ b/templates/maas/tutorials.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}Tutorials{% endblock %}
+{% block title %}Tutorials | MAAS{% endblock %}
 
 {% block content %}
 

--- a/templates/microcloud/contact-us.html
+++ b/templates/microcloud/contact-us.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1gIqyGENG6YQm0OH7WIS893stAzWZukfCtFD05bHr4pY/edit
 {% endblock %}
 
-{% block title %}Contact us{% endblock %}
+{% block title %}Contact us | MicroCloud{% endblock %}
 
 {% block body_class %}
   is-paper

--- a/templates/microcloud/index.html
+++ b/templates/microcloud/index.html
@@ -9,7 +9,7 @@
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 {% from 'macros/_macros-lite-video.jinja' import lite_video %}
 
-{% block title %}MicroCloud: your open source cloud platform{% endblock %}
+{% block title %}MicroCloud{% endblock %}
 
 {% block meta_description %}
   MicroCloud offers a lightweight, automated, and trusted open source cloud platform, integrated with the best open source cloud infrastructure components

--- a/templates/microcloud/resources.html
+++ b/templates/microcloud/resources.html
@@ -2,7 +2,7 @@
 
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 
-{% block title %}MicroCloud Resources{% endblock %}
+{% block title %}Resources | MicroCloud{% endblock %}
 
 {% block meta_description %}
   A collection of useful and educational material and information about MicroClouds and its components.

--- a/templates/microcloud/thank-you.html
+++ b/templates/microcloud/thank-you.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}MicroCloud &ndash; Thank you{% endblock %}
+{% block title %}Thank you | MicroCloud{% endblock %}
 
 {% block body_class %}is-paper{% endblock body_class %}
 

--- a/templates/microcloud/what-is-microcloud.html
+++ b/templates/microcloud/what-is-microcloud.html
@@ -6,7 +6,7 @@
 {% from "_macros/vf_resources.jinja" import vf_resources %}
 {% from "_macros/vf_cta-section.jinja" import vf_cta_section %}
 
-{% block title %}What is MicroCloud?{% endblock %}
+{% block title %}Overview | MicroCloud{% endblock %}
 
 {% block meta_description %}
   Find out more about Canonical’s lightweight, open source cloud platform, MicroCloud. Learn about what MicroCloud is, its components, and how it works.

--- a/templates/microk8s/contact-us.html
+++ b/templates/microk8s/contact-us.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1gIqyGENG6YQm0OH7WIS893stAzWZukfCtFD05bHr4pY/edit
 {% endblock %}
 
-{% block title %}Contact us{% endblock %}
+{% block title %}Contact us | MicroK8s{% endblock %}
 
 {% block body_class %}
   is-paper

--- a/templates/microk8s/features/index.html
+++ b/templates/microk8s/features/index.html
@@ -1,8 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}
-  MicroK8s features
-{% endblock title %}
+{% block title %}Features | MicroK8s{% endblock title %}
 
 {% block meta_description %}
   MicroK8s high availability is automatic when three or more nodes are joined into the cluster. If there are more than three nodes, then a spare one is automatically promoted if a data store node goes offline, creating a zero-ops resilient HA Kubernetes which can lose nodes and heal itself.

--- a/templates/microk8s/index.html
+++ b/templates/microk8s/index.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}MicroK8s &ndash; Zero-ops Kubernetes for developers, edge and IoT{% endblock %}
+{% block title %}MicroK8s{% endblock %}
 
 {% block meta_description %}
   High availability Kubernetes with autonomous clusters. MicroK8s is the simplest production-grade conformant K8s for edge and IoT, on Linux, Windows, and macOS.

--- a/templates/microk8s/resources/index.html
+++ b/templates/microk8s/resources/index.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Resources{% endblock %}
+{% block title %}Resources | MicroK8s{% endblock %}
 
 {% block meta_description %}
 A collection of useful and educational material and information about MicroK8s. Learn more

--- a/templates/microk8s/tutorials.html
+++ b/templates/microk8s/tutorials.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}MicroK8s tutorials{% endblock %}
+{% block title %}Tutorials | MicroK8s{% endblock %}
 
 {% block meta_copydoc %}
 https://docs.google.com/document/d/1Lpo7Od9VA1aHYmr9UVp02vCGOP5Zxmzx4zZE9YJwlQg/edit

--- a/templates/mir/index.html
+++ b/templates/mir/index.html
@@ -5,9 +5,7 @@
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 {% from "_macros/vf_equal-heights.jinja" import vf_equal_heights %}
 
-{% block title %}
-  Canonical Mir Display Server
-{% endblock title %}
+{% block title %}Mir display server{% endblock title %}
 
 {% block meta_copydoc %}
   https://docs.google.com/document/d/1wqmWPx4TJ_oJoFt4gBOg4trYMIAsugMYtHGXzYJx8kc/edit#

--- a/templates/mlops/contact-us.html
+++ b/templates/mlops/contact-us.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Contact us | Artificial Intellegence{% endblock %}
+{% block title %}Contact us | MLOps{% endblock %}
 
 {% block meta_copydoc %}
   https://docs.google.com/document/d/185NqOTBSWuVIAppRIT0K7hcQzTHm6Rk7XyZXcjNTFQM/edit

--- a/templates/mlops/feast.html
+++ b/templates/mlops/feast.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Feast feature store - enterprise solution{% endblock %}
+{% block title %}Feast feature store | MLOps{% endblock %}
 
 {% block meta_description %}
   Enterprise-ready Feast feature store for ML pipelines. Charmed Feast integrates with Kubeflow and simplifies feature management.

--- a/templates/mlops/index.html
+++ b/templates/mlops/index.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Open source MLOps{% endblock %}
+{% block title %}MLOps{% endblock %}
 
 {% block meta_description %}
   The open source MLOps platform that seamlessly integrates open source tooling to cover all stages of the machine learning lifecycle.

--- a/templates/mlops/kubeflow/index.html
+++ b/templates/mlops/kubeflow/index.html
@@ -3,7 +3,7 @@
 {% from "_macros/vf_equal-heights.jinja" import vf_equal_heights %}
 {% from "_macros/vf_cta-section.jinja" import vf_cta_section %}
 
-{% block title %}Kubeflow AI and MLOps at any scale{% endblock %}
+{% block title %}Kubeflow | MLOps{% endblock %}
 
 {% block meta_description %}
   Enterprise-ready Charmed Kubeflow, the fully supported MLOps platform for any cloud.

--- a/templates/mlops/kubeflow/what-is-kubeflow.html
+++ b/templates/mlops/kubeflow/what-is-kubeflow.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}What is Kubeflow?{% endblock %}
+{% block title %}Overview | Kubeflow | MLOps{% endblock %}
 
 {% block meta_description %}
   Charmed Kubeflow is an enterprise-ready, fully supported MLOps platform for any cloud. A complete, free, open source solution for sophisticated data science labs.

--- a/templates/mlops/mlflow.html
+++ b/templates/mlops/mlflow.html
@@ -2,7 +2,7 @@
 
 {% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
 
-{% block title %}Charmed MLflow{% endblock %}
+{% block title %}MLflow | MLOps{% endblock %}
 
 {% block meta_description %}
   MLflow is an open-source platform used for managing machine learning workflows

--- a/templates/mlops/mlops-workshop.html
+++ b/templates/mlops/mlops-workshop.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}MLOps workshop{% endblock %}
+{% block title %}Workshop | MLOps{% endblock %}
 
 {% block meta_description %}
   Accelerate your AI/ML projects with the MLOps workshop hosted by Canonical open source experts.

--- a/templates/multipass/index.html
+++ b/templates/multipass/index.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Multipass orchestrates virtual Ubuntu instances{% endblock %}
+{% block title %}Multipass{% endblock %}
 
 {% block meta_description %}
   Multipass is a CLI to launch and manage VMs on Windows, Mac and Linux that simulates a cloud environment with support for cloud-init. Get Ubuntu on-demand with clean integration to your IDE and version control on your native platform.

--- a/templates/observability/index.html
+++ b/templates/observability/index.html
@@ -3,7 +3,7 @@
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Open source observability for enterprises{% endblock %}
+{% block title %}Observability{% endblock %}
 
 {% block meta_description %}
   Enterprise-class open source observability with long-term support for Prometheus, Alertmanager, Grafana and more.

--- a/templates/observability/managed/index.html
+++ b/templates/observability/managed/index.html
@@ -3,7 +3,7 @@
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 
-{% block title %}Managed Open Source Observability{% endblock %}
+{% block title %}Managed services | Observability{% endblock %}
 
 {% block meta_description %}
   Managed open-source observability: how to achieve end-to-end cloud observability while maintaining your business focus and without spending your budget keeping the lights on.

--- a/templates/observability/what-is-observability.html
+++ b/templates/observability/what-is-observability.html
@@ -3,7 +3,7 @@
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}What is observability{% endblock %}
+{% block title %}What is observability? | Observability{% endblock %}
 
 {% block meta_description %}
   What is observability, the difference between observability and monitoring (observability vs monitoring) and how the different types of telemetry that are collected and analyzed in the state of the art of open-source observability.

--- a/templates/openstack/architecture.html
+++ b/templates/openstack/architecture.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1i8rjvhw3N2gDA5NXuKEPcftXY95zePjsURmQu4dSgGo
 {% endblock meta_copydoc %}
 
-{% block title %}OpenStack architecture{% endblock %}
+{% block title %}Architecture | OpenStack{% endblock %}
 
 {% block meta_description %}
   OpenStack under the hood: explore OpenStack architecture and understand how it works.

--- a/templates/openstack/compare/contact-us.html
+++ b/templates/openstack/compare/contact-us.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1gIqyGENG6YQm0OH7WIS893stAzWZukfCtFD05bHr4pY/edit
 {% endblock %}
 
-{% block title %}Contact us{% endblock %}
+{% block title %}Contact us | OpenStack{% endblock %}
 
 {% block body_class %}
   is-paper

--- a/templates/openstack/compare/index.html
+++ b/templates/openstack/compare/index.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1_luFPxd5yZy6eJt3-GE7jX_G8m3wTjo-JDo1aUPOnpU
 {% endblock meta_copydoc %}
 
-{% block title %}OpenStack distributions: a comparison{% endblock %}
+{% block title %}Distributions comparison | OpenStack{% endblock %}
 
 {% block meta_description %}
   See a detailed comparison of all the different OpenStack distributions. Compare architecture, features, support, pricing, and more with our extensive breakdown.

--- a/templates/openstack/features/contact-us.html
+++ b/templates/openstack/features/contact-us.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Contact the Canonical team{% endblock %}
+{% block title %}Contact us | OpenStack{% endblock %}
 
 {% block meta_description %}
   Contact Canonical to learn how OpenStack can fit your use case

--- a/templates/openstack/features/index.html
+++ b/templates/openstack/features/index.html
@@ -11,7 +11,7 @@
   https://docs.google.com/document/d/1W5icC6V49_BDGjrHmB7xD_uDZ8IT1pJDriOiB3HYw_g/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Enterprise cloud solution{% endblock %}
+{% block title %}Features | OpenStack{% endblock %}
 
 {% block meta_description %}
   Looking for an enterprise cloud solution? Canonical delivers comprehensive products with full automation tailored to the most demanding use cases.

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1v1G2y465b_VYVUG9TIV-A_X1dU4kg5Zvrwd2latidCk/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Canonical OpenStack{% endblock %}
+{% block title %}OpenStack{% endblock %}
 
 {% block meta_description %}
   Canonical OpenStack - your own professional cloud for sophisticated workloads, including AI/ML, and full control over your sensitive data

--- a/templates/openstack/resources.html
+++ b/templates/openstack/resources.html
@@ -9,7 +9,7 @@
   https://docs.google.com/document/d/1Fv9eAy2_iPm5m4lOliqQIJN0Gg4OSo9XtrtvH180Jvg
 {% endblock meta_copydoc %}
 
-{% block title %}OpenStack resources{% endblock %}
+{% block title %}Resources | OpenStack{% endblock %}
 
 {% block meta_description %}
   Explore a collection of useful OpenStack resources and educational materials. Learn OpenStack from the ground up from one of the key industry players.

--- a/templates/openstack/support/contact-us.html
+++ b/templates/openstack/support/contact-us.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1gIqyGENG6YQm0OH7WIS893stAzWZukfCtFD05bHr4pY/edit
 {% endblock %}
 
-{% block title %}Contact us{% endblock %}
+{% block title %}Contact us | OpenStack{% endblock %}
 
 {% block body_class %}
   is-paper

--- a/templates/openstack/support/index.html
+++ b/templates/openstack/support/index.html
@@ -14,7 +14,7 @@
     https://docs.google.com/document/d/12moyGHnRV3UgUtHTT9SvHbUjia_kFfyufz6JA_Bn4hk/edit?tab=t.0
 {% endblock meta_form_copydoc %}
 
-{% block title %}OpenStack support{% endblock %}
+{% block title %}Support | OpenStack{% endblock %}
 
 {% block meta_description %}
     Get enterprise support at every stage of your OpenStack deployment project on Ubuntu

--- a/templates/partners/channel-and-reseller.html
+++ b/templates/partners/channel-and-reseller.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1rn2f4wL8wxnILlnmfchkNQV2RzsYUMcRaCfP-d6V_5Q{% endblock %}
 
-{% block title %}Channel / Reseller Programme | Partners{% endblock %}
+{% block title %}Channel / Reseller program | Partners{% endblock %}
 
 {% block meta_description %}
   Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers.

--- a/templates/partners/desktop.html
+++ b/templates/partners/desktop.html
@@ -4,7 +4,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1ewbQK9llXu9khMszy2A2EuzR-cpB3OC-3tvuYhA9NVE{% endblock %}
 
-{% block title %}Canonical Desktop partner program{% endblock %}
+{% block title %}Desktop partner program | Partners{% endblock %}
 
 {% block meta_description %}
   Canonical collaborates with the world&rsquo;s leading vendors to optimize and certify Ubuntu on hundreds of laptops, desktops and workstations for a securely designed and maintained enterprise grade platform.

--- a/templates/partners/executive-summit.html
+++ b/templates/partners/executive-summit.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/15C3k-htvapwp-WTrYQ2SdHBW20Lp9IinpY9mkvo6q3U{% endblock %}
 
-{% block title %}Executive Summit | Partners{% endblock %}
+{% block title %}Executive summit | Partners{% endblock %}
 
 {% block meta_description %}
   Connect with partners from around the globe to learn about open source, from data centre to the cloud, to maximize your company sales.

--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Find a Canonical partner | Partners{% endblock %}
+{% block title %}Find a partner | Partners{% endblock %}
 
 {% block meta_copydoc %}
   https://docs.google.com/document/d/1R3s-aiSrFvbNrHjdfblYo_XX1f_EQ989DkmPS41seZc/edit

--- a/templates/partners/gsi.html
+++ b/templates/partners/gsi.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1PgdZCn16zMVA3LVcLihN03DYFLLqkHIqTqfsgx_LHFg{% endblock %}
 
-{% block title %}Global System Integrator Programme | Partners{% endblock %}
+{% block title %}Global system integrator program | Partners{% endblock %}
 
 {% block meta_description %}
   Together we've successfully helped telecom providers, governmental agencies, financial services companies and other industries be relevant in the market by having the most current open source technology available today.

--- a/templates/partners/ihv-and-oem.html
+++ b/templates/partners/ihv-and-oem.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1p8Et43R14AGiFn9g7ro9VLXZh26gph9Kk5K6_lc8W8U{% endblock %}
 
-{% block title %}IHV and OEM Programme | Partners{% endblock %}
+{% block title %}IHV and OEM program | Partners{% endblock %}
 
 {% block meta_description %}
   For nearly two decades, Canonical and our enterprise partners have provided market-leading solutions for customers seeking alternatives to complex and costly proprietary operating environments.

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Canonical | Partner programs{% endblock %}
+{% block title %}Partner programs{% endblock %}
 
 {% block meta_copydoc %}
   https://docs.google.com/document/d/1q6dkqQ0zcshrfOmdJA_bAip73EaMSEyXAn8bAD7GqNw/edit

--- a/templates/partners/iot-device.html
+++ b/templates/partners/iot-device.html
@@ -8,7 +8,7 @@
   https://docs.google.com/document/d/1qNEjihmySR6l6LZJ-SkSVTpaBSxuY8imoseN0OLkiMw/edit#
 {% endblock %}
 
-{% block title %}IoT Device Programme | Partners{% endblock %}
+{% block title %}IoT device program | Partners{% endblock %}
 
 {% block meta_image %}https://assets.ubuntu.com/v1/a491f87c-Ubuntu+Certified+Hardware.svg{% endblock %}
 

--- a/templates/partners/isv-program/embedding-faq.html
+++ b/templates/partners/isv-program/embedding-faq.html
@@ -2,7 +2,7 @@
 
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}FAQs - IPRights Policy - January 2024{% endblock %}
+{% block title %}IP rights policy FAQs | Partners{% endblock %}
 
 {% block meta_description %}
   Embedded Linux development is easy and secure on Ubuntu. Choose an enterprise app store or use the global Snap Store for reliable IoT package management. Start your embedded Linux project today. Get Ubuntu on your board with hardware certification and enablement.

--- a/templates/partners/isv-program/index.html
+++ b/templates/partners/isv-program/index.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1qWWpFbwZykjAIt-Kf6iFCXPCnmmuKBbU5mzvILnO-q0/{% endblock %}
 
-{% block title %}ISV program{% endblock %}
+{% block title %}ISV program | Partners{% endblock %}
 
 {% block meta_description %}
   Canonical's ISV program helps software vendors build products and solutions at speed with a trusted open source ecosystem.

--- a/templates/partners/public-cloud.html
+++ b/templates/partners/public-cloud.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1O3KUX41hwsehnAedYV5Pp4i_aMrKDTGYiri5uR6N9fc{% endblock %}
 
-{% block title %}Public Cloud Programme{% endblock %}
+{% block title %}Public cloud program | Partners{% endblock %}
 
 {% block meta_description %}
   Ubuntu is the most popular guest OS on both public and private clouds, thanks to its security, versatility and continually updated features.

--- a/templates/partners/silicon/index.html
+++ b/templates/partners/silicon/index.html
@@ -10,7 +10,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1nyiz4I1GqBiXe_SKpDzho3yv20LKyYpyhHh0fvvUrOI/{% endblock %}
 
-{% block title %}Silicon Program | Partners{% endblock %}
+{% block title %}Silicon program | Partners{% endblock %}
 
 {% block meta_image %}https://assets.ubuntu.com/v1/a491f87c-Ubuntu+Certified+Hardware.svg{% endblock %}
 

--- a/templates/partners/silicon/intel/index.html
+++ b/templates/partners/silicon/intel/index.html
@@ -4,7 +4,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1GstP9FfZfbXO81YcX-9oCJdP9pamlgpl2kKkSqlrWFE{% endblock %}
 
-{% block title %}Intel and Canonical{% endblock %}
+{% block title %}Intel | Partners{% endblock %}
 
 {% block meta_description %}
   Canonical collaborates with the world&rsquo;s leading vendors to optimise and certify Ubuntu on 100s of laptops, desktops and workstations for a secure and constantly updated platform.

--- a/templates/partners/thank-you.html
+++ b/templates/partners/thank-you.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Become a partner - Thank you{% endblock %}
+{% block title %}Thank you | Partners{% endblock %}
 
 {% block meta_description %}Thank you for your interest in partnering with Ubuntu.{% endblock %}
 

--- a/templates/projects/index.html
+++ b/templates/projects/index.html
@@ -2,7 +2,7 @@
 
 {% extends 'base_index.html' %}
 
-{% block title %}Canonical | Open source projects{% endblock %}
+{% block title %}Open source projects{% endblock %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1GTnsk_Fk-ZHJQi--6X2TuaURwUCwnxZQjKdWDFBsaS0{% endblock %}
 

--- a/templates/solutions/ai/edge.html
+++ b/templates/solutions/ai/edge.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/17eHoiLrhFLrfV8UXD_4bxn-yY1_YToxf4cs8-5kYkxo/edit
 {% endblock meta_copydoc %}
 
-{% block title %}Enterprise AI edge computing{% endblock %}
+{% block title %}Edge computing | AI{% endblock %}
 
 {% block meta_description %}
   Get everything you need to deploy AI at the edge in one solution. Secure and compliant open source optimised for embedded AI use cases.

--- a/templates/solutions/ai/genai.html
+++ b/templates/solutions/ai/genai.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1eMvLlW6U-3ZWRRtY3Bq2u6EaFRqop4n6x8wgj3OWw-k/edit
 {% endblock meta_copydoc %}
 
-{% block title %}GenAI infrastructure{% endblock %}
+{% block title %}GenAI | AI{% endblock %}
 
 {% block meta_description %}
   Use open source GenAI infrastructure to take your models to market faster and more securely.

--- a/templates/solutions/ai/index.html
+++ b/templates/solutions/ai/index.html
@@ -9,7 +9,7 @@
   https://docs.google.com/document/d/1AtAApqxX9cbWf4a3cakEYbk7OoTfdBBi7FlA3WZz5ZM/edit
 {% endblock %}
 
-{% block title %}Open source AI for the enterprise{% endblock %}
+{% block title %}AI{% endblock %}
 
 {% block meta_description %}
   Innovate quickly, securely, and cost-effectively with open source AI for the enterprise &mdash; all on a single stack.

--- a/templates/solutions/ai/infrastructure/index.html
+++ b/templates/solutions/ai/infrastructure/index.html
@@ -7,7 +7,7 @@
 {% from "_macros/vf_tab-section.jinja" import vf_tab_section %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Full-stack AI infrastructure{% endblock %}
+{% block title %}Infrastructure | AI{% endblock %}
 
 {% block meta_description %}
   Fast-track your AI projects with a proven and supported open source

--- a/templates/solutions/automotive/buyers-guide/index.html
+++ b/templates/solutions/automotive/buyers-guide/index.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block title %}Boost your automotive business with Ubuntu{% endblock %}
+{% block title %}Buyer's guide | Automotive{% endblock %}
 
 {% block meta_description %}
   Ubuntu is widely used to reduce time to market in automotive companies, as a platform for data analytics, online services, robotics and machine learning. Infotainment, ADAS and cockpit application development on Ubuntu is faster. New real-time hypervisors enable Ubuntu VMs alongside functional safety RTOS solutions.

--- a/templates/solutions/automotive/index.html
+++ b/templates/solutions/automotive/index.html
@@ -8,7 +8,7 @@
     https://docs.google.com/document/d/10jSLdwz2Ks7gnEMXlKWzrpsY6TQFxISUgnQo4y3yOrA/edit?tab=t.0
 {% endblock %}
 
-{% block title %}Boost your automotive business with Ubuntu{% endblock %}
+{% block title %}Ubuntu for automotive{% endblock %}
 
 {% block meta_description %}
     Ubuntu is widely used to reduce time to market in automotive companies, as a platform for data analytics, online services, robotics and machine learning. Infotainment, ADAS and cockpit application development on Ubuntu is faster. New real-time hypervisors enable Ubuntu VMs alongside functional safety RTOS solutions.

--- a/templates/solutions/index.html
+++ b/templates/solutions/index.html
@@ -6,7 +6,7 @@
   https://docs.google.com/document/d/1vdnlbFSCidiNBXZ1zVKHWNIv1kl6C0vMmQAMYfz3yhU/edit?tab=t.0
 {% endblock %}
 
-{% block title %}Canonical - open source solutions{% endblock %}
+{% block title %}Open source solutions{% endblock %}
 
 {% block meta_description %}
   Discover Canonical's open source solutions. Cost-effective, composable, and completely under your control. From the OS to AI applications and MLOps.

--- a/templates/solutions/industrial/index.html
+++ b/templates/solutions/industrial/index.html
@@ -4,7 +4,7 @@
 {% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Industrial{% endblock %}
+{% block title %}Industrial solutions{% endblock %}
 
 {% block meta_copydoc %}
     https://docs.google.com/document/d/1QiU75g49lRKebt82oyLSxR3-PU96Sk87nqauAZ4vvIY

--- a/templates/solutions/infrastructure/edge-computing/index.html
+++ b/templates/solutions/infrastructure/edge-computing/index.html
@@ -6,7 +6,7 @@
 {% from "_macros/vf_equal-heights.jinja" import vf_equal_heights %}
 {% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
 
-{% block title %}Straightforward, nimble edge infrastructure{% endblock %}
+{% block title %}Edge computing | Infrastructure{% endblock %}
 
 {% block meta_description %}
   Deploy, manage, and secure edge infrastructure on a flexible, cost-effective, robust open source foundation.

--- a/templates/solutions/infrastructure/index.html
+++ b/templates/solutions/infrastructure/index.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Run your data center like a cloud with Canonical infrastructure solutions{% endblock %}
+{% block title %}Infrastructure solutions{% endblock %}
 
 {% block meta_description %}
   Canonical infrastructure solutions enable you to build an enterprise-grade cloud with open

--- a/templates/solutions/infrastructure/private-cloud-pricing.html
+++ b/templates/solutions/infrastructure/private-cloud-pricing.html
@@ -3,7 +3,7 @@
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 {% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
 
-{% block title %}Private cloud pricing{% endblock %}
+{% block title %}Private cloud pricing | Infrastructure{% endblock %}
 
 {% block meta_description %}
   Use this private cloud pricing page and calculator to estimate the cost of running your workloads in a private cloud.

--- a/templates/solutions/infrastructure/sovereign-cloud.html
+++ b/templates/solutions/infrastructure/sovereign-cloud.html
@@ -7,7 +7,7 @@
 
 {% extends "base_index.html" %}
 
-{% block title %}Sovereign cloud{% endblock %}
+{% block title %}Sovereign cloud | Infrastructure{% endblock %}
 
 {% block meta_description %}
   Gain control of your data and infrastructure with an open source sovereign cloud from Canonical

--- a/templates/solutions/infrastructure/virtualization-solutions/index.html
+++ b/templates/solutions/infrastructure/virtualization-solutions/index.html
@@ -5,7 +5,7 @@
 {% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
 {% from "_macros/vf_logo-section.jinja" import vf_logo_section %}
 
-{% block title %}Virtualization solutions{% endblock %}
+{% block title %}Virtualization solutions | Infrastructure{% endblock %}
 
 {% block meta_description %}
 Canonical's open source virtualization solutions scale from a single laptop to multi-region data centers &ndash; all without licensing fees or lock.

--- a/templates/solutions/iot-and-devices/index.html
+++ b/templates/solutions/iot-and-devices/index.html
@@ -5,7 +5,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1htb7rb55Ks5ZHn7RLzoeU51nZpWOX6YC10CfZ8UJxDM{% endblock %}
 
-{% block title %}Build, secure and manage IoT devices at scale{% endblock %}
+{% block title %}IoT and devices{% endblock %}
 
 {% block meta_description %}
   Choose the OS that ensures scalable, secure IoT for businesses. Streamline your IoT lifecycle with an OS that runs seamlessly from development to production.

--- a/templates/solutions/open-source-security/cyber-resilience-act/index.html
+++ b/templates/solutions/open-source-security/cyber-resilience-act/index.html
@@ -6,7 +6,7 @@
   https://docs.google.com/document/d/13VaiP6GGkGB4mE01bIqJ3cg8MfQXulNs9m3cmYb20HQ
 {% endblock meta_copydoc %}
 
-{% block title %}Understand the Cyber Resilience Act requirements{% endblock %}
+{% block title %}Cyber Resilience Act | Open source security{% endblock %}
 
 {% block meta_description %}
   Discover what you need to know about the EU Cyber Resilience Act requirements, get clear recommendations for compliance, and learn how Canonical helps with CRA compliance.

--- a/templates/solutions/open-source-security/index.html
+++ b/templates/solutions/open-source-security/index.html
@@ -8,7 +8,7 @@
 
 {% from "_macros/vf_blog.jinja" import vf_blog %}
 
-  {% block title %}Get open source security from Canonical{% endblock %}
+  {% block title %}Open source security{% endblock %}
 
   {% block meta_description %}
     Standardize your open source supply chain with the publisher of Ubuntu. Ideal to stay compliant across your devices, apps, cloud infrastructure, and systems.

--- a/templates/solutions/telco/5g-core.html
+++ b/templates/solutions/telco/5g-core.html
@@ -2,7 +2,7 @@
 
 {% from "_macros/vf_cta-section.jinja" import vf_cta_section %}
 
-{% block title %}Canonical telecom solutions for a cloud-native 5G core{% endblock %}
+{% block title %}5G core | Telco{% endblock %}
 
 {% block meta_description %}
   Canonical's infrastructure solutions meet the 5G Core needs of telecom giants, ensuring robust, scalable, and secure network infrastructures.

--- a/templates/solutions/telco/5g-edge.html
+++ b/templates/solutions/telco/5g-edge.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}5G multi-access edge computing with Canonical{% endblock %}
+{% block title %}5G edge | Telco{% endblock %}
 
 {% block meta_description %}
   Canonical's Ubuntu, OpenStack, Kubernetes, and MicroCloud solutions meet telco edge needs with real-time performance, security, and scalability.

--- a/templates/solutions/telco/index.html
+++ b/templates/solutions/telco/index.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1yRSYYY8_UNfZzdLcp_fYxi-STGm40o3UP9vD2vW6brw
 {% endblock meta_copydoc %}
 
-{% block title %}Canonical Telco Solutions{% endblock %}
+{% block title %}Telco solutions{% endblock %}
 
 {% block meta_description %}
   Open source makes telco projects more cost-effective and innovative. Navigate the complex landscape of telco software with confidence, and scale with Canonical.

--- a/templates/solutions/telco/open-ran.html
+++ b/templates/solutions/telco/open-ran.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Canonical's open source infrastructure products for Open RAN with virtual RAN{% endblock %}
+{% block title %}Open RAN | Telco{% endblock %}
 
 {% block meta_description %}
   Canonical’s high-performance products help telcos shift from proprietary systems to networks with disaggregated virtual RAN components and Open RAN architecture

--- a/templates/solutions/ubuntu-os/index.html
+++ b/templates/solutions/ubuntu-os/index.html
@@ -4,7 +4,7 @@
   https://docs.google.com/document/d/1X3osSqcm3rWLqYUJr5G4fXEEHCby-j5FEJwClLNx5S4/edit
 {% endblock meta_copydoc %}
 
-{% block title %}The world's favourite enterprise OS{% endblock %}
+{% block title %}Ubuntu OS{% endblock %}
 
 {% block meta_description %}
   Ubuntu is the world's most popular Linux distribution. Unify your tech stack with the enterprise OS that is favoured for servers, IoT and applications.

--- a/templates/solutions/ubuntu-os/workstations.html
+++ b/templates/solutions/ubuntu-os/workstations.html
@@ -5,7 +5,7 @@
 {% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
 {% from "macros/_macros-image.jinja" import image_wrapper %}
 
-{% block title %}Performance and compliance for enterprise workstations with Ubuntu{% endblock %}
+{% block title %}Workstations | Ubuntu OS{% endblock %}
 
 {% block description %}
   Choose a workstation Linux OS that unlocks the full performance of your hardware and your teams. Discover Ubuntu as a proven OS for enterprise workstations.


### PR DESCRIPTION
## Summary

Restructure all page titles (~159 templates) to conform with WCAG 2.4.2 and W3C guidance on meaningful page titles.

## Changes

- Move `| Canonical` outside the title block in `base_index.html` so all pages inherit it automatically without repeating it
- Apply W3C pattern throughout: `Page | Section | Canonical` (most specific context first)
- Replace marketing straplines with concise, descriptive identifiers
- Add section breadcrumbs to sub-pages that were missing context
- Apply sentence case consistently per Canonical style guide
- Use US English `program` instead of `programme` throughout
- Standardise separator to `|` across all templates

## References

- [WCAG 2.4.2 Page Titled](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html)
- [W3C guidance on page titles](https://www.w3.org/Provider/Style/TITLE.html)