### PR TITLE
updated Docs URLs on /lxd page

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -123,7 +123,7 @@ lxd:
     - title: Manage
       path: /lxd/manage
     - title: Docs
-      path: https://canonical-lxd.readthedocs-hosted.com/en/
+      path: /lxd/docs
     - title: Forum
       path: https://discourse.ubuntu.com/c/lxd/126?_ga=2.69179345.1978494405.1700868870-354120313.1700868870
 

--- a/templates/lxd/index.html
+++ b/templates/lxd/index.html
@@ -271,7 +271,7 @@
           </div>
           <div class="col-4 col-small-2">
             <p>
-              <a href="https://documentation.ubuntu.com/lxd/en/latest/">Read the documentation&nbsp;&rsaquo;</a>
+              <a href="/lxd/docs">Read the documentation&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done
Updated the docs URLs on the /lxd page.
Changed two links:
-  Under “Menu structure” : change link for Docs
-  Under “Join the LXD Community”: change link for Read the documentation

## QA

- Open the [DEMO](__DEMO_URL__/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card
Copy docs: https://docs.google.com/document/d/1LJ6ajHYAmKdxSNDaD5kbriDod1t7RcmIwVJtevAeKFQ/edit?tab=t.0
Jira ticket: https://warthogs.atlassian.net/browse/WD-37088

Fixes #

## Screenshots

[if relevant, include a screenshot]
