### PR TITLE
fix: update Roadshow events to Canonical Days

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -522,5 +522,5 @@ events:
   path: /events
 
   children:
-    - title: Roadshow events
+    - title: Canonical Days
       path: /events/canonical-days


### PR DESCRIPTION
## Done
- Updated Roadhow events to Canonical Days on nav

## QA
- Open [demo](https://canonical-com-2617.demos.haus/events/canonical-days)
- Ensure nav says Canonical Days

## Issue / Card
https://warthogs.atlassian.net/browse/WD-37002
