### PR TITLE
fix: pass CSP nonce to lite-youtube so its shadow-DOM styles aren't blocked

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -64,6 +64,14 @@
                   content="https://assets.ubuntu.com/v1/c17ef7b4-careers-meta-image-resized.png" />
           {% endif %}
 
+          <!--
+            Pass the CSP nonce to lite-youtube so the <style> it injects into
+            its shadow DOM is allowed by our nonce-based style-src directive.
+            Must run before the deferred lite-youtube module upgrades the
+            element.
+          -->
+          <script nonce="{{ csp_nonce }}">window.liteYouTubeNonce = "{{ csp_nonce }}";</script>
+
           {% block extra_metatags %}{% endblock %}
 
           <link rel="apple-touch-icon"


### PR DESCRIPTION
## Done

- Set `window.liteYouTubeNonce` to the per-request CSP nonce in `base_index.html`, just before the `extra_metatags` block.
  - `lite-youtube@1.9.0` injects a `<style>` into its open shadow DOM at runtime. Our `style-src` directive is nonce-based with no `'unsafe-inline'`, so that injected style was blocked with a CSP violation and the player rendered unstyled.
  - The component reads a nonce from `window.liteYouTubeNonce` and stamps it onto the `<style>` it injects. Setting it before the deferred module upgrades the element lets the injected style satisfy our nonce-based `style-src`.
  - Centralised in the base template (a classic inline `<script>` in `<head>`), so it runs before the loader and covers every page that embeds a lite-youtube video without per-template edits.

Affected pages (all embed lite-youtube and extend `base_index.html`):
https://canonical.com/maas
https://canonical.com/microcloud
https://canonical.com/anbox-cloud
https://canonical.com/solutions/automotive
https://canonical.com/solutions/education
https://canonical.com/solutions/financial-services
https://canonical.com/solutions/infrastructure/virtualization-solutions
https://canonical.com/public-sector
https://canonical.com/company
https://canonical.com/data/spark
https://canonical.com/careers/company-culture/progression
https://canonical.com/careers/hiring-process
https://canonical.com/case-study/oediv
https://canonical.com/case-study/oediv-de
https://canonical.com/knowledge/ubuntu-and-linux/what-is-linux-kernel
https://canonical.com/knowledge/security-and-compliance/what-is-software-supply-chain-security
https://canonical.com/knowledge/security-and-compliance/open-source-security
https://canonical.com/knowledge/internet-of-things/what-is-iot-security
https://canonical.com/knowledge/internet-of-things/yocto-vs-ubuntu-core


## QA

- Open the [DEMO](https://canonical-com-2618.demos.haus/)
- Visit [/careers/hiring-process](https://canonical-com-2618.demos.haus/careers/hiring-process) (or any affected page below)
- https://canonical-com-2618.demos.haus/maas
https://canonical-com-2618.demos.haus/microcloud
https://canonical-com-2618.demos.haus/anbox-cloud
https://canonical-com-2618.demos.haus/solutions/automotive
https://canonical-com-2618.demos.haus/solutions/education
https://canonical-com-2618.demos.haus/solutions/financial-services
https://canonical-com-2618.demos.haus/solutions/infrastructure/virtualization-solutions
https://canonical-com-2618.demos.haus/public-sector
https://canonical-com-2618.demos.haus/company
https://canonical-com-2618.demos.haus/data/spark
https://canonical-com-2618.demos.haus/careers/company-culture/progression
https://canonical-com-2618.demos.haus/careers/hiring-process
https://canonical-com-2618.demos.haus/case-study/oediv
https://canonical-com-2618.demos.haus/case-study/oediv-de
https://canonical-com-2618.demos.haus/knowledge/ubuntu-and-linux/what-is-linux-kernel
https://canonical-com-2618.demos.haus/knowledge/security-and-compliance/what-is-software-supply-chain-security
https://canonical-com-2618.demos.haus/knowledge/security-and-compliance/open-source-security
https://canonical-com-2618.demos.haus/knowledge/internet-of-things/what-is-iot-security
https://canonical-com-2618.demos.haus/knowledge/internet-of-things/yocto-vs-ubuntu-core

  - Confirm the YouTube poster/player renders with correct styling
  - Open DevTools console and confirm there is **no** `style-src` CSP violation referencing the injected inline style
  - Inspect the `<lite-youtube>` element's shadow root and confirm its `<style>` carries a `nonce="…"` matching the page's `Content-Security-Policy` header nonce

## Issue / Card

Fixes [WD-37159](https://warthogs.atlassian.net/browse/WD-37159)

## Screenshots

[if relevant, include a before/after of the player styling]



[WD-37159]: https://warthogs.atlassian.net/browse/WD-37159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ