### PR TITLE
chore: add blog redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -2042,5 +2042,8 @@ blog/group/(?P<group>[^/]+)/?: /blog/archives?group={group}
 # Infrastructure modernization redirects
 blog/cloudify-your-data-centre: https://assets.ubuntu.com/v1/855af1ef-infrastructure_modernization_and_sovereignty_datasheet.pdf
 
+# Hiring blog redirect
+blog/how-we-hire-at-canonical: /careers/hiring-process
+
 
 robots.txt?: "/static/files/robots.txt"


### PR DESCRIPTION
## Done

- Added a redirect for "how-we-hire-at-canonical" blog

## QA

- Open the [DEMO](https://canonical-com-2652.demos.haus/blog/how-we-hire-at-canonical)
- Alternatively, checkout this pull request, run the project using `dotrun` and access page at localhost:8002/blog/how-we-hire-at-canonical
- Verify it gets redirected to https://canonical.com/careers/hiring-process

## Issue / Card

Fixes [WD-37262](https://warthogs.atlassian.net/browse/WD-37262)

[WD-37262]: https://warthogs.atlassian.net/browse/WD-37262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
