### PR TITLE
fix: remove phone_country from payload

### DIFF
--- a/static/js/prepare-form-inputs.js
+++ b/static/js/prepare-form-inputs.js
@@ -60,7 +60,7 @@ export function setupIntlTelInput(countryCode, phoneInput) {
   iti = intlTelInput(phoneInput, {
     utilsScript: "/static/js/modules/intl-tel-input/utils.js",
     separateDialCode: true,
-    hiddenInput: () => ({ phone: inputName, country: `${inputName}_country` }),
+    hiddenInput: () => ({ phone: inputName }),
     initialCountry: countryCode,
   });
 


### PR DESCRIPTION
## Done

- Remove unexpected `phone_country` form field that is causing failing form submissions

## QA

- Go to https://canonical-com-2675.demos.haus/anbox-cloud#get-in-touch or any other form
- Submit form, see that it goes through Marketo
  - If you do not have access to Marketo, please reach out and I will check for you

## Issue / Card

Fixes [WD-37247](https://warthogs.atlassian.net/browse/WD-37247)

## Screenshots

[if relevant, include a screenshot]


[WD-37247]: https://warthogs.atlassian.net/browse/WD-37247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ