### PR TITLE
update juju links to new domain

### DIFF
--- a/templates/juju/charmhub-community.html
+++ b/templates/juju/charmhub-community.html
@@ -390,7 +390,7 @@
     attrs={'id': 'get-started'}
     ) -%}
     {%- if slot == 'cta' -%}
-      <a href="https://documentation.ubuntu.com/juju" class="p-button--positive">Read Docs</a>
+      <a href="https://canonical.com/juju/docs/juju-cli/" class="p-button--positive">Read Docs</a>
       <a href="/contact-us" class="js-invoke-modal p-button" aria-controls="juju-modal">Contact us</a>
     {%- endif -%}
   {% endcall -%}

--- a/templates/juju/charms-architecture.html
+++ b/templates/juju/charms-architecture.html
@@ -262,7 +262,7 @@
           "type": "html",
           "content": '
           <p>
-            For more detailed information you can <a href="https://documentation.ubuntu.com/juju/3.6/reference/hook/">read our charm lifecycle documentation article&nbsp;&gt;</a>
+            For more detailed information you can <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/hook/">read our charm lifecycle documentation article&nbsp;&gt;</a>
           </p>
         '
         }

--- a/templates/juju/docs/index.html
+++ b/templates/juju/docs/index.html
@@ -7,18 +7,18 @@
     <nav class="p-tabs">
       <ul class="p-tabs__list">
         <li class="p-tabs__item">
-          <a href="https://documentation.ubuntu.com/juju" class="p-tabs__link">Juju Docs</a>
+          <a href="https://canonical.com/juju/docs/juju-cli/" class="p-tabs__link">Juju Docs</a>
         </li>
         <li class="p-tabs__item">
-          <a href="https://documentation.ubuntu.com/terraform-provider-juju"
+          <a href="https://canonical.com/juju/docs/terraform-provider-juju/"
              class="p-tabs__link">Terraform Provider Juju Docs</a>
         </li>
         <li class="p-tabs__item">
-          <a href="https://documentation.ubuntu.com/jubilant/"
+          <a href="https://canonical.com/juju/docs/jubilant"
              class="p-tabs__link">Jubilant Docs</a>
         </li>
         <li class="p-tabs__item">
-          <a href="https://documentation.ubuntu.com/jaas" class="p-tabs__link">JAAS
+          <a href="https://canonical.com/juju/docs/jaas" class="p-tabs__link">JAAS
           Docs</a>
         </li>
         <li class="p-tabs__item">
@@ -27,7 +27,7 @@
           Docs</a>
         </li>
         <li class="p-tabs__item">
-          <a href="https://ops.readthedocs.io" class="p-tabs__link">Ops Docs</a>
+          <a href="https://canonical.com/juju/docs/ops" class="p-tabs__link">Ops Docs</a>
         </li>
       </ul>
     </nav>
@@ -45,7 +45,7 @@
           and operators called 'charms'.
         </p>
         <div class="p-cta-block">
-          <a href="https://documentation.ubuntu.com/juju/3.6/tutorial/"
+          <a href="https://canonical.com/juju/docs/juju-cli/3.6/tutorial/"
              class="p-button--positive u-no-margin--bottom">Try the Juju tutorial</a>
         </div>
       </div>
@@ -79,7 +79,7 @@
     <div class="p-equal-height-row">
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
-          <a href="https://documentation.ubuntu.com/juju">
+          <a href="https://canonical.com/juju/docs/juju-cli/">
             <div class="p-image-container">
               {{ image(url="https://assets.ubuntu.com/v1/57c99e47-1%20What%20is%20Juju.svg",
                             alt="",
@@ -94,14 +94,14 @@
         </div>
         <div class="p-equal-height-row__item">
           <h4 class="u-font-weight-500">
-            <a href="https://documentation.ubuntu.com/juju">What is Juju?</a>
+            <a href="https://canonical.com/juju/docs/juju-cli/">What is Juju?</a>
           </h4>
         </div>
       </div>
 
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
-          <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-juju/#install-juju">
+          <a href="https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-juju/#install-juju">
             <div class="p-image-container">
               {{ image(url="https://assets.ubuntu.com/v1/8dc83bbc-2%20Install%20Juju.svg",
                             alt="",
@@ -116,7 +116,7 @@
         </div>
         <div class="p-equal-height-row__item">
           <h4 class="u-font-weight-500">
-            <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-juju/#install-juju">Install
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-juju/#install-juju">Install
             Juju</a>
           </h4>
         </div>
@@ -124,7 +124,7 @@
 
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
-          <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-clouds/#add-a-cloud">
+          <a href="https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-clouds/#add-a-cloud">
             <div class="p-image-container">
               {{ image(url="https://assets.ubuntu.com/v1/c212142f-3%20Connect%20a%20cloud.svg",
                             alt="",
@@ -140,46 +140,46 @@
         </div>
         <div class="p-equal-height-row__item">
           <h4 class="u-font-weight-500">
-            <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-clouds/#add-a-cloud">Connect
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-clouds/#add-a-cloud">Connect
             a cloud</a>
           </h4>
           <div>
             <p class="p-text--small">
-              <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-amazon-ec2-cloud-and-juju">Amazon
+              <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-amazon-ec2-cloud-and-juju">Amazon
                 EC2</a>&nbsp;&nbsp;&nbsp;
-                <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-amazon-eks-cloud-and-juju">Amazon
+                <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-amazon-eks-cloud-and-juju">Amazon
                   EKS</a>&nbsp;&nbsp;&nbsp;
-                  <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-canonical-ks-cloud-and-juju">Canonical K8s</a>
+                  <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-canonical-ks-cloud-and-juju">Canonical K8s</a>
                 </p>
                 <p class="p-text--small">
-                    <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-google-gce-cloud-and-juju">Google
+                    <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-google-gce-cloud-and-juju">Google
                       GCE</a>&nbsp;&nbsp;&nbsp;
-                      <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-google-gke-cloud-and-juju">Google
+                      <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-google-gke-cloud-and-juju">Google
                       GKE</a>&nbsp;&nbsp;&nbsp;
-                      <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju">LXD</a>&nbsp;&nbsp;&nbsp;
+                      <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju">LXD</a>&nbsp;&nbsp;&nbsp;
                     </p>
                     <p class="p-text--small">
-                      <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-maas-cloud-and-juju">MAAS</a>&nbsp;&nbsp;&nbsp;
-                      <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microk8s-cloud-and-juju/#cloud-kubernetes-microk8s">MicroK8s</a>&nbsp;&nbsp;&nbsp;
-                      <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-aks-cloud-and-juju/#cloud-kubernetes-aks">Microsoft
+                      <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-maas-cloud-and-juju">MAAS</a>&nbsp;&nbsp;&nbsp;
+                      <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-microk8s-cloud-and-juju/#cloud-kubernetes-microk8s">MicroK8s</a>&nbsp;&nbsp;&nbsp;
+                      <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-aks-cloud-and-juju/#cloud-kubernetes-aks">Microsoft
                         AKS</a>
                     </p>
                     <p class="p-text--small">
-                        <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-azure-cloud-and-juju">Microsoft
+                        <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-azure-cloud-and-juju">Microsoft
                           Azure</a>&nbsp;&nbsp;&nbsp;
-                          <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju">OpenStack</a>
+                          <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju">OpenStack</a>
                         </p>
                         <p class="p-text--small">
-                          <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-oracle-oci-cloud-and-juju">Oracle OCI</a>&nbsp;&nbsp;&nbsp;
-                          <a href="https://documentation.ubuntu.com/juju/latest/reference/cloud/list-of-supported-clouds/the-unmanaged-cloud-and-juju">Unmanaged</a>&nbsp;&nbsp;&nbsp;
-                          <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-vmware-vsphere-cloud-and-juju/#cloud-vsphere">VMware vSphere</a>
+                          <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-oracle-oci-cloud-and-juju">Oracle OCI</a>&nbsp;&nbsp;&nbsp;
+                          <a href="https://canonical.com/juju/docs/juju-cli/latest/reference/cloud/list-of-supported-clouds/the-unmanaged-cloud-and-juju">Unmanaged</a>&nbsp;&nbsp;&nbsp;
+                          <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-vmware-vsphere-cloud-and-juju/#cloud-vsphere">VMware vSphere</a>
                         </p>
                       </div>
                     </div>
                   </div>
                   <div class="p-equal-height-row__col">
                     <div class="p-equal-height-row__item">
-                      <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-applications/">
+                      <a href="https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-applications/">
                         <div class="p-image-container">
                           {{ image(url="https://assets.ubuntu.com/v1/944cab0d-4%20Use%20charmed%20applications.svg",
                                                     alt="",
@@ -196,20 +196,20 @@
                     </div>
                     <div class="p-equal-height-row__item">
                       <h4 class="u-font-weight-500">
-                        <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-applications/">Use
+                        <a href="https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-applications/">Use
                         charmed applications</a>
                       </h4>
                       <div>
                         <p class="p-text--small">
-                          <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-applications/#deploy-an-application">Deploy</a>&nbsp;&nbsp;&nbsp;
-                          <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-applications/#configure-an-application">Configure</a>&nbsp;&nbsp;&nbsp;
-                          <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-applications/#integrate-an-application-with-another-application">Integrate</a>&nbsp;&nbsp;&nbsp;
-                          <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-applications/#scale-an-application">Scale</a>
+                          <a href="https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-applications/#deploy-an-application">Deploy</a>&nbsp;&nbsp;&nbsp;
+                          <a href="https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-applications/#configure-an-application">Configure</a>&nbsp;&nbsp;&nbsp;
+                          <a href="https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-applications/#integrate-an-application-with-another-application">Integrate</a>&nbsp;&nbsp;&nbsp;
+                          <a href="https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-applications/#scale-an-application">Scale</a>
                         </p>
                         <p class="p-text--small">
                           <a href="https://charmhub.io/topics/canonical-observability-stack">Monitor</a>&nbsp;&nbsp;&nbsp;
-                          <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-applications/#upgrade-an-application">Upgrade</a>&nbsp;&nbsp;&nbsp;
-                          <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-applications/#remove-an-application">Remove</a>
+                          <a href="https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-applications/#upgrade-an-application">Upgrade</a>&nbsp;&nbsp;&nbsp;
+                          <a href="https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-applications/#remove-an-application">Remove</a>
                         </p>
                       </div>
                     </div>
@@ -333,7 +333,7 @@
                   <div class="p-equal-height-row__col">
                     <div class="p-equal-height-row__item">
                       <div class="p-image-container is-highlighted">
-                        <a href="https://documentation.ubuntu.com/juju">
+                        <a href="https://canonical.com/juju/docs/juju-cli/">
                           {{ image(url="https://assets.ubuntu.com/v1/630fc738-Interactively.svg",
                                                     alt="",
                                                     width="1132",
@@ -346,14 +346,14 @@
                     <p class="p-equal-height-row__item">with the Juju CLI</p>
                     <div class="p-equal-height-row__item">
                       <hr class="p-rule--muted" />
-                      <a href="https://documentation.ubuntu.com/juju" class="p-button">Read Juju docs</a>
+                      <a href="https://canonical.com/juju/docs/juju-cli/" class="p-button">Read Juju docs</a>
                     </div>
                   </div>
 
                   <div class="p-equal-height-row__col">
                     <div class="p-equal-height-row__item">
                       <div class="p-image-container is-highlighted">
-                        <a href="https://documentation.ubuntu.com/terraform-provider-juju">
+                        <a href="https://canonical.com/juju/docs/terraform-provider-juju/">
                           {{ image(url="https://assets.ubuntu.com/v1/96037188-Declaratively.svg",
                                                     alt="",
                                                     width="1132",
@@ -366,7 +366,7 @@
                     <p class="p-equal-height-row__item">with Terraform Juju</p>
                     <div class="p-equal-height-row__item">
                       <hr class="p-rule--muted" />
-                      <a href="https://documentation.ubuntu.com/terraform-provider-juju"
+                      <a href="https://canonical.com/juju/docs/terraform-provider-juju/"
                          class="p-button">
                         <span>Read Terraform Juju docs</span>
                       </a>
@@ -376,7 +376,7 @@
                   <div class="p-equal-height-row__col">
                     <div class="p-equal-height-row__item">
                       <div class="p-image-container is-highlighted">
-                        <a href="https://documentation.ubuntu.com/jubilant/">
+                        <a href="https://canonical.com/juju/docs/jubilant">
                           {{ image(url="https://assets.ubuntu.com/v1/d968780e-Programatically.svg",
                                                     alt="",
                                                     width="1132",
@@ -389,14 +389,14 @@
                     <p class="p-equal-height-row__item">with Jubilant</p>
                     <div class="p-equal-height-row__item">
                       <hr class="p-rule--muted" />
-                      <a href="https://documentation.ubuntu.com/jubilant/" class="p-button">Read Jubilant docs</a>
+                      <a href="https://canonical.com/juju/docs/jubilant" class="p-button">Read Jubilant docs</a>
                     </div>
                   </div>
 
                   <div class="p-equal-height-row__col">
                     <div class="p-equal-height-row__item">
                       <div class="p-image-container is-highlighted">
-                        <a href="https://documentation.ubuntu.com/jaas">
+                        <a href="https://canonical.com/juju/docs/jaas">
                           {{ image(url="https://assets.ubuntu.com/v1/d1ffe118-Enterprise%20style.svg",
                                                     alt="",
                                                     width="1132",
@@ -409,7 +409,7 @@
                     <p class="p-equal-height-row__item">with JAAS</p>
                     <div class="p-equal-height-row__item">
                       <hr class="p-rule--muted" />
-                      <a href="https://documentation.ubuntu.com/jaas" class="p-button">Read JAAS docs</a>
+                      <a href="https://canonical.com/juju/docs/jaas" class="p-button">Read JAAS docs</a>
                     </div>
                   </div>
                 </div>
@@ -558,7 +558,7 @@
                   <div class="p-equal-height-row__col u-grid-column-span-6">
                     <div class="p-equal-height-row__item">
                       <div class="p-image-container is-highlighted">
-                        <a href="https://ops.readthedocs.io">
+                        <a href="https://canonical.com/juju/docs/ops">
                           {{ image(url="https://assets.ubuntu.com/v1/4d41864a-any%20app.svg",
                                                     alt="",
                                                     width="1000",
@@ -575,7 +575,7 @@
                       <hr class="p-rule--muted" />
                     </div>
                     <div class="p-equal-height-row__item">
-                      <a href="https://ops.readthedocs.io" class="p-button">Read the Ops docs</a>
+                      <a href="https://canonical.com/juju/docs/ops" class="p-button">Read the Ops docs</a>
                     </div>
                   </div>
                 </div>
@@ -599,7 +599,7 @@
                       <h3 class="p-heading--5">Older juju versions</h3>
                     </div>
                     <div class="grid-col-4">
-                      <a href="https://documentation.ubuntu.com/juju/2.9/">Juju 2.9 docs</a>
+                      <a href="https://canonical.com/juju/docs/juju-cli/2.9/">Juju 2.9 docs</a>
                     </div>
                   </div>
                   <div class="grid-row">

--- a/templates/juju/index.html
+++ b/templates/juju/index.html
@@ -108,13 +108,13 @@
             {
               "content_html": "Get started with Juju",
               "attrs": {
-                "href": "https://documentation.ubuntu.com/juju/3.6/tutorial/"
+                "href": "https://canonical.com/juju/docs/juju-cli/3.6/tutorial/"
               }
             },
             {
               "content_html": "Create your first charm",
               "attrs": {
-                "href": "https://documentation.ubuntu.com/juju/3.6/howto/manage-charms/#build-a-charm"
+                "href": "https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-charms/#build-a-charm"
               }
             }
           ]
@@ -142,7 +142,7 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-amazon-ec2-cloud-and-juju/#cloud-ec2">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-amazon-ec2-cloud-and-juju/#cloud-ec2">
               {{ image(url="https://assets.ubuntu.com/v1/3477dfe5-aws-logo.png",
                             alt="AWS",
                             width="151",
@@ -154,7 +154,7 @@
             </a>
           </div>
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-azure-cloud-and-juju/">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-azure-cloud-and-juju/">
               {{ image(url="https://assets.ubuntu.com/v1/dad928bd-google-cloud-logomark.png",
                             alt="Google Cloud",
                             width="115",
@@ -166,7 +166,7 @@
             </a>
           </div>
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-google-gce-cloud-and-juju/">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-google-gce-cloud-and-juju/">
               {{ image(url="https://assets.ubuntu.com/v1/77661134-oracle-new-logo.png",
                             alt="Oracle OCI",
                             width="313",
@@ -178,7 +178,7 @@
             </a>
           </div>
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-oracle-oci-cloud-and-juju/">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-oracle-oci-cloud-and-juju/">
               {{ image(url="https://assets.ubuntu.com/v1/a8ada77e-microsoft-azure-2021.png",
                             alt="Microsoft Azure",
                             width="95",
@@ -202,7 +202,7 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microk8s-cloud-and-juju/">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-microk8s-cloud-and-juju/">
               {{ image(url="https://assets.ubuntu.com/v1/c262d56a-canonical_kubernetes.png",
                             alt="Canonical Kubernetes",
                             width="391",
@@ -224,7 +224,7 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-amazon-eks-cloud-and-juju/#cloud-kubernetes-eks">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-amazon-eks-cloud-and-juju/#cloud-kubernetes-eks">
               {{ image(url="https://assets.ubuntu.com/v1/efdcfaf0-amazon_eks_logo.png",
                             alt="Amazon EKS",
                             width="107",
@@ -236,7 +236,7 @@
             </a>
           </div>
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-google-gke-cloud-and-juju/">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-google-gke-cloud-and-juju/">
               {{ image(url="https://assets.ubuntu.com/v1/d70931ef-google_gke_logo.png",
                             alt="Google GKE",
                             width="112",
@@ -248,7 +248,7 @@
             </a>
           </div>
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-google-gce-cloud-and-juju/">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-google-gce-cloud-and-juju/">
               {{ image(url="https://assets.ubuntu.com/v1/ef369b31-google_gce_logo.png",
                             alt="Google GCE",
                             width="117",
@@ -260,7 +260,7 @@
             </a>
           </div>
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-aks-cloud-and-juju/">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-aks-cloud-and-juju/">
               {{ image(url="https://assets.ubuntu.com/v1/9a35bf2c-amazon_kubernetes_services.png",
                             alt="Amazon EKS",
                             width="113",
@@ -284,7 +284,7 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju/">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju/">
               {{ image(url="https://assets.ubuntu.com/v1/e38ea791-canonical_lxd.png",
                             alt="Canonical LXD",
                             width="191",
@@ -296,7 +296,7 @@
             </a>
           </div>
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju/">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju/">
               {{ image(url="https://assets.ubuntu.com/v1/502cc5bd-canonical_openstack.png",
                             alt="Canonical OpenStack",
                             width="379",
@@ -308,7 +308,7 @@
             </a>
           </div>
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-vmware-vsphere-cloud-and-juju/#cloud-vsphere">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-vmware-vsphere-cloud-and-juju/#cloud-vsphere">
               {{ image(url="https://assets.ubuntu.com/v1/d961ad84-vmware_logo.png",
                             alt="Canonical VMware",
                             width="323",
@@ -331,7 +331,7 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-maas-cloud-and-juju/">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-maas-cloud-and-juju/">
               {{ image(url="https://assets.ubuntu.com/v1/ad5f89f6-canonical_maas.png",
                             alt="Canonical MAAS",
                             width="249",
@@ -343,7 +343,7 @@
             </a>
           </div>
           <div class="p-logo-section__item">
-            <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-equinix-metal-cloud-and-juju/#cloud-equinix">
+            <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds/the-equinix-metal-cloud-and-juju/#cloud-equinix">
               {{ image(url="https://assets.ubuntu.com/v1/b294f8b7-equinix_logo.png",
                             alt="Equinix",
                             width="263",

--- a/templates/juju/juju-architecture.html
+++ b/templates/juju/juju-architecture.html
@@ -29,7 +29,7 @@
         "type": "html",
         "content": '
         <p>
-            The following diagram provides an overview of the high level architecture of a Juju deployment and it describes the key components of the system. You can find a more detailed explanation of all the components you find in this page in the <a href="https://documentation.ubuntu.com/juju/3.6/reference/">reference section</a> of the Juju documentation.
+            The following diagram provides an overview of the high level architecture of a Juju deployment and it describes the key components of the system. You can find a more detailed explanation of all the components you find in this page in the <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/">reference section</a> of the Juju documentation.
         </p>
         '
         }
@@ -141,7 +141,7 @@
                      aria-labelledby="cloud"
                      aria-hidden="true">
                     <p>
-                        To Juju, a <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/">cloud</a> (or backing cloud) is any entity that has an API that can provide compute, networking, and optionally storage resources in order for application units to be deployed on them. This includes public clouds such as Amazon Web Services, Google Compute Engine, Microsoft Azure and Kubernetes as well as private OpenStack-based clouds.
+                        To Juju, a <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/">cloud</a> (or backing cloud) is any entity that has an API that can provide compute, networking, and optionally storage resources in order for application units to be deployed on them. This includes public clouds such as Amazon Web Services, Google Compute Engine, Microsoft Azure and Kubernetes as well as private OpenStack-based clouds.
                     </p>
                     <p>
                         Juju works on most cloud environments. Juju can also make use of environments which are not clouds per se, by treating them as a cloud. MAAS and LXD fit into this last category. Because of this, in Juju a cloud is sometimes also called a <em>substrate</em>.
@@ -153,7 +153,7 @@
                      aria-labelledby="controller"
                      aria-hidden="true">
                     <p>
-                        A <a href="https://documentation.ubuntu.com/juju/3.6/reference/controller">controller</a> is the management node of any deployed cloud environment. A controller:
+                        A <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/controller">controller</a> is the management node of any deployed cloud environment. A controller:
                     </p>
                     <ul>
                         <li>Talks to the cli as well as all the other juju clients.</li>
@@ -163,7 +163,7 @@
                         <li>Facilitates the integration between charms in the same cloud or across clouds.</li>
                     </ul>
                     <p>
-                        Controllers must first be <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-controllers/#bootstrap-a-controller">bootstrapped</a>.
+                        Controllers must first be <a href="https://canonical.com/juju/docs/juju-cli/3.6/howto/manage-controllers/#bootstrap-a-controller">bootstrapped</a>.
                     </p>
                 </div>
                 <div tabindex="0"
@@ -172,7 +172,7 @@
                      aria-labelledby="model"
                      aria-hidden="true">
                     <p>
-                        A <a href="https://documentation.ubuntu.com/juju/3.6/reference/model">model</a> is a user-defined collection of applications that wraps all of the components required to support them, such as integrations, storage, and network spaces.
+                        A <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/model">model</a> is a user-defined collection of applications that wraps all of the components required to support them, such as integrations, storage, and network spaces.
                     </p>
                     <p>
                         A model is associated with a single controller. A controller can have an indefinite number of models and each model can have an indefinite number of applications. Models themselves can be shared amongst Juju users.
@@ -187,7 +187,7 @@
                      aria-labelledby="charm"
                      aria-hidden="true">
                     <p>
-                        A <a href="https://documentation.ubuntu.com/juju/3.6/reference/charm">charm</a> is an operator: business logic encapsulated in reusable software packages that automate every aspect of an application’s life.
+                        A <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/charm">charm</a> is an operator: business logic encapsulated in reusable software packages that automate every aspect of an application’s life.
                     </p>
                     <p>
                         Charms are publicly available on Charmhub and they are of two kinds, depending on the target deployment substrate:
@@ -207,7 +207,7 @@
                      aria-labelledby="application"
                      aria-hidden="true">
                     <p>
-                        An <a href="https://documentation.ubuntu.com/juju/3.6/reference/application">application</a> is a running abstraction of a charm in the Juju model. It is the sum of all units of a given charm with the same name.
+                        An <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/application">application</a> is a running abstraction of a charm in the Juju model. It is the sum of all units of a given charm with the same name.
                     </p>
                     <p>
                         Applications could correspond to a traditional software package but they could also include instructions to apply a certain set of changes to an existing workload.
@@ -221,7 +221,7 @@
                      aria-labelledby="integration"
                      aria-hidden="true">
                     <p>
-                        An <a href="https://documentation.ubuntu.com/juju/3.6/reference/relation">integration</a> is a connection between applications.
+                        An <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/relation">integration</a> is a connection between applications.
                     </p>
                     <p>
                         An integration between two applications is formed by connecting their endpoints. Endpoints can only be connected if they support the same interface and are of a compatible role (for example: requires to provides; provides to requires; peers to peers).
@@ -236,7 +236,7 @@
                      aria-labelledby="client"
                      aria-hidden="true">
                     <p>
-                        A Juju <a href="https://documentation.ubuntu.com/juju/3.6/reference/client/">client</a> is any software that implements the Juju client apiserver contract and it is able to talk to the controller.
+                        A Juju <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/client/">client</a> is any software that implements the Juju client apiserver contract and it is able to talk to the controller.
                     </p>
                     <p>This currently includes:</p>
                     <ul>
@@ -252,7 +252,7 @@
                      aria-labelledby="action"
                      aria-hidden="true">
                     <p>
-                        An <a href="https://documentation.ubuntu.com/juju/3.6/reference/action">action</a> is a custom operation for a specific charm or application delivered by a charm.
+                        An <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/action">action</a> is a custom operation for a specific charm or application delivered by a charm.
                     </p>
                     <p>
                         It contains a list of commands defined by a charm to allow a user to interact with the application and streamline the performance of a specific task.
@@ -267,7 +267,7 @@
                      aria-labelledby="units"
                      aria-hidden="true">
                     <p>
-                        In Juju a <a href="https://documentation.ubuntu.com/juju/3.6/reference/unit">unit</a> is a deployed charm, a single deployed entity of a deployed application.
+                        In Juju a <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/unit">unit</a> is a deployed charm, a single deployed entity of a deployed application.
                     </p>
                     <p>
                         The number of units can generally be controlled by the IT manager, however the charm might also specify certain requirements in order to enable certain features (e.g. high availability).
@@ -287,7 +287,7 @@
         "item": {
         "type": "text",
         "content": '
-        Juju and charms <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds">support multiple cloud backends</a>, giving you the choice to deploy your applications to the most cost effective, resource-rich or commercially suitable clouds, and then connect them in a way that suits your application model.
+        Juju and charms <a href="https://canonical.com/juju/docs/juju-cli/3.6/reference/cloud/list-of-supported-clouds">support multiple cloud backends</a>, giving you the choice to deploy your applications to the most cost effective, resource-rich or commercially suitable clouds, and then connect them in a way that suits your application model.
         '
         }
         },

--- a/templates/juju/partials/_contact-us.html
+++ b/templates/juju/partials/_contact-us.html
@@ -6,7 +6,7 @@
   layout='25-75'
   ) -%}
   {%- if slot == 'cta' -%}
-    <a href="https://documentation.ubuntu.com/juju/3.6/#"
+    <a href="https://canonical.com/juju/docs/juju-cli/3.6/#"
        class="p-button--positive">Read Docs</a>
     <button class="p-button js-invoke-modal" aria-controls="juju-modal">Contact us</button>
   {%- endif -%}


### PR DESCRIPTION
## Done

Updated Juju, Terraform Provider for Juju, JAAS, Jubilant, and Ops documentation links to their new location on canonical.com.

