### PR TITLE
fix: use valid sitemap links

### DIFF
--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -13,13 +13,13 @@
     <loc>https://canonical.com/blog/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/juju-cli/page/doc-sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/juju-cli/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/terraform-provider-juju/page/doc-sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/terraform-provider-juju/latest/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/jaas/page/doc-sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/jaas/v3/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
     <loc>https://canonical.com/knowledge/sitemap.xml</loc>
@@ -31,7 +31,7 @@
     <loc>https://canonical.com/dqlite/docs/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/maas/docs/sitemap.xml</loc>
+    <loc>https://canonical.com/maas/docs/latest/sitemap.xml</loc>
   </sitemap>
   <sitemap>
     <loc>https://canonical.com/juju/docs/wordpress-k8s-charm/latest/sitemap.xml</loc>


### PR DESCRIPTION
## Done

- Fixes sitemap links that were either 404 or 302

## QA

- We don't have the RTD haproxy setup on demo, but here is what the link will be once merged. Check they are all valid xml
- https://canonical.com/juju/docs/juju-cli/latest/doc-sitemap.xml
- https://canonical.com/juju/docs/terraform-provider-juju/latest/sitemap.xml
- https://canonical.com/juju/docs/jaas/v3/doc-sitemap.xml
- https://canonical.com/maas/docs/latest/sitemap.xml
- https://canonical.com/sitemap.xml


