### PR TITLE
fix: nonce lite-youtube bootstrap script so injected <style> passes CSP

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -70,7 +70,7 @@
             Must run before the deferred lite-youtube module upgrades the
             element.
           -->
-          <script nonce="{{ csp_nonce }}">window.liteYouTubeNonce = "{{ csp_nonce }}";</script>
+          <script nonce="{{ csp_nonce }}">window.liteYouTubeNonce = {{ csp_nonce | tojson }};</script>
 
           {% block extra_metatags %}{% endblock %}
 

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -70,7 +70,7 @@
             Must run before the deferred lite-youtube module upgrades the
             element.
           -->
-          <script>window.liteYouTubeNonce = "{{ csp_nonce }}";</script>
+          <script nonce="{{ csp_nonce }}">window.liteYouTubeNonce = "{{ csp_nonce }}";</script>
 
           {% block extra_metatags %}{% endblock %}
 


### PR DESCRIPTION
## Done

- Added `nonce="{{ csp_nonce }}"` to the inline `<script>` that sets `window.liteYouTubeNonce` in `base_index.html`. Without it, the script was blocked by our nonce-based `script-src` CSP, so `window.liteYouTubeNonce` was never set and lite-youtube injected an unnonced `<style>` into its shadow DOM — triggering a `style-src` CSP violation on every page using `lite_video`.

## QA

- Open the [DEMO](https://canonical-com-2696.demos.haus/microcloud)
- Visit a page that embeds a video via the `lite_video` macro (e.g. https://canonical-com-2696.demos.haus/maas)
- Open the browser console and confirm there is **no** CSP error about inline styles violating the `style-src` directive
- Confirm the YouTube embed still renders and plays correctly

Compare with some links on production
Affected pages (all embed lite-youtube and extend `base_index.html`):
https://canonical.com/maas
https://canonical.com/microcloud
https://canonical.com/anbox-cloud

## Issue / Card

Fixes [WD-37396](https://warthogs.atlassian.net/browse/WD-37396)
https://warthogs.atlassian.net/browse/WD-37396

## Screenshots

[if relevant, include a screenshot]



[WD-37396]: https://warthogs.atlassian.net/browse/WD-37396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ