### PR TITLE
feat(sitemap): add Multipass sitemap entries

### DIFF
--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -90,4 +90,10 @@
   <sitemap>
     <loc>https://canonical.com/juju/docs/wireguard-gateway-charm/latest/sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://canonical.com/multipass/docs/stable/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://canonical.com/multipass/docs/latest/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>

--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -91,9 +91,9 @@
     <loc>https://canonical.com/juju/docs/wireguard-gateway-charm/latest/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/multipass/docs/stable/sitemap.xml</loc>
+    <loc>https://canonical.com/multipass/docs/stable/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/multipass/docs/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/multipass/docs/latest/doc-sitemap.xml</loc>
   </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

Add Multipass docs sitemaps

## QA

- Open the [DEMO](__DEMO_URL__/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes 

https://warthogs.atlassian.net/browse/MULTI-2718
