### PR TITLE
feat: adopt canonicalwebteam.discourse response cache and rate-limit handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.blog==6.8.4
 canonicalwebteam.http==1.0.4
 canonicalwebteam.image-template==1.9.0
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.discourse==7.1.1
+canonicalwebteam.discourse==7.6.0
 canonicalwebteam.search==2.1.2
 canonicalwebteam.form-generator==2.2.0
 canonicalwebteam.directory-parser==1.2.11

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import patch
+
+from canonicalwebteam.discourse import RateLimitedError
+
+from webapp import app as app_module
+from webapp.app import app
+
+
+class TestRateLimitedErrorHandling(unittest.TestCase):
+    """
+    RateLimitedError from the discourse package must surface as a 503
+    with Retry-After, never a 500, and the body format must match what
+    the client accepts.
+    """
+
+    def setUp(self):
+        app.testing = True
+        self.client = app.test_client()
+        patcher = patch.object(
+            app_module.engage_pages,
+            "get_index",
+            side_effect=RateLimitedError(retry_after=77),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_rate_limited_page_returns_styled_503(self):
+        response = self.client.get("/case-study")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.headers.get("Retry-After"), "77")
+        self.assertTrue(response.content_type.startswith("text/html"))
+
+    def test_rate_limited_json_accept_header_returns_json_503(self):
+        response = self.client.get(
+            "/case-study", headers={"Accept": "application/json"}
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.headers.get("Retry-After"), "77")
+        self.assertTrue(response.content_type.startswith("application/json"))
+
+    def test_retry_after_defaults_to_60_without_hint(self):
+        with patch.object(
+            app_module.engage_pages,
+            "get_index",
+            side_effect=RateLimitedError(retry_after=None),
+        ):
+            response = self.client.get("/case-study")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.headers.get("Retry-After"), "60")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -33,6 +33,8 @@ from canonicalwebteam.discourse import (
     DocParser,
     Docs,
     EngagePages,
+    RateLimitedError,
+    ResponseCache,
     TutorialParser,
     Tutorials,
 )
@@ -149,6 +151,7 @@ charmhub_discourse_api = DiscourseAPI(
     api_key=CHARMHUB_DISCOURSE_API_KEY,
     api_username=CHARMHUB_DISCOURSE_API_USERNAME,
     get_topics_query_id=2,
+    cache=ResponseCache(ttl=600),
 )
 search_session = get_requests_session()
 discourse_session = get_requests_session()
@@ -1225,6 +1228,7 @@ dqlite_docs = Docs(
         api=DiscourseAPI(
             base_url="https://discourse.dqlite.io/",
             session=discourse_session,
+            cache=ResponseCache(ttl=600),
         ),
         index_topic_id=34,
         url_prefix="/dqlite/docs",
@@ -1258,6 +1262,7 @@ maas_docs = Docs(
             base_url="https://discourse.maas.io/",
             session=discourse_session,
             get_topics_query_id=2,
+            cache=ResponseCache(ttl=600),
         ),
         index_topic_id=6662,
         url_prefix=maas_url_prefix,
@@ -1342,6 +1347,7 @@ tutorials_discourse = Tutorials(
             api_key=MAAS_DISCOURSE_API_KEY,
             api_username=MAAS_DISCOURSE_API_USERNAME,
             get_topics_query_id=2,
+            cache=ResponseCache(ttl=600),
         ),
         index_topic_id=1289,
         url_prefix="/maas/tutorials",
@@ -1440,6 +1446,38 @@ def handle_maas_goget():
         path == "/maas" or path.startswith("/maas/")
     ) and flask.request.query_string == b"go-get=1":
         return flask.render_template("maas/gomod.html"), 200
+
+
+@app.errorhandler(503)
+def service_unavailable(error):
+    """
+    Rendered when an upstream API (e.g. Discourse) is rate-limiting us
+    and there is no cached response to fall back on. Retry-After tells
+    well-behaved clients and crawlers when to come back.
+    """
+    accepts = flask.request.accept_mimetypes
+    wants_json = flask.request.path.endswith(".json") or (
+        accepts.accept_json and not accepts.accept_html
+    )
+    if wants_json:
+        response = flask.make_response(
+            flask.jsonify(error="Service temporarily unavailable"), 503
+        )
+    else:
+        response = flask.make_response(flask.render_template("500.html"), 503)
+    retry_after = getattr(error, "retry_after", None)
+    response.headers["Retry-After"] = str(retry_after or 60)
+    return response
+
+
+@app.errorhandler(RateLimitedError)
+def discourse_rate_limited(error):
+    """
+    The discourse package raises RateLimitedError when Discourse
+    returns 429 and no cached response is available; serve the same
+    503 as any other upstream outage.
+    """
+    return service_unavailable(error)
 
 
 @app.errorhandler(502)
@@ -1585,6 +1623,7 @@ engage_pages_discourse_api = DiscourseAPI(
     get_topics_query_id=14,
     api_key=DISCOURSE_API_KEY,
     api_username=DISCOURSE_API_USERNAME,
+    cache=ResponseCache(ttl=300),
 )
 engage_pages = EngagePages(
     api=engage_pages_discourse_api,
@@ -1614,6 +1653,7 @@ discourse_api = DiscourseAPI(
     session=search_session,
     api_key=DISCOURSE_API_KEY,
     api_username=DISCOURSE_API_USERNAME,
+    cache=ResponseCache(ttl=600),
 )
 
 
@@ -1649,6 +1689,7 @@ microk8s_discourse_api = Docs(
         api=DiscourseAPI(
             base_url="https://discuss.kubernetes.io/",
             session=get_requests_session(),
+            cache=ResponseCache(ttl=600),
         ),
         index_topic_id=11243,
         url_prefix=microk8s_url_prefix,


### PR DESCRIPTION
## Done

- Bump `canonicalwebteam.discourse` 7.1.1 → 7.6.0 and pass a `ResponseCache` to all 7 `DiscourseAPI` instances (charmhub, dqlite, MAAS docs + tutorials, engage pages, Mir docs, MicroK8s docs), so repeat renders serve from cache instead of calling Discourse on every request
- Handle the package's new `RateLimitedError`: Discourse rate limits now return a 503 with `Retry-After` (JSON body for JSON/API clients) instead of a 500

## Why

Crawler traffic recently exhausted the Discourse admin API quota (60 req/min, shared globally per instance) and 500'd Discourse-backed pages on ubuntu.com. **canonical.com's engage pages and Mir docs use the same API key against discourse.ubuntu.com**, uncached — so this site both suffers from and contributes to that shared-quota exhaustion. The caching + circuit breaker now live in the package (canonical/canonicalwebteam.discourse#227); this adopts them. Companion PR: canonical/ubuntu.com#16551.

## QA

- Check `/case-study`, `/events`, `/mir/docs`, `/maas/docs`, `/dqlite/docs`, `/microk8s/docs` load normally
- Repeat visits within the TTL (5–10 min) should not re-hit Discourse
- During a Discourse rate-limit, uncached pages return 503 + `Retry-After` rather than 500
- `pytest tests/test_app.py` passes; `yarn lint-python` clean
