### PR TITLE
feat: increase default Cache-Control max-age to 1 hour

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,5 @@
 import unittest
-from webapp.app import is_remote
+from webapp.app import app, is_remote
 
 
 class TestIsRemote(unittest.TestCase):
@@ -8,3 +8,54 @@ class TestIsRemote(unittest.TestCase):
         self.assertTrue(is_remote({"location": {"name": None}}))
         self.assertTrue(is_remote({"location": {"name": "Home Based - EMEA"}}))
         self.assertFalse(is_remote({"location": {"name": "Paris, France"}}))
+
+
+class TestCacheControlHeaders(unittest.TestCase):
+    def setUp(self):
+        app.testing = True
+        self.client = app.test_client()
+
+    def test_html_page_defaults_to_one_hour_max_age(self):
+        """
+        Pages that don't set their own Cache-Control should get
+        the app-wide 1 hour default, not flask-base's 60 seconds
+        """
+        response = self.client.get("/legal")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.cache_control.max_age, 3600)
+
+    def test_explicit_max_age_is_preserved(self):
+        """
+        Views that set their own Cache-Control max-age should not
+        be overridden by the 1 hour default
+        """
+        response = self.client.get("/sitemap.xml")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.cache_control.public)
+        self.assertEqual(response.cache_control.max_age, 43200)
+
+    def test_status_endpoints_are_not_cached(self):
+        response = self.client.get("/_status/check")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.cache_control.no_store)
+        self.assertIsNone(response.cache_control.max_age)
+
+    def test_html_responses_vary_by_cookie(self):
+        """
+        HTML bodies are rewritten based on the "utms" cookie
+        (append_utms_cookie_to_ubuntu_links), so shared caches must
+        key HTML responses on the Cookie header
+        """
+        response = self.client.get("/legal")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Cookie", response.vary)
+
+    def test_non_html_responses_do_not_vary_by_cookie(self):
+        response = self.client.get("/sitemap.xml")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Cookie", response.vary)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -342,7 +342,7 @@ def index_sitemap():
     xml_sitemap = flask.render_template("sitemap-index.xml")
     response = flask.make_response(xml_sitemap)
     response.headers["Content-Type"] = "application/xml"
-    response.headers["-Control"] = "public, max-age=43200"
+    response.headers["Cache-Control"] = "public, max-age=43200"
 
     return response
 
@@ -1550,6 +1550,26 @@ def no_cache(response):
         response.cache_control.max_age = None
         response.cache_control.no_store = True
         response.cache_control.public = False
+
+    return response
+
+
+@app.after_request
+def default_cache_control(response):
+    """
+    Cache pages for 1 hour by default, instead of flask-base's 60s.
+    Views that set their own max-age or mark the response
+    no-store/no-cache/private are left untouched.
+    """
+    if (
+        response.status_code == 200
+        and not flask.request.path.startswith("/_status")
+        and not response.cache_control.no_store
+        and not response.cache_control.no_cache
+        and not response.cache_control.private
+        and type(response.cache_control.max_age) is not int
+    ):
+        response.cache_control.max_age = 3600
 
     return response
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -317,6 +317,11 @@ def append_utms_cookie_to_ubuntu_links(response):
     Append utms cookie parameter to all ubuntu.com links in HTML responses
     """
     if response.mimetype == "text/html" and response.is_sequence:
+        # The body of HTML responses varies by the "utms" cookie, so
+        # shared caches (e.g. content-cache) must not serve a variant
+        # built for one cookie value to other users
+        response.vary.add("Cookie")
+
         cookie_value = flask.request.cookies.get("utms")
 
         if cookie_value:


### PR DESCRIPTION
## Done

- Set the default Cache-Control: max-age to 3600s (was flask-base's 60s default), so content-cache can cache pages for 1 hour
- Registered as an after_request hook that runs before flask-base's, which then skips its 60s default; stale-while-revalidate/stale-if-error are still applied
- Views that set their own max-age (e.g. /takeovers.json) or opt out via no-store/no-cache/private are untouched; /_status stays no-store
- Added tests for the 1h default and for explicit max-age being preserved

## QA

- Open the [DEMO](https://canonical-com-2729.demos.haus/)
- Run the site and check 
```bash
  curl -sI https://canonical-com-2729.demos.haus/ | grep -i cache-control
```
- returns `max-age=3600, stale-while-revalidate=86400, stale-if-error=300`
- Check /_status/check still returns no-store

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]

