### PR TITLE
ci: cleanup bauer generated branch

### DIFF
--- a/.github/workflows/delete-bauer-generated-branch.yaml
+++ b/.github/workflows/delete-bauer-generated-branch.yaml
@@ -1,0 +1,35 @@
+name: Delete generated output branch after merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup-output-branch:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete Bauer parse-output branch after merge
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Detect the Bauer parse-output branch referenced in the PR body,
+          # e.g. "bauer/doc-suggestions-<id>".
+          BAUER_BRANCH=$(printf '%s' "$PR_BODY" \
+            | grep -oE 'bauer/doc-suggestions-[A-Za-z0-9._-]+' \
+            | head -n 1)
+
+          if [ -z "$BAUER_BRANCH" ]; then
+            echo "No Bauer parse-output branch found in PR body, nothing to do."
+            exit 0
+          fi
+
+          echo "Deleting branch: $BAUER_BRANCH"
+          gh api \
+            -X DELETE \
+            "repos/${{ github.repository }}/git/refs/heads/$BAUER_BRANCH"


### PR DESCRIPTION
## Done

- Parse-output branch: bauer/doc-suggestions-1783584310

## QA

- See that the referred branch is deleted in [`cleanup-output-branch`](https://github.com/canonical/canonical.com/actions/runs/29004146711/job/86071572744?pr=2736) action
- See that `bauer/doc-suggestions-1783584310` branch is no longer present in https://github.com/canonical/canonical.com/branches/all?query=bauer%2Fdoc-suggestions

## Issue / Card

Fixes [WD-37105](https://warthogs.atlassian.net/browse/WD-37105)

## Screenshots

[if relevant, include a screenshot]


[WD-37105]: https://warthogs.atlassian.net/browse/WD-37105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
