### PR TITLE
Update whitepaper link on Mir page

### DIFF
--- a/templates/mir/index.html
+++ b/templates/mir/index.html
@@ -100,7 +100,7 @@
         <p>
           Mir is a system-level component that can be used to unlock next-generation user experiences. It runs on a range of Linux powered devices including traditional desktops, IoT and embedded products. Mir implements the Wayland protocol, which is a modern replacement for the X window server system. It allows device makers and desktop users to have a well-defined, efficient, flexible, and secure platform for their graphical environment.
         </p>
-        <a href="https://ubuntu.com/blog/build-smart-display-devices-with-mir-fast-to-production-secure-open-source"
+        <a href="https://assets.ubuntu.com/v1/b26b4bb7-building_custom_wayland_compositors_made_simple_with_mir.pdf"
            class="p-button--positive">Download the whitepaper</a>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Update the "Download the whitepaper" button on `/mir` to point to the new asset
- Replace `ubuntu.com/blog/build-smart-display-devices-with-mir-fast-to-production-secure-open-source` with `assets.ubuntu.com/v1/b26b4bb7-building_custom_wayland_compositors_made_simple_with_mir.pdf`

## QA

- Open the [DEMO](https://canonical-com-2742.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Visit `/mir`, click "Download the whitepaper", and confirm it opens the new PDF

## Issue / Card

Copy doc: https://docs.google.com/document/d/1wqmWPx4TJ_oJoFt4gBOg4trYMIAsugMYtHGXzYJx8kc/edit?tab=t.0
Jira ticket: https://warthogs.atlassian.net/browse/WD-37734

Fixes [WD-37734](https://warthogs.atlassian.net/browse/WD-37734)

## Screenshots

[if relevant, include a screenshot]


[WD-37734]: https://warthogs.atlassian.net/browse/WD-37734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
