### PR TITLE
fix: re-introduce 'unsafe-inline' to style-src

### DIFF
--- a/templates/careers/_base-department.html
+++ b/templates/careers/_base-department.html
@@ -207,7 +207,3 @@
   {% include custom_blog_section %}
 {% endif %}
 
-<script async defer
-        src="https://cdn.jsdelivr.net/npm/github-buttons@2.32.0/dist/buttons.min.js"
-        integrity="sha384-ZhcuGDV+Yp73dqAwwf9TcmQydIjkGkv+3oJxfQFaadDitRkt+COogTczHw8CTFgH"
-        crossorigin="anonymous" nonce="{{ csp_nonce }}"></script>

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -204,6 +204,7 @@ CSP = {
         "'self'",
         "cdn.jsdelivr.net",
         "www.tfaforms.com",
+        "'unsafe-inline'",
     ],
     "media-src": [
         "'self'",
@@ -268,7 +269,7 @@ def _build_csp_report_only(csp):
 
 CSP_REPORT_ONLY = _build_csp_report_only(CSP)
 
-NONCED_DIRECTIVES = ("script-src", "script-src-elem", "style-src")
+NONCED_DIRECTIVES = ("script-src", "script-src-elem")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Done

- re-introduce 'unsafe-inline' to style-src to get rid of `Applying inline style violates the following Content Security Policy directive 'style-src` errors. We set `X-Frame-Options: SAMEORIGIN` at flask-base level so the security threat is minimal

## QA

- Open the [DEMO](https://canonical-com-2746.demos.haus/juju)
- Open console, see there are no CSP for loading scripts (compared to [https//canonical.com/juju](https//canonical.com/juju))
## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37737

