### PR TITLE
Careers results: Use static department list

### DIFF
--- a/templates/careers/results.html
+++ b/templates/careers/results.html
@@ -81,8 +81,7 @@
       </div>
   {% else %}
     <div class="row">
-        <caption>
-            <div class="p-strip">
+        <div class="p-strip">
             <div class="row">
                 <div class="u-align--right col-2 col-medium-1 col-small-1">
                 <img src="https://assets.ubuntu.com/v1/263e7c5d-iot_orange.svg" alt="" />
@@ -93,8 +92,7 @@
                 <a class="p-button--positive" href="/careers/career-explorer">Retake choices again?</a>
                 </div>
             </div>
-            </div>
-        </caption>
+        </div>
     </div>
   {% endif %}
 {% endblock %}

--- a/templates/careers/results.html
+++ b/templates/careers/results.html
@@ -22,58 +22,39 @@
     <div class="row">
       <h2 class="p-muted-heading">Top roles for you</h2>
     </div>
-  {% endif %}
-  <div class="row u-sv3">
-    {% for vacancy in vacancies %}
-      {% if loop.index < 5 %}
-        {% if loop.index == 3 %}<div class="row">{% endif %}
-          <div class="p-card--highlighted col-4"
-               data-office="{{ vacancy.office }}"
-               data-employment="{{ vacancy.employment }}"
-               data-date="{{ vacancy.date }}"
-               data-location="{{ vacancy.location }}"
-               data-management="{{ vacancy.management }}"
-               data-sector="{{ vacancy.departments | map(attribute='name') | join(', ') }}">
+    <div class="row">
+      {% for vacancy in vacancies[:4] %}
+        <div class="p-card--highlighted col-4"
+              data-office="{{ vacancy.office }}"
+              data-employment="{{ vacancy.employment }}"
+              data-date="{{ vacancy.date }}"
+              data-location="{{ vacancy.location }}"
+              data-management="{{ vacancy.management }}"
+              data-sector="{{ vacancy.departments | map(attribute='name') | join(', ') }}"
+          >
             <h3 class="p-card__title u-no-padding--top">
-              <a class="p-link--soft"
-                 href="/careers/{{ vacancy.id }}/{{ vacancy.slug }}">{{ vacancy.title }}&nbsp;&rsaquo;</a>
+                <a class="p-link--soft"
+                    href="/careers/{{ vacancy.id }}/{{ vacancy.slug }}">{{ vacancy.title }}&nbsp;&rsaquo;
+                </a>
             </h3>
             {% if vacancy.description %}<p clss="p-cart__content">{{ vacancy.description }}</p>{% endif %}
             <p class="u-no-margin--bottom">
-              <small {% if checkbox %}class="u-padding-left-2rem"{% endif %}>{{ vacancy.location }}</small>
+                <small {% if checkbox %}class="u-padding-left-2rem"{% endif %}>{{ vacancy.location }}</small>
             </p>
-          </div>
-          {% if loop.index == 2 %}</div>{% endif %}
-      {% endif %}
-    {% endfor %}
-    <div class="col-8">
-      <div class="row">
+        </div>
+      {% endfor %}
+    </div>
+    <div class="row">
         <div class="col-8">
-          {% if not vacancies %}
-            <caption>
-              <div class="p-strip">
-                <div class="row">
-                  <div class="u-align--right col-2 col-medium-1 col-small-1">
-                    <img src="https://assets.ubuntu.com/v1/263e7c5d-iot_orange.svg" alt="" />
-                  </div>
-                  <div class="u-align--left col-6 col-medium-3 col-small-3">
-                    <p class="p-heading--4 u-no-margin--bottom">We couldn't find matching results</p>
-                    <p>There are no roles matching your selection.</p>
-                    <a class="p-button--positive" href="/careers/career-explorer">Retake choices again?</a>
-                  </div>
-                </div>
-              </div>
-            </caption>
-          {% else %}
             <div class="js-filter-jobs-container">
               <h2>More matches for you to consider</h2>
-              {% for department in vacancies_by_department.values() %}
+              {% for department in departments %}
                 <div class="u-sv3">
                   <h3>
                     <a class="p-link--soft" href="/careers/{{ department.slug }}">{{ department.name }}</a>
                   </h3>
                   <ul class="p-list is-split u-no-margin--bottom">
-                    {% for vacancy in department.vacancies %}
+                    {% for vacancy in vacancies_by_department[department.slug] %}
                       {% if loop.index < 10 %}
                         <li class="p-list u-sv1"
                             data-office="{{ vacancy.office }}"
@@ -88,15 +69,32 @@
                     {% endfor %}
                   </ul>
                   <p>
-                    <a href="/careers/{{ department.slug }}">See all roles in {{ department.name }}&nbsp;&rsaquo;</a>
+                    <a href="/careers/{{ department.slug }}">
+                        See all roles in {{ department.name }}&nbsp;&rsaquo;
+                    </a>
                   </p>
                   <hr class="p-rule--muted" />
                 </div>
               {% endfor %}
             </div>
-          {% endif %}
         </div>
       </div>
+  {% else %}
+    <div class="row">
+        <caption>
+            <div class="p-strip">
+            <div class="row">
+                <div class="u-align--right col-2 col-medium-1 col-small-1">
+                <img src="https://assets.ubuntu.com/v1/263e7c5d-iot_orange.svg" alt="" />
+                </div>
+                <div class="u-align--left col-6 col-medium-3 col-small-3">
+                <p class="p-heading--4 u-no-margin--bottom">We couldn't find matching results</p>
+                <p>There are no roles matching your selection.</p>
+                <a class="p-button--positive" href="/careers/career-explorer">Retake choices again?</a>
+                </div>
+            </div>
+            </div>
+        </caption>
     </div>
-  </div>
+  {% endif %}
 {% endblock %}

--- a/templates/careers/results.html
+++ b/templates/careers/results.html
@@ -37,7 +37,7 @@
                     href="/careers/{{ vacancy.id }}/{{ vacancy.slug }}">{{ vacancy.title }}&nbsp;&rsaquo;
                 </a>
             </h3>
-            {% if vacancy.description %}<p clss="p-cart__content">{{ vacancy.description }}</p>{% endif %}
+            {% if vacancy.description %}<p class="p-card__content">{{ vacancy.description }}</p>{% endif %}
             <p class="u-no-margin--bottom">
                 <small {% if checkbox %}class="u-padding-left-2rem"{% endif %}>{{ vacancy.location }}</small>
             </p>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -69,7 +69,6 @@ from webapp.canonical_cla.views import (
 )
 from webapp.careers import (
     DEPARTMENT_LIST,
-    _group_by_department,
     _get_sorted_departments,
     _get_all_departments,
 )

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -67,6 +67,12 @@ from webapp.canonical_cla.views import (
     canonical_cla_api_launchpad_logout,
     canonical_cla_api_proxy,
 )
+from webapp.careers import (
+    DEPARTMENT_LIST,
+    _group_by_department,
+    _get_sorted_departments,
+    _get_all_departments,
+)
 from webapp.greenhouse import Greenhouse, Harvest
 from webapp.handlers import init_handlers
 from webapp.navigation import (
@@ -160,128 +166,6 @@ app.register_blueprint(application_bp, url_prefix="/careers/application")
 form_template_path = "shared/forms/form-template.html"
 form_loader = FormGenerator(app, form_template_path)
 form_loader.load_forms()
-
-
-def _group_by_department(harvest, vacancies):
-    """
-    Return a dictionary of departments by slug,
-    where each department will have a new
-    "vacancies" property of all the vacancies in
-    that department
-    """
-
-    all_departments = harvest.get_departments()
-    vacancies_by_department = {}
-
-    departments_by_slug = {}
-
-    for department in all_departments:
-        departments_by_slug[department.slug] = department
-
-    for vacancy in vacancies:
-        for department in vacancy.departments:
-            slug = department.slug
-
-            if slug not in vacancies_by_department:
-                vacancies_by_department[slug] = departments_by_slug[slug]
-                vacancies_by_department[slug].vacancies = [vacancy]
-            else:
-                vacancies_by_department[slug].vacancies.append(vacancy)
-
-    # Add departments with no vacancies
-    for dept in departments_by_slug:
-        slug = departments_by_slug[dept].slug
-        if slug not in vacancies_by_department:
-            vacancies_by_department[slug] = departments_by_slug[slug]
-            vacancies_by_department[slug].vacancies = {}
-
-    return vacancies_by_department
-
-
-def _get_sorted_departments(greenhouse, harvest):
-    departments = _group_by_department(harvest, greenhouse.get_vacancies())
-
-    sort_order = [
-        "engineering",
-        "support-engineering",
-        "marketing",
-        "web-and-design",
-        "project-management",
-        "commercial-operations",
-        "product",
-        "sales",
-        "finance",
-        "people",
-        "administration",
-        "legal",
-        "alliances-and-channels",
-    ]
-
-    sorted = {slug: departments[slug] for slug in sort_order}
-    remaining_slugs = set(departments.keys()).difference(sort_order)
-    remaining = {slug: departments[slug] for slug in remaining_slugs}
-    sorted_departments = {**sorted, **remaining}
-
-    return sorted_departments
-
-
-def _get_all_departments(greenhouse, harvest) -> tuple:
-    """
-    Refactor for careers search section
-    """
-    all_departments = (
-        _group_by_department(harvest, greenhouse.get_vacancies()),
-    )
-
-    dept_list = [
-        {"slug": "engineering", "icon": "84886ac6-Engineering.svg"},
-        {
-            "slug": "support-engineering",
-            "icon": "df08c7f2-Support Engineering.svg",
-        },
-        {"slug": "marketing", "icon": "27b93be4-Marketing.svg"},
-        {"slug": "web-and-design", "icon": "b200e162-design.svg"},
-        {
-            "slug": "project-management",
-            "icon": "0f64ee5c-Project Management.svg",
-        },
-        {"slug": "commercial-operations", "icon": "1f84f8c7-Operations.svg"},
-        {"slug": "product", "icon": "d5341dfa-Product.svg"},
-        {"slug": "sales", "icon": "2dc1ceb1-Sales.svg"},
-        {"slug": "finance", "icon": "8b2110ea-finance.svg"},
-        {"slug": "people", "icon": "01ff5233-Human Resources.svg"},
-        {"slug": "administration", "icon": "a42f5ab5-Admin.svg"},
-        {"slug": "legal", "icon": "4e54c36b-Legal.svg"},
-        {
-            "slug": "alliances-and-channels",
-            "icon": "46a968ed-no%20bg%20hand%20&%20fingers-new.svg",
-        },
-    ]
-
-    departments_overview = []
-
-    for vacancy in all_departments:
-        for dept in dept_list:
-            if vacancy[dept["slug"]]:
-                if vacancy[dept["slug"]].vacancies:
-                    count = len(vacancy[dept["slug"]].vacancies)
-                else:
-                    count = 0
-                name = vacancy[dept["slug"]].name
-                slug = vacancy[dept["slug"]].slug
-                icon = dept["icon"]
-
-                departments_overview.append(
-                    {
-                        "name": name,
-                        "count": count,
-                        "slug": slug,
-                        "icon": icon,
-                    }
-                )
-
-    return all_departments, departments_overview
-
 
 # Sentry setup
 sentry_dsn = get_flask_env("SENTRY_DSN")

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -286,6 +286,7 @@ def secure_boot():
         "../static/files", "secure-boot-master-ca.crl"
     )
 
+
 @app.route("/juju/docs/search", methods=["GET"])
 def search_docs():
     """Main search function that fetches and ranks documentation results."""
@@ -370,6 +371,7 @@ def handle_careers_results():
         greenhouse = Greenhouse.from_session(session)
         return careers_results(greenhouse)
 
+
 def careers_results(greenhouse):
     vacancies = []
 
@@ -378,9 +380,9 @@ def careers_results(greenhouse):
 
     vacancies_by_department = {slug: [] for slug in DEPARTMENT_LIST.keys()}
     for v in vacancies:
-       for d in v.departments:
-           if d.slug in DEPARTMENT_LIST.keys():
-               vacancies_by_department[d.slug].append(v)
+        for d in v.departments:
+            if d.slug in DEPARTMENT_LIST.keys():
+                vacancies_by_department[d.slug].append(v)
 
     context = {
         "departments": DEPARTMENT_LIST.values(),

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -378,11 +378,11 @@ def careers_results(greenhouse):
     core_skills = flask.request.args.get("core-skills", "").split(",")
     vacancies = greenhouse.get_vacancies_by_skills(core_skills)
 
-    vacancies_by_department = {slug: [] for slug in DEPARTMENT_LIST.keys()}
-    for v in vacancies:
-        for d in v.departments:
-            if d.slug in DEPARTMENT_LIST.keys():
-                vacancies_by_department[d.slug].append(v)
+    vacancies_by_department = {slug: [] for slug in DEPARTMENT_LIST}
+    for vacancy in vacancies:
+        for department in vacancy.departments:
+            if department.slug in vacancies_by_department:
+                vacancies_by_department[department.slug].append(vacancy)
 
     context = {
         "departments": DEPARTMENT_LIST.values(),

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -286,16 +286,6 @@ def secure_boot():
         "../static/files", "secure-boot-master-ca.crl"
     )
 
-
-# Career departments
-@app.route("/careers/results")
-def handle_careers_results():
-    with get_requests_session() as session:
-        greenhouse = Greenhouse.from_session(session)
-        harvest = Harvest.from_session(session)
-        return careers_results(greenhouse, harvest)
-
-
 @app.route("/juju/docs/search", methods=["GET"])
 def search_docs():
     """Main search function that fetches and ranks documentation results."""
@@ -373,17 +363,27 @@ def get_latest_versions():
         return {"error": str(e)}, 500
 
 
-def careers_results(greenhouse, harvest):
+# Career departments
+@app.route("/careers/results")
+def handle_careers_results():
+    with get_requests_session() as session:
+        greenhouse = Greenhouse.from_session(session)
+        return careers_results(greenhouse)
+
+def careers_results(greenhouse):
     vacancies = []
 
     core_skills = flask.request.args.get("core-skills", "").split(",")
     vacancies = greenhouse.get_vacancies_by_skills(core_skills)
-    vacancies_by_department = _group_by_department(harvest, vacancies)
+
+    vacancies_by_department = {slug: [] for slug in DEPARTMENT_LIST.keys()}
+    for v in vacancies:
+       for d in v.departments:
+           if d.slug in DEPARTMENT_LIST.keys():
+               vacancies_by_department[d.slug].append(v)
 
     context = {
-        "all_departments": _group_by_department(
-            harvest, greenhouse.get_vacancies()
-        ),
+        "departments": DEPARTMENT_LIST.values(),
         "vacancies": vacancies,
         "vacancies_by_department": vacancies_by_department,
         "recaptcha_site_key": RECAPTCHA_SITE_KEY,

--- a/webapp/careers.py
+++ b/webapp/careers.py
@@ -1,0 +1,155 @@
+DEPARTMENT_LIST = {
+    "engineering": {
+        "name": "Engineering",
+        "slug": "engineering",
+        "icon": "84886ac6-Engineering.svg",
+    },
+    "support-engineering": {
+        "name": "Support Engineering",
+        "slug": "support-engineering",
+        "icon": "df08c7f2-Support Engineering.svg",
+    },
+    "marketing": {
+        "name": "Marketing",
+        "slug": "marketing",
+        "icon": "27b93be4-Marketing.svg",
+    },
+    "web-and-design": {
+        "name": "Web & Design",
+        "slug": "web-and-design",
+        "icon": "b200e162-design.svg",
+    },
+    "project-management": {
+        "name": "Project Management",
+        "slug": "project-management",
+        "icon": "0f64ee5c-Project Management.svg",
+    },
+    "commercial-operations": {
+        "name": "Commercial Operations",
+        "slug": "commercial-operations",
+        "icon": "1f84f8c7-Operations.svg",
+    },
+    "product": {
+        "name": "Product",
+        "slug": "product",
+        "icon": "d5341dfa-Product.svg",
+    },
+    "sales": {"name": "Sales", "slug": "sales", "icon": "2dc1ceb1-Sales.svg"},
+    "finance": {
+        "name": "Finance",
+        "slug": "finance",
+        "icon": "8b2110ea-finance.svg",
+    },
+    "people": {
+        "name": "People",
+        "slug": "people",
+        "icon": "01ff5233-Human Resources.svg",
+    },
+    "administration": {
+        "name": "Administration",
+        "slug": "administration",
+        "icon": "a42f5ab5-Admin.svg",
+    },
+    "legal": {"name": "Legal", "slug": "legal", "icon": "4e54c36b-Legal.svg"},
+    "alliances-and-channels": {
+        "name": "Alliances & Channels",
+        "slug": "alliances-and-channels",
+        "icon": "46a968ed-no%20bg%20hand%20&%20fingers-new.svg",
+    },
+}
+
+
+def _group_by_department(harvest, vacancies):
+    """
+    Return a dictionary of departments by slug,
+    where each department will have a new
+    "vacancies" property of all the vacancies in
+    that department
+    """
+
+    all_departments = harvest.get_departments()
+    vacancies_by_department = {}
+
+    departments_by_slug = {}
+
+    for department in all_departments:
+        departments_by_slug[department.slug] = department
+
+    for vacancy in vacancies:
+        for department in vacancy.departments:
+            slug = department.slug
+
+            if slug not in vacancies_by_department:
+                vacancies_by_department[slug] = departments_by_slug[slug]
+                vacancies_by_department[slug].vacancies = [vacancy]
+            else:
+                vacancies_by_department[slug].vacancies.append(vacancy)
+
+    # Add departments with no vacancies
+    for dept in departments_by_slug:
+        slug = departments_by_slug[dept].slug
+        if slug not in vacancies_by_department:
+            vacancies_by_department[slug] = departments_by_slug[slug]
+            vacancies_by_department[slug].vacancies = {}
+
+    return vacancies_by_department
+
+
+def _get_sorted_departments(greenhouse, harvest):
+    departments = _group_by_department(harvest, greenhouse.get_vacancies())
+
+    sort_order = [
+        "engineering",
+        "support-engineering",
+        "marketing",
+        "web-and-design",
+        "project-management",
+        "commercial-operations",
+        "product",
+        "sales",
+        "finance",
+        "people",
+        "administration",
+        "legal",
+        "alliances-and-channels",
+    ]
+
+    sorted = {slug: departments[slug] for slug in sort_order}
+    remaining_slugs = set(departments.keys()).difference(sort_order)
+    remaining = {slug: departments[slug] for slug in remaining_slugs}
+    sorted_departments = {**sorted, **remaining}
+
+    return sorted_departments
+
+
+def _get_all_departments(greenhouse, harvest) -> tuple:
+    """
+    Refactor for careers search section
+    """
+    all_departments = (
+        _group_by_department(harvest, greenhouse.get_vacancies()),
+    )
+
+    departments_overview = []
+
+    for vacancy in all_departments:
+        for dept in DEPARTMENT_LIST.values():
+            if vacancy[dept["slug"]]:
+                if vacancy[dept["slug"]].vacancies:
+                    count = len(vacancy[dept["slug"]].vacancies)
+                else:
+                    count = 0
+                name = vacancy[dept["slug"]].name
+                slug = vacancy[dept["slug"]].slug
+                icon = dept["icon"]
+
+                departments_overview.append(
+                    {
+                        "name": name,
+                        "count": count,
+                        "slug": slug,
+                        "icon": icon,
+                    }
+                )
+
+    return all_departments, departments_overview


### PR DESCRIPTION
## Done

Updated the careers results view to use the static department mapping instead of calling Harvest API

## QA

Compare `/careers/results` from the demo against staging/prod an check the same vacancies are returned.
