### PR TITLE
fix(WD-37616): careers location filter broken for jobs with multiple locations

### DIFF
--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -32,7 +32,7 @@
   // Read data-location property and parse locations into well-defined categories
   function parseLocations(location, filters) {
     const regions = {
-      emea: [
+      emea: new Set([
         "emea",
         "slovakia",
         "bratislava",
@@ -42,8 +42,8 @@
         "berlin",
         "london",
         "worldwide",
-      ],
-      americas: [
+      ]),
+      americas: new Set([
         "americas",
         "southwest",
         "san francisco",
@@ -56,22 +56,37 @@
         "america",
         "worldwide",
         "boston",
-      ],
-      apac: ["apac", "taiwan", "taipei", "beijing", "china", "worldwide"],
+      ]),
+      apac: new Set([
+        "apac",
+        "taiwan",
+        "taipei",
+        "beijing",
+        "china",
+        "worldwide",
+      ]),
     };
 
     // format job location string
-    local = location.toLowerCase().split("-").pop().split(",");
+    var locations = location.split(";");
 
-    //check if job location matches a location in filtered region(s)
-    for (let i = 0; i < filters.length; i++) {
-      let regionKey = regions[filters[i].toLowerCase()];
-      for (let j = 0; j < local.length; j++) {
-        if (Object.values(regionKey).includes(local[j].trim())) {
-          return 1;
+    for (const loc of locations) {
+      var local = loc.toLowerCase().split("-").pop().split(",");
+
+      //check if job location matches a location in filtered region(s)
+      for (let i = 0; i < filters.length; i++) {
+        let regionKey = regions[filters[i].toLowerCase()];
+        if (!regionKey) {
+          continue;
+        }
+        for (let j = 0; j < local.length; j++) {
+          if (regionKey.has(local[j].trim())) {
+            return true;
+          }
         }
       }
     }
+    return false;
   }
 
   // Update search box text with data from query params


### PR DESCRIPTION
## Done

- Fixed careers location filtering logic for jobs with multiple locations
- (drive-by): Optimized performance by reducing time complexity

## QA

### Before
- Go to [live](https://canonical.com/careers/all?search=marketing+manager&filter=Marketing&location=americas)
- Verify "Marketing Manager" job does not show up in the list

### After
- Go to [demo](https://canonical-com-2763.demos.haus/careers/all?search=marketing+manager&filter=Marketing&location=americas)
- Verify "Marketing Manager" job showing up in the list

## Issue / Card

Fixes [WD-37616](https://warthogs.atlassian.net/browse/WD-37616)



[WD-37616]: https://warthogs.atlassian.net/browse/WD-37616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ