### PR TITLE
fix: show all locations on job details page

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,7 @@
 import unittest
 from webapp.app import app, is_remote
+from unittest.mock import MagicMock, patch
+from webapp.app import job_details
 
 
 class TestIsRemote(unittest.TestCase):
@@ -59,3 +61,91 @@ class TestCacheControlHeaders(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Cookie", response.vary)
+
+
+class TestJobDetailsLocationOverride(unittest.TestCase):
+    """
+    job_details() should override the single Harvest location with the
+    Greenhouse board location, which may contain multiple regions joined
+    by ";".
+    """
+
+    def _run_job_details(self, harvest_job, vacancy_location):
+        harvest = MagicMock()
+        harvest.get_job_post.return_value = harvest_job
+
+        greenhouse = MagicMock()
+        vacancy = MagicMock()
+        vacancy.content = "<p>Job content</p>"
+        vacancy.location = vacancy_location
+        greenhouse.get_vacancy.return_value = vacancy
+
+        captured = {}
+
+        def fake_render_template(template_name, **context):
+            captured.update(context)
+            return ""
+
+        with app.test_request_context("/careers/1234/some-role"):
+            with patch(
+                "webapp.app.flask.render_template",
+                side_effect=fake_render_template,
+            ):
+                job_details(MagicMock(), greenhouse, harvest, "1234")
+
+        return captured
+
+    def test_multi_location_string_overrides_harvest_location(self):
+        harvest_job = {
+            "active": True,
+            "live": True,
+            "location": {"name": "Home based - EMEA"},
+        }
+        captured = self._run_job_details(
+            harvest_job,
+            "Home Based - Americas; Home based - EMEA",
+        )
+
+        self.assertEqual(
+            captured["job"]["location"]["name"],
+            "Home Based - Americas; Home based - EMEA",
+        )
+
+    def test_single_location_is_overridden_with_board_value(self):
+        harvest_job = {
+            "active": True,
+            "live": True,
+            "location": {"name": "Home based - EMEA"},
+        }
+        captured = self._run_job_details(harvest_job, "Home Based - Americas")
+
+        self.assertEqual(
+            captured["job"]["location"]["name"],
+            "Home Based - Americas",
+        )
+
+    def test_missing_board_location_keeps_harvest_location(self):
+        harvest_job = {
+            "active": True,
+            "live": True,
+            "location": {"name": "Home based - EMEA"},
+        }
+        captured = self._run_job_details(harvest_job, None)
+
+        self.assertEqual(
+            captured["job"]["location"]["name"],
+            "Home based - EMEA",
+        )
+
+    def test_missing_harvest_location_does_not_error(self):
+        harvest_job = {
+            "active": True,
+            "live": True,
+            "location": None,
+        }
+        captured = self._run_job_details(
+            harvest_job,
+            "Home Based - Americas; Home based - EMEA",
+        )
+
+        self.assertIsNone(captured["job"]["location"])

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -611,6 +611,12 @@ def job_details(session, greenhouse, harvest, job_id):
 
         job_post = greenhouse.get_vacancy(job_id)
         context["job"]["content"] = job_post.content
+        # The Harvest job post only exposes a single location, while the
+        # Greenhouse board API returns all regions a role is open to (joined
+        # with ";"). Use the board value so multi-region roles show every
+        # location on the details page.
+        if context["job"].get("location") and job_post.location:
+            context["job"]["location"]["name"] = job_post.location
         context["job"]["is_remote"] = is_remote(context["job"])
 
     except HTTPError as error:


### PR DESCRIPTION
**Note:** Diff is from tests, the actual change is small

## Done

- Update job location name to show all applicable locations on the details page

## QA

### Before
- https://canonical.com/careers/6110691
<img width="669" height="259" alt="image" src="https://github.com/user-attachments/assets/c0a60df5-641b-48a5-bf50-1caabf00bc33" />


### After
- https://canonical-com-2765.demos.haus/careers/6110691
<img width="669" height="259" alt="image" src="https://github.com/user-attachments/assets/e71fa1bd-807e-4a54-864d-efb24808b20b" />

## Issue / Card

Fixes [WD-37616](https://warthogs.atlassian.net/browse/WD-37616)

## Screenshots

[if relevant, include a screenshot]


[WD-37616]: https://warthogs.atlassian.net/browse/WD-37616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
