### PR TITLE
templates/sitemap-index.xml: add MicroCloud

### DIFF
--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -55,6 +55,12 @@
     <loc>https://canonical.com/lxd/docs/default/sitemap.xml</loc>
   </sitemap>
   <sitemap>
+    <loc>https://canonical.com/microcloud/docs/latest/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://canonical.com/microcloud/docs/default/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
     <loc>https://canonical.com/juju/docs/12-factor/latest/sitemap.xml</loc>
   </sitemap>
   <sitemap>


### PR DESCRIPTION
## Done

Add MicroCloud documentation sitemaps to canonical.com.

## QA

- Open the [DEMO](__DEMO_URL__/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
