### PR TITLE
feat: add cronjob to verify dynamically generated sitemaps

### DIFF
--- a/.github/workflows/dynamic-sitemaps.yml
+++ b/.github/workflows/dynamic-sitemaps.yml
@@ -43,3 +43,9 @@ jobs:
                     --retry 3 \
                     --retry-delay 10 \
                     --retry-all-errors
+
+            - name: Send message on failure
+              if: failure()
+              env:
+                  BOT_URL: ${{ secrets.BOT_URL }}
+              run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" $BOT_URL?room=web-alerts

--- a/.github/workflows/dynamic-sitemaps.yml
+++ b/.github/workflows/dynamic-sitemaps.yml
@@ -1,0 +1,45 @@
+name: Verify dynamically generated sitemaps for canonical.com
+
+on:
+    # schedule:
+    #   - cron: "0 7 * * 1" # every Monday at 07:00 UTC
+
+    pull_request:
+
+permissions:
+    contents: read
+
+jobs:
+    setup:
+        runs-on: ubuntu-latest
+        outputs:
+            targets: ${{ steps.extract_targets.outputs.targets }}
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
+
+            - name: Extract targets
+              id: extract_targets
+              run: |
+                  echo "targets=$(yq -o=json -I=0 '.' dynamic-sitemaps.yaml)" >> "$GITHUB_OUTPUT"
+
+    verify:
+        needs: setup
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                target: ${{ fromJSON(needs.setup.outputs.targets) }}
+        steps:
+            - name: Verify sitemap for ${{ env.TARGET }}
+              env:
+                  TARGET: ${{ matrix.target }}
+              run: |
+                  curl --fail-with-body -X GET "https://canonical.com/$TARGET/sitemap.xml" \
+                    --connect-timeout 30 \
+                    --max-time 300 \
+                    --retry 3 \
+                    --retry-delay 10 \
+                    --retry-all-errors

--- a/.github/workflows/dynamic-sitemaps.yml
+++ b/.github/workflows/dynamic-sitemaps.yml
@@ -1,10 +1,10 @@
 name: Verify dynamically generated sitemaps for canonical.com
 
 on:
-    # schedule:
-    #   - cron: "0 7 * * 1" # every Monday at 07:00 UTC
+    schedule:
+      - cron: "0 7 * * 1" # every Monday at 07:00 UTC
 
-    pull_request:
+    workflow_dispatch:
 
 permissions:
     contents: read

--- a/dynamic-sitemaps.yaml
+++ b/dynamic-sitemaps.yaml
@@ -1,0 +1,9 @@
+# Sitemaps that are already generated and don't need to be updated.
+# Can be seen on /sitemap.xml
+- careers
+- partners
+- blog
+- knowledge
+- microk8s/docs
+- dqlite/docs
+- maas/docs

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -31,3 +31,4 @@ parts:
       - flask/app/redirects.yaml
       - flask/app/navigation.yaml
       - flask/app/secondary-navigation.yaml
+      - flask/app/dynamic-sitemaps.yaml

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -94,16 +94,8 @@ logger = logging.getLogger(__name__)
 
 # Sitemaps that are already generated and don't need to be updated.
 # Can be seen on /sitemap.xml
-DYNAMIC_SITEMAPS = [
-    "careers",
-    "partners",
-    "blog",
-    "knowledge",
-    "microk8s/docs",
-    "dqlite/docs",
-    "maas/docs",
-    "tests",
-]
+with open("dynamic-sitemaps.yaml") as sitemaps_file:
+    DYNAMIC_SITEMAPS = yaml.load(sitemaps_file.read(), Loader=yaml.FullLoader)
 
 
 # Web tribe websites custom search ID


### PR DESCRIPTION
## Done

- Added workflow that runs weekly to verify dynamically generated sitemaps

## QA

- Verify all [sitemap checks](https://github.com/canonical/canonical.com/actions/runs/29561687295/job/87825351220?pr=2786) are passed

<img width="318" height="347" alt="image" src="https://github.com/user-attachments/assets/dc7d2f0c-138c-410c-9827-fc251ebdbf27" />


## Issue / Card

Fixes [WD-37802](https://warthogs.atlassian.net/browse/WD-37802)



[WD-37802]: https://warthogs.atlassian.net/browse/WD-37802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ