### PR TITLE
fix(WD-37817): Update what is microcloud docs links

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -186,7 +186,7 @@ microcloud:
     - title: Resources
       path: /microcloud/resources
     - title: Docs
-      path: https://canonical.com/microcloud/docs/
+      path: /microcloud/docs/
 
 microk8s:
   title: MicroK8s      

--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -186,7 +186,7 @@ microcloud:
     - title: Resources
       path: /microcloud/resources
     - title: Docs
-      path: https://documentation.ubuntu.com/microcloud/
+      path: https://canonical.com/microcloud/docs/
 
 microk8s:
   title: MicroK8s      

--- a/templates/microcloud/what-is-microcloud.html
+++ b/templates/microcloud/what-is-microcloud.html
@@ -78,7 +78,7 @@
       "title_text": "Trusted software defined networking with MicroOVN",
       "image_html":  '<img src="https://assets.ubuntu.com/v1/d74339cb-microovn.png" class="p-image-container__image" width="568" height="568" alt="" />',
 "description_html": "<p>MicroOVN provides virtual network abstractions, such as virtual L2 and L3 overlays, security groups, DHCP, and other networking services. It separates logical network topology from physical infrastructure, making the cloud easier to operate.</p>",
-      "cta_html": "<a href='https://canonical.com/microcloud/docs/default/explanation/networking/'>Learn more about MicroCloud’s networking approach&nbsp;&rsaquo;</a>"
+      "cta_html": "<a href='/microcloud/docs/default/explanation/networking/'>Learn more about MicroCloud’s networking approach&nbsp;&rsaquo;</a>"
     }
   ]
 ) %}

--- a/templates/microcloud/what-is-microcloud.html
+++ b/templates/microcloud/what-is-microcloud.html
@@ -78,7 +78,7 @@
       "title_text": "Trusted software defined networking with MicroOVN",
       "image_html":  '<img src="https://assets.ubuntu.com/v1/d74339cb-microovn.png" class="p-image-container__image" width="568" height="568" alt="" />',
 "description_html": "<p>MicroOVN provides virtual network abstractions, such as virtual L2 and L3 overlays, security groups, DHCP, and other networking services. It separates logical network topology from physical infrastructure, making the cloud easier to operate.</p>",
-      "cta_html": "<a href='https://canonical.com/microcloud/docs/default/explanation/networking'>Learn more about MicroCloud’s networking approach&nbsp;&rsaquo;</a>"
+      "cta_html": "<a href='https://canonical.com/microcloud/docs/default/explanation/networking/'>Learn more about MicroCloud’s networking approach&nbsp;&rsaquo;</a>"
     }
   ]
 ) %}

--- a/templates/microcloud/what-is-microcloud.html
+++ b/templates/microcloud/what-is-microcloud.html
@@ -78,7 +78,7 @@
       "title_text": "Trusted software defined networking with MicroOVN",
       "image_html":  '<img src="https://assets.ubuntu.com/v1/d74339cb-microovn.png" class="p-image-container__image" width="568" height="568" alt="" />',
 "description_html": "<p>MicroOVN provides virtual network abstractions, such as virtual L2 and L3 overlays, security groups, DHCP, and other networking services. It separates logical network topology from physical infrastructure, making the cloud easier to operate.</p>",
-      "cta_html": "<a href='https://documentation.ubuntu.com/microcloud/v2/microcloud/explanation/networking/'>Learn more about MicroCloud’s networking approach&nbsp;&rsaquo;</a>"
+      "cta_html": "<a href='https://canonical.com/microcloud/docs/default/explanation/networking'>Learn more about MicroCloud’s networking approach&nbsp;&rsaquo;</a>"
     }
   ]
 ) %}


### PR DESCRIPTION
## Done

- Changed the link mentioned in the copydoc under the ticket.
- Changed the navigation link for "Docs" as requested in the ticket description.

## QA

- Open the [DEMO](https://canonical-com-2788.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Navigate to /microcloud/what-is-microcloud
- Make sure the links are updated.

## Issue / Card

Fixes [WD-37817](https://warthogs.atlassian.net/browse/WD-37817)


[WD-37817]: https://warthogs.atlassian.net/browse/WD-37817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ