### PR TITLE
fix: add missing products.yaml to rockcraft.yaml parts

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -32,3 +32,4 @@ parts:
       - flask/app/navigation.yaml
       - flask/app/secondary-navigation.yaml
       - flask/app/dynamic-sitemaps.yaml
+      - flask/app/products.yaml


### PR DESCRIPTION
## Done

- Add `products.yaml` to `rockcraft.yaml` parts — this file was missing from the rock image, causing production and staging failures.

## QA

- Open the [DEMO](__DEMO_URL__/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Confirm the site builds/runs without errors related to `products.yaml`

## Issue / Card

Fixes #

## Screenshots

N/A
