### PR TITLE
chore: update sitemap definitions for PFE charm doc sites

### DIFF
--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -43,7 +43,7 @@
     <loc>https://canonical.com/maas/docs/latest/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/wordpress-k8s-charm/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/wordpress-k8s-charm/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
     <loc>https://canonical.com/anbox-cloud/docs/doc-sitemap.xml</loc>
@@ -61,52 +61,55 @@
     <loc>https://canonical.com/microcloud/docs/default/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/12-factor/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/12-factor/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/charmed-ingresses/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/12-factor/v1/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/backup-charms/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/charmed-ingresses/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/content-cache-charms/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/backup-charms/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/content-cache-k8s-charm/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/content-cache-charms/latest/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://canonical.com/juju/docs/content-cache-k8s-charm/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
     <loc>https://canonical.com/juju/docs/discourse-k8s-charm/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/dns-charms/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/dns-charms/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/falco-charms/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/falco-charms/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/gateway-api-integrator-charm/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/gateway-api-integrator-charm/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/github-runner-charms/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/github-runner-charms/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/haproxy-charm/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/haproxy-charm/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/ingress-configurator-charm/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/ingress-configurator-charm/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/nginx-ingress-integrator-charm/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/nginx-ingress-integrator-charm/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/synapse-charm/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/synapse-charm/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/traefik-k8s-charm/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/traefik-k8s-charm/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://canonical.com/juju/docs/wireguard-gateway-charm/latest/sitemap.xml</loc>
+    <loc>https://canonical.com/juju/docs/wireguard-gateway-charm/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
     <loc>https://canonical.com/juju/docs/charmcraft/latest/sitemap.xml</loc>


### PR DESCRIPTION
## Done

Updated the following sitemap entries (from `*/sitemap.xml` to `*/doc-sitemap.xml`:
* https://canonical.com/juju/docs/wordpress-k8s-charm/latest/doc-sitemap.xml
* https://canonical.com/juju/docs/12-factor/latest/doc-sitemap.xml
* https://canonical.com/juju/docs/charmed-ingresses/latest/doc-sitemap.xml 
* https://canonical.com/juju/docs/backup-charms/latest/doc-sitemap.xml
* https://canonical.com/juju/docs/content-cache-charms/latest/doc-sitemap.xml 
* https://canonical.com/juju/docs/content-cache-k8s-charm/latest/doc-sitemap.xml 
* https://canonical.com/juju/docs/dns-charms/latest/doc-sitemap.xml
* https://canonical.com/juju/docs/falco-charms/latest/doc-sitemap.xml 
* https://canonical.com/juju/docs/gateway-api-integrator-charm/latest/doc-sitemap.xml 
* https://canonical.com/juju/docs/github-runner-charms/latest/doc-sitemap.xml 
* https://canonical.com/juju/docs/haproxy-charm/latest/doc-sitemap.xml 
* https://canonical.com/juju/docs/ingress-configurator-charm/latest/doc-sitemap.xml 
* https://canonical.com/juju/docs/nginx-ingress-integrator-charm/latest/doc-sitemap.xml 
* https://canonical.com/juju/docs/synapse-charm/latest/doc-sitemap.xml 
* https://canonical.com/juju/docs/traefik-k8s-charm/latest/doc-sitemap.xml 
* https://canonical.com/juju/docs/wireguard-gateway-charm/latest/doc-sitemap.xml 

Added the following sitemap entry:
* https://canonical.com/juju/docs/12-factor/v1/doc-sitemap.xml 

## QA

- Open the [DEMO](__DEMO_URL__/)
- Alternatively, check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
