### PR TITLE
ci: cache packed charm and yarn deps to speed up deploys

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,6 +26,9 @@ concurrency:
 env:
   CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: true
   ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: true
+  # Pinned so the charm cache stays reproducible: edge drift can't leave a
+  # stale .charm cached under an unchanged charm/** key. Bump to invalidate.
+  CHARMCRAFT_REVISION: "8137"
 
 jobs:
   pack-charm:
@@ -45,7 +48,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./charm/*.charm
-          key: charm-${{ hashFiles('charm/**') }}
+          key: charm-${{ runner.os }}-${{ runner.arch }}-cc${{ env.CHARMCRAFT_REVISION }}-${{ hashFiles('charm/**') }}
 
       - name: Setup LXD
         if: steps.charm-cache.outputs.cache-hit != 'true'
@@ -53,7 +56,7 @@ jobs:
 
       - name: Setup Charmcraft
         if: steps.charm-cache.outputs.cache-hit != 'true'
-        run: sudo snap install charmcraft --classic --channel=latest/edge
+        run: sudo snap install charmcraft --classic --revision ${{ env.CHARMCRAFT_REVISION }}
 
       - name: Pack charm
         if: steps.charm-cache.outputs.cache-hit != 'true'
@@ -76,7 +79,7 @@ jobs:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,13 +36,27 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
+      # The charm is a generic 12-factor flask-framework charm whose output
+      # depends only on the charm/ directory. Almost every deploy changes app
+      # code (webapp/, templates/, static/) and leaves charm/ untouched, so we
+      # cache the packed charm and only rebuild when charm/ actually changes.
+      - name: Restore cached charm
+        id: charm-cache
+        uses: actions/cache@v4
+        with:
+          path: ./charm/*.charm
+          key: charm-${{ hashFiles('charm/**') }}
+
       - name: Setup LXD
+        if: steps.charm-cache.outputs.cache-hit != 'true'
         uses: canonical/setup-lxd@main
 
       - name: Setup Charmcraft
+        if: steps.charm-cache.outputs.cache-hit != 'true'
         run: sudo snap install charmcraft --classic --channel=latest/edge
 
       - name: Pack charm
+        if: steps.charm-cache.outputs.cache-hit != 'true'
         run: |
           cd charm
           charmcraft pack -v --project-dir ./
@@ -63,10 +77,13 @@ jobs:
 
       - name: Use Node.js
         uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'yarn'
 
       - name: Build Assets
         run: |
-          yarn install
+          yarn install --frozen-lockfile
           yarn run build
 
       - name: Pre-generate llms-full.txt


### PR DESCRIPTION
## Done

Speed up the deploy pipeline by caching build inputs:

- **Cache the packed charm** (keyed on `charm/**`). The charm is a generic 12-factor flask-framework charm that only changes when `charm/` changes — which almost no deploy does. On a cache hit we skip LXD + `charmcraft pack` entirely. Measured: `pack-charm` **638s → ~6–11s**, taking it off the critical path.
- **Cache yarn deps** in `pack-rock` via `setup-node` (+ pin Node 20), so `yarn install` stops re-downloading every run. Minor gain — `pack-rock` is dominated by `rockcraft pack` — but harmless and better hygiene.

Net: the charm job is no longer the bottleneck; the pipeline floor is now the `pack-rock → publish-image → deploy-staging` chain. No behaviour change — the built charm and image are identical.

## QA

- Trigger a deploy that doesn't touch `charm/`: the "Restore cached charm" step reports a cache hit and the Setup LXD / Charmcraft / Pack charm steps are skipped.
  - Check https://github.com/canonical/canonical.com/actions/runs/29736297232
- After
  - https://github.com/canonical/canonical.com/actions/runs/29737088083

## Issue / Card

[WD-37854](https://warthogs.atlassian.net/browse/WD-37854)

## Screenshots
Before
<img width="984" height="307" alt="image" src="https://github.com/user-attachments/assets/9fcbe73f-b6ca-44c7-906c-410e0828cb61" />

After
<img width="947" height="298" alt="image" src="https://github.com/user-attachments/assets/ec254323-e965-4580-a3e6-cdedee484e1d" />



[WD-37854]: https://warthogs.atlassian.net/browse/WD-37854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ