### PR TITLE
refactor: reuse single discourse cache across API instances

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -300,9 +300,6 @@ def search_docs():
     )
 
 
-CACHE_TTL = 60 * 60  # 1 hour cache
-
-
 @app.route("/juju/latest.json")
 @cross_origin()
 @cached(cache=TTLCache(maxsize=128, ttl=CACHE_TTL))

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1134,7 +1134,7 @@ dqlite_docs = Docs(
         api=DiscourseAPI(
             base_url="https://discourse.dqlite.io/",
             session=discourse_session,
-            cache=ubuntu_discourse_cache,
+            cache=None,
         ),
         index_topic_id=34,
         url_prefix="/dqlite/docs",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -93,6 +93,7 @@ from webapp.utils.juju_doc_search import (
     search_all_docs,
 )
 from webapp import ubuntu_pro_description as _upsd
+from webapp.utils.constants import CACHE_TTL
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +147,7 @@ loader = ChoiceLoader(
 app.jinja_loader = loader
 search_session = get_requests_session()
 discourse_session = get_requests_session()
+ubuntu_discourse_cache = ResponseCache(ttl=CACHE_TTL)
 
 app.register_blueprint(application_bp, url_prefix="/careers/application")
 
@@ -1135,7 +1137,7 @@ dqlite_docs = Docs(
         api=DiscourseAPI(
             base_url="https://discourse.dqlite.io/",
             session=discourse_session,
-            cache=ResponseCache(ttl=600),
+            cache=ubuntu_discourse_cache,
         ),
         index_topic_id=34,
         url_prefix="/dqlite/docs",
@@ -1169,7 +1171,7 @@ maas_docs = Docs(
             base_url="https://discourse.maas.io/",
             session=discourse_session,
             get_topics_query_id=2,
-            cache=ResponseCache(ttl=600),
+            cache=ubuntu_discourse_cache,
         ),
         index_topic_id=6662,
         url_prefix=maas_url_prefix,
@@ -1254,7 +1256,7 @@ tutorials_discourse = Tutorials(
             api_key=MAAS_DISCOURSE_API_KEY,
             api_username=MAAS_DISCOURSE_API_USERNAME,
             get_topics_query_id=2,
-            cache=ResponseCache(ttl=600),
+            cache=ubuntu_discourse_cache,
         ),
         index_topic_id=1289,
         url_prefix="/maas/tutorials",
@@ -1518,7 +1520,7 @@ engage_pages_discourse_api = DiscourseAPI(
     get_topics_query_id=14,
     api_key=DISCOURSE_API_KEY,
     api_username=DISCOURSE_API_USERNAME,
-    cache=ResponseCache(ttl=600),
+    cache=ubuntu_discourse_cache,
 )
 engage_pages = EngagePages(
     api=engage_pages_discourse_api,
@@ -1548,7 +1550,7 @@ discourse_api = DiscourseAPI(
     session=search_session,
     api_key=DISCOURSE_API_KEY,
     api_username=DISCOURSE_API_USERNAME,
-    cache=ResponseCache(ttl=600),
+    cache=ubuntu_discourse_cache,
 )
 
 
@@ -1584,7 +1586,7 @@ microk8s_discourse_api = Docs(
         api=DiscourseAPI(
             base_url="https://discuss.kubernetes.io/",
             session=get_requests_session(),
-            cache=ResponseCache(ttl=600),
+            cache=None,
         ),
         index_topic_id=11243,
         url_prefix=microk8s_url_prefix,

--- a/webapp/utils/constants.py
+++ b/webapp/utils/constants.py
@@ -5,3 +5,6 @@ ONE_WEEK_IN_MINUTES = 10080
 # and this is undesired. We are tracking the req ID here so that
 # it can be hidden on the Candidate Dash.
 SECOND_LOOK_REQ_ID = 3013911
+
+# Default time-to-live for ResponseCache instances, in seconds (24 hours)
+CACHE_TTL = 60 * 60

--- a/webapp/utils/constants.py
+++ b/webapp/utils/constants.py
@@ -6,5 +6,5 @@ ONE_WEEK_IN_MINUTES = 10080
 # it can be hidden on the Candidate Dash.
 SECOND_LOOK_REQ_ID = 3013911
 
-# Default time-to-live for ResponseCache instances, in seconds (24 hours)
+# Default time-to-live for ResponseCache instances, in seconds (1 hour)
 CACHE_TTL = 60 * 60


### PR DESCRIPTION
## Done

- Use single Discourse cache across API instances
- For Discourse instances without API keys, set cache as `None`

## QA

- Go to the Discourse related pages
  - https://canonical-com-2830.demos.haus/case-study
  - https://canonical-com-2830.demos.haus/events
  - https://canonical-com-2830.demos.haus/dqlite/docs
  - https://canonical-com-2830.demos.haus/maas/docs
  - https://canonical-com-2830.demos.haus/mir/docs
  - https://canonical-com-2830.demos.haus/microk8s/docs
  - https://canonical-com-2830.demos.haus/maas/tutorials 
- See that all loads as expected

## Issue / Card

Fixes [WD-37940](https://warthogs.atlassian.net/browse/WD-37940)

## Screenshots

[if relevant, include a screenshot]


[WD-37940]: https://warthogs.atlassian.net/browse/WD-37940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ