### PR TITLE
fix(navigation): match list font style of 'Company' dropdown to 'Solutions' dropdown

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -166,6 +166,8 @@ $navigation-heading-color: #fff9;
       }
 
       a.p-link--inverted {
+        font-weight: $font-weight-regular-text;
+
         &:hover {
           color: var(--vf-color-text-muted);
         }


### PR DESCRIPTION

## Done

- match list font style of 'Company' dropdown to 'Solutions' dropdown (ie. updating font weight to 400 from 500). As detailed in [the ticket](https://warthogs.atlassian.net/browse/WD-37246?focusedCommentId=1158950&sourceType=mention)

## QA

- Open the [DEMO](https://canonical-com-2838.demos.haus/)
- Check the vertical lists in 'Company' dropdown match 'Solutions' dropdown

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37246

