### PR TITLE
fix: improve markdown rendering for knowledge hub pages

### DIFF
--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -12,7 +12,7 @@
         products and services.</span>
     </label>
     <p>By submitting this form, I confirm that I have read and agree to <a
-        href="/legal/dataprivacy" target="_blank">Canonical's Privacy Policy</a>.</p>
+        href="/legal/data-privacy" target="_blank">Canonical's Privacy Policy</a>.</p>
   </div>
 
   <button type="submit" class="u-no-margin--bottom">Sign up</button>

--- a/templates/knowledge/_base_knowledge_markdown.html
+++ b/templates/knowledge/_base_knowledge_markdown.html
@@ -65,7 +65,7 @@
           <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
         </label>
         <p>
-          By submitting this form, I confirm that I have read and agree to <a href="#">Canonical's Privacy Policy</a>.
+          By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy">Canonical's Privacy Policy</a>.
         </p>
         <button type="submit" class="u-no-margin--bottom js-submit-button">Sign up</button>
       </form>

--- a/templates/knowledge/_base_knowledge_markdown.html
+++ b/templates/knowledge/_base_knowledge_markdown.html
@@ -109,6 +109,7 @@
     {% endcall -%}
   {% endif %}
   
+  <div data-md-strip>
   {{ vf_blog(
     title={"text": blog.get('title', 'Latest from our blog')},
     padding="deep",
@@ -119,6 +120,7 @@
       "template_id": "template"
     })
   }}
+  </div>
   
   <script src="{{ versioned_static('js/in-page-navigation.js') }}" nonce="{{ csp_nonce }}"></script>
   <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}" nonce="{{ csp_nonce }}"></script>

--- a/templates/legal/data-privacy/partner-portal.md
+++ b/templates/legal/data-privacy/partner-portal.md
@@ -9,7 +9,7 @@ context:
 
 # Privacy notice - Partner Portal
 
-This privacy notice tells you about the information we collect from you when you access the Canonical Partner Portal. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our [privacy policy](/legal/dataprivacy).
+This privacy notice tells you about the information we collect from you when you access the Canonical Partner Portal. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our [privacy policy](/legal/data-privacy).
 
 ## Who are we ?
 

--- a/templates/partial/_knowledge_breadcrumbs.html
+++ b/templates/partial/_knowledge_breadcrumbs.html
@@ -17,45 +17,47 @@
     </ol>
 
     <!-- Small screens -->
-    {% if breadcrumbs | length == 1 %}
-      {% set breadcrumb = breadcrumbs[0] %}
+    <div data-md-strip>
+      {% if breadcrumbs | length == 1 %}
+        {% set breadcrumb = breadcrumbs[0] %}
 
-      <!-- Single row with truncation -->
-      <ol class="p-inline-list p-knowledge-breadcrumb u-truncate p-text--small-caps u-hide--large u-hide--medium u-margin-bottom-0-5rem">
-        <li class="p-inline-list__item p-knowledge-breadcrumbs__item">
-          <a href="/knowledge">Knowledge Hub</a>
-        </li>
-        <li class="p-inline-list__item p-knowledge-breadcrumbs__item">
-          {% if breadcrumb.href %}<a href="{{ breadcrumb.href }}">{{ breadcrumb.name }}</a> 
-          {% else %}
-            {{ breadcrumb.name }}
-          {% endif %}
-        </li>
-      </ol>
-
-    {% else %}
-
-      <!-- Two rows -->
-      <ol class="p-inline-list p-knowledge-breadcrumbs p-text--small-caps u-hide--large u-hide--medium">
-        <li class="p-knowledge-breadcrumbs">
-          <ol class="p-inline-list">
-            <li class="p-inline-list__item p-knowledge-breadcrumbs__item p-knowledge-breadcrumbs__item--home">
-              <a href="/knowledge">Knowledge Hub</a>
-            </li>
-          </ol>
-        </li>
-        <ol class="p-inline-list u-truncate u-margin-bottom-0-5rem">
-          {% for breadcrumb in breadcrumbs %}
-            <li class="p-inline-list__item p-knowledge-breadcrumbs__item">
-              {% if breadcrumb.href %}<a href="{{ breadcrumb.href }}">{{ breadcrumb.name }}</a> 
-              {% else %}
-                {{ breadcrumb.name }}
-              {% endif %}
-            </li>
-          {% endfor %}
+        <!-- Single row with truncation -->
+        <ol class="p-inline-list p-knowledge-breadcrumb u-truncate p-text--small-caps u-hide--large u-hide--medium u-margin-bottom-0-5rem">
+          <li class="p-inline-list__item p-knowledge-breadcrumbs__item">
+            <a href="/knowledge">Knowledge Hub</a>
+          </li>
+          <li class="p-inline-list__item p-knowledge-breadcrumbs__item">
+            {% if breadcrumb.href %}<a href="{{ breadcrumb.href }}">{{ breadcrumb.name }}</a>
+            {% else %}
+              {{ breadcrumb.name }}
+            {% endif %}
+          </li>
         </ol>
-      </ol>
-    {% endif %}
+
+      {% else %}
+
+        <!-- Two rows -->
+        <ol class="p-inline-list p-knowledge-breadcrumbs p-text--small-caps u-hide--large u-hide--medium">
+          <li class="p-knowledge-breadcrumbs">
+            <ol class="p-inline-list">
+              <li class="p-inline-list__item p-knowledge-breadcrumbs__item p-knowledge-breadcrumbs__item--home">
+                <a href="/knowledge">Knowledge Hub</a>
+              </li>
+            </ol>
+          </li>
+          <ol class="p-inline-list u-truncate u-margin-bottom-0-5rem">
+            {% for breadcrumb in breadcrumbs %}
+              <li class="p-inline-list__item p-knowledge-breadcrumbs__item">
+                {% if breadcrumb.href %}<a href="{{ breadcrumb.href }}">{{ breadcrumb.name }}</a>
+                {% else %}
+                  {{ breadcrumb.name }}
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ol>
+        </ol>
+      {% endif %}
+    </div>
   </div>
   <hr class="p-rule" />
 </div>

--- a/templates/partial/_knowledge_breadcrumbs.html
+++ b/templates/partial/_knowledge_breadcrumbs.html
@@ -45,16 +45,18 @@
               </li>
             </ol>
           </li>
-          <ol class="p-inline-list u-truncate u-margin-bottom-0-5rem">
-            {% for breadcrumb in breadcrumbs %}
-              <li class="p-inline-list__item p-knowledge-breadcrumbs__item">
-                {% if breadcrumb.href %}<a href="{{ breadcrumb.href }}">{{ breadcrumb.name }}</a>
-                {% else %}
-                  {{ breadcrumb.name }}
-                {% endif %}
-              </li>
-            {% endfor %}
-          </ol>
+          <li>
+            <ol class="p-inline-list u-truncate u-margin-bottom-0-5rem">
+              {% for breadcrumb in breadcrumbs %}
+                <li class="p-inline-list__item p-knowledge-breadcrumbs__item">
+                  {% if breadcrumb.href %}<a href="{{ breadcrumb.href }}">{{ breadcrumb.name }}</a>
+                  {% else %}
+                    {{ breadcrumb.name }}
+                  {% endif %}
+                </li>
+              {% endfor %}
+            </ol>
+          </li>
         </ol>
       {% endif %}
     </div>


### PR DESCRIPTION
## Done

- remove duplicate breadcrumbs in MD format
- use correct privacy policy link
- remove JS dependent blog section from MD format

flyby:
- clean up some broken privacy policy links in other pages

## QA

- Open the [DEMO](https://canonical-com-2841.demos.haus/knowledge/cloud-and-infrastructure/what-is-container-security?format=md)
- See the breadcrumbs aren't duplicated
- Check the `Canonical's Privacy Policy` points to our privacy policy
- See there is no `## Latest articles on container security` at the bottom of the page

## Issue / Card

Fixes
https://warthogs.atlassian.net/browse/WD-38119
https://warthogs.atlassian.net/browse/WD-38122