### PR TITLE
WD-37829: Add Ubuntu Pro chip to hero sections of Pro-connected pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "sass": "1.89.2",
     "use-query-params": "^2.2.1",
     "uuid": "^11.1.0",
-    "vanilla-framework": "4.50.0",
+    "vanilla-framework": "4.56.0",
     "venobox": "2.1.8",
     "yup": "^1.6.1"
   },

--- a/templates/data/spark-on-kubernetes.html
+++ b/templates/data/spark-on-kubernetes.html
@@ -22,10 +22,6 @@
       <div class="col-6 col-medium-3">
         <div class="p-section--shallow">
           <h1 class="u-no-margin--bottom">Run production-grade Apache Spark&reg; workloads on Kubernetes</h1>
-          <span class="p-chip--branded">
-            <i class="p-icon--circle-of-friends"></i>
-            <span class="p-chip__value">Supported with Ubuntu Pro</span>
-          </span>
         </div>
       </div>
       <div class="col-6 col-medium-3">

--- a/templates/data/spark-on-kubernetes.html
+++ b/templates/data/spark-on-kubernetes.html
@@ -22,6 +22,10 @@
       <div class="col-6 col-medium-3">
         <div class="p-section--shallow">
           <h1 class="u-no-margin--bottom">Run production-grade Apache Spark&reg; workloads on Kubernetes</h1>
+          <span class="p-chip--branded">
+            <i class="p-icon--circle-of-friends"></i>
+            <span class="p-chip__value">Supported with Ubuntu Pro</span>
+          </span>
         </div>
       </div>
       <div class="col-6 col-medium-3">

--- a/templates/data/spark/index.html
+++ b/templates/data/spark/index.html
@@ -2,6 +2,7 @@
 
 {% from "_macros/vf_pricing-block.jinja" import vf_pricing_block %}
 {% from 'macros/_macros-lite-video.jinja' import lite_video %}
+{% from "_macros/vf_hero.jinja" import vf_hero %}
 
 {% block meta_copydoc %}
   https://docs.google.com/document/d/1sM8pgyM-N8VK8fyHgMsW21PdXUiqYrdRkPkipIljNd0/edit
@@ -21,38 +22,49 @@
 
 {% block content %}
 
-  <section class="p-strip is-shallow u-no-padding--bottom">
-    <div class="p-section">
-      <div class="grid-row--50-50">
-        <div class="grid-col">
-          <div class="p-section--shallow">
-            <h1 class="u-no-margin--bottom">
-              Apache Spark<sup>&reg;</sup> operations, simplified
-            </h1>
-          </div>
-          <div class="p-section--shallow">
-            <p>
-              Secure and automate the deployment, maintenance and upgrades of Spark on Kubernetes. Run your big data clusters across private and public clouds.
-            </p>
-          </div>
-          <a class="p-button--positive js-invoke-modal"
-             aria-controls="data-spark-modal"
-             href="/contact-us">Contact us</a>
-        </div>
-        <div class="grid-col">
-          <div class="u-vertically-center u-aspect-ratio--16-9 p-image-wrapper u-container--background u-align--center p-strip">
-            {{ image(url="https://assets.ubuntu.com/v1/8baab06a-apache-spark-logo.png",
-                        alt="Apache Spark",
-                        width="143",
-                        height="186",
-                        hi_def=True,
-                        loading="auto") | safe
-            }}
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
+  {% call(slot) vf_hero(
+    title_text='Apache Spark<sup>&reg;</sup> operations, simplified',
+    chip_text='Supported with Ubuntu Pro',
+    layout='50/50',
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "text",
+          "content": "Secure and automate the deployment, maintenance and upgrades of Spark on Kubernetes. Run your big data clusters across private and public clouds."
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Contact us",
+            "attrs": {
+              "href": "/contact-us",
+              "class": "js-invoke-modal",
+              "aria-controls": "data-spark-modal"
+            }
+          }
+        }
+      },
+      {
+        "type": "image",
+        "item": {
+          "aspect_ratio": "16-9",
+          "is_highlighted": true,
+          "attrs": {
+            "src": "https://assets.ubuntu.com/v1/8baab06a-apache-spark-logo.png",
+            "alt": "Apache Spark",
+            "width": "143",
+            "height": "186"
+          }
+        }
+      }
+    ]
+  ) -%}
+  {% endcall -%}
 
   <section class="p-section">
     <div class="grid-row--50-50">

--- a/templates/juju/index.html
+++ b/templates/juju/index.html
@@ -941,42 +941,50 @@
     </div>
   </section>
 
-  {% call(slot) vf_rich_vertical_list(
-      title_text='Add visibility and compliance controls with JAAS.',
-      list_item_tick_style="tick"
-    ) -%}
-    {%- if slot == 'description' -%}
-      <p>
-        JAAS (Juju as a service) is your centralised enterprise control plane for Juju deployments.
-      </p>
-    {%- endif -%}
-    {%- if slot == 'list_item_1' -%}
-      Manage hundreds of Juju controllers
-    {%- endif -%}
-    {%- if slot == 'list_item_2' -%}
-      Add fine grained access controls.
-    {%- endif -%}
-    {%- if slot == 'list_item_3' -%}
-      Enable enhanced audit functionalities.
-    {%- endif -%}
-    {%- if slot == 'list_item_4' -%}
-      Protect deployments by having a smaller attack area.
-    {%- endif -%}
-    {%- if slot == 'cta' -%}
-      <a href="/jaas" class="p-button--positive">Discover JAAS</a>
-    {%- endif -%}
-    {%- if slot == 'image' -%}
-      <div class="u-embedded-media">
-        {{ image(url="https://assets.ubuntu.com/v1/ed078d85-juju-dashboard.gif",
-                  alt="",
-                  height="779",
-                  width="1200",
-                  hi_def=True,
-                  loading="lazy",) | safe
-        }}
-      </div>
-    {%- endif -%}
-  {% endcall -%}
+  {{ vf_rich_vertical_list(
+      title={"text": "Add visibility and compliance controls with JAAS."},
+      items=[
+        {
+          "type": "description",
+          "item": {
+            "type": "html",
+            "content": "<p>JAAS (Juju as a service) is your centralised enterprise control plane for Juju deployments.</p>"
+          }
+        },
+        {
+          "type": "list",
+          "item": {
+            "list_items": [
+              {"list_item_type": "tick", "content": "Manage hundreds of Juju controllers"},
+              {"list_item_type": "tick", "content": "Add fine grained access controls."},
+              {"list_item_type": "tick", "content": "Enable enhanced audit functionalities."},
+              {"list_item_type": "tick", "content": "Protect deployments by having a smaller attack area."}
+            ]
+          }
+        },
+        {
+          "type": "cta-block",
+          "item": {
+            "primary": {
+              "content_html": "Discover JAAS",
+              "attrs": {"href": "/jaas"}
+            }
+          }
+        }
+      ],
+      media={
+        "type": "image",
+        "ratio": {"large": "3-2", "medium_small": "3-2"},
+        "fit": "contain",
+        "attrs": {
+          "src": "https://assets.ubuntu.com/v1/ed078d85-juju-dashboard.gif",
+          "alt": "",
+          "width": "1200",
+          "height": "779",
+          "loading": "lazy"
+        }
+      }
+    ) }}
 
   <section class="p-section">
     <hr class="is-fixed-width" />

--- a/templates/mlops/feast.html
+++ b/templates/mlops/feast.html
@@ -1,5 +1,7 @@
 {% extends 'base_index.html' %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
 {% block title %}Feast feature store | MLOps{% endblock %}
 
 {% block meta_description %}
@@ -16,47 +18,56 @@
 
 {% block content %}
 
-  <section class="p-strip is-shallow">
-    <div class="row--25-75">
-      <div class="col u-no-padding--bottom p-section">
-        <div>
-          {{ image (
-          url="https://assets.ubuntu.com/v1/5dc85b16-feast-logo.png",
-          alt="",
-          width="852",
-          height="175",
-          hi_def=True,
-          loading="auto"
-          ) | safe
-          }}
-        </div>
-      </div>
-      <div class="col">
-        <div class="row">
-          <div class="col p-section--shallow">
-            <h1 class="u-no-margin--bottom">
-              Best in class feature store,
-              <br class="u-hide--small u-hide--medium" />
-              integrated into your MLOps stack
-            </h1>
-            <h2>Open source. Fully supported. Built for scale.</h2>
-          </div>
-          <div class="p-section--shallow">
-            <p>
-              Charmed Feast is Canonical's securely designed, production-ready feature store for machine learning. Deploy it in minutes alongside Charmed Kubeflow, and manage features across environments with confidence.
-            </p>
-          </div>
-        </div>
-
-        <hr class="p-rule--muted" />
-        <a class="p-button--positive"
-           href="https://documentation.ubuntu.com/charmed-feast/">Install Charmed Feast</a>
-        <a class="p-button js-invoke-modal"
-           href="/mlops/contact-us"
-           aria-controls="mlops-modal">Contact us</a>
-      </div>
-    </div>
-  </section>
+  {% call(slot) vf_hero(
+    title_text='Best in class feature store, <br class="u-hide--small u-hide--medium" /> integrated into your MLOps stack',
+    subtitle_text='Open source. Fully supported. Built for scale.',
+    chip_text='Supported with Ubuntu Pro',
+    layout='25/75',
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "html",
+          "content": '<p>Charmed Feast is Canonical\'s securely designed, production-ready feature store for machine learning. Deploy it in minutes alongside Charmed Kubeflow, and manage features across environments with confidence.</p><hr class="p-rule--muted" />'
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Install Charmed Feast",
+            "attrs": {
+              "href": "https://documentation.ubuntu.com/charmed-feast/"
+            }
+          },
+          "secondaries": [
+            {
+              "content_html": "Contact us",
+              "attrs": {
+                "href": "/mlops/contact-us",
+                "class": "js-invoke-modal",
+                "aria-controls": "mlops-modal"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  ) -%}
+    {%- if slot == 'signpost_image' -%}
+      {{ image (
+      url="https://assets.ubuntu.com/v1/5dc85b16-feast-logo.png",
+      alt="",
+      width="852",
+      height="175",
+      hi_def=True,
+      loading="auto"
+      ) | safe
+      }}
+    {%- endif -%}
+  {%- endcall -%}
 
   <section class="p-section">
     <div class="u-fixed-width">

--- a/templates/mlops/kubeflow/index.html
+++ b/templates/mlops/kubeflow/index.html
@@ -2,6 +2,7 @@
 
 {% from "_macros/vf_equal-heights.jinja" import vf_equal_heights %}
 {% from "_macros/vf_cta-section.jinja" import vf_cta_section %}
+{% from "_macros/vf_hero.jinja" import vf_hero %}
 
 {% block title %}Kubeflow | MLOps{% endblock %}
 
@@ -21,33 +22,42 @@
 
 {% block content %}
 
-  <section class="p-section--hero">
-    <div class="grid-row">
-      <div class="grid-col-4 grid-col-medium-2">
-        <div class="p-section--shallow">
-          <h1>
-            Kubeflow AI and MLOps
-            <br class="u-hide--small" />
-            at any scale
-          </h1>
-        </div>
-      </div>
-      <div class="grid-col-4 grid-col-medium-2">
-        <div class="p-section--shallow">
-          <p>
-            <strong>Enterprise-ready Charmed Kubeflow, the fully supported MLOps platform for any cloud.</strong>
-            Charmed Kubeflow is Canonical's enterprise-ready MLOps platform. Deploy, scale, and manage AI workflows across clouds, VMs, or bare metal. A complete solution for sophisticated data science labs. Upgrades and security updates – all supported in the free, open source distribution.
-          </p>
-        </div>
-        <div class="p-cta-block">
-          <a href="/contact-us"
-             class="p-button--positive js-invoke-modal"
-             aria-controls="mlops-modal">Get in touch</a>
-          <a href="https://ubuntu.com/engage/mlops-guide">Read our guide to MLOps&nbsp;&rsaquo;</a>
-        </div>
-      </div>
-    </div>
-  </section>
+  {% call(slot) vf_hero(
+    title_text='Kubeflow AI and MLOps <br class="u-hide--small" /> at any scale',
+    chip_text='Supported with Ubuntu Pro',
+    layout='50/50',
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "html",
+          "content": "<p><strong>Enterprise-ready Charmed Kubeflow, the fully supported MLOps platform for any cloud.</strong> Charmed Kubeflow is Canonical's enterprise-ready MLOps platform. Deploy, scale, and manage AI workflows across clouds, VMs, or bare metal. A complete solution for sophisticated data science labs. Upgrades and security updates – all supported in the free, open source distribution.</p>"
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Get in touch",
+            "attrs": {
+              "href": "/contact-us",
+              "class": "js-invoke-modal",
+              "aria-controls": "mlops-modal"
+            }
+          },
+          "link": {
+            "content_html": "Read our guide to MLOps&nbsp;&rsaquo;",
+            "attrs": {
+              "href": "https://ubuntu.com/engage/mlops-guide"
+            }
+          }
+        }
+      }
+    ]
+  ) -%}
+  {%- endcall -%}
 
   {% call(slot) vf_equal_heights(
     title_text="Why choose Charmed Kubeflow?",

--- a/templates/mlops/mlflow.html
+++ b/templates/mlops/mlflow.html
@@ -1,6 +1,4 @@
 {% extends 'base_index.html' %}
-
-{% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 
 {% block title %}MLflow | MLOps{% endblock %}
@@ -32,7 +30,7 @@
         "padding": "shallow",
         "item": {
           "type": "text",
-          "content": "Charmed MFlow is a lightweight and securely designed machine learning platform for any developer. It can be deployed on your infrastructure of choice, and is backed by expert support."
+          "content": "Charmed MLFlow is a lightweight and securely designed machine learning platform for any developer. It can be deployed on your infrastructure of choice, and is backed by expert support."
         }
       },
       {

--- a/templates/mlops/mlflow.html
+++ b/templates/mlops/mlflow.html
@@ -1,6 +1,7 @@
 {% extends 'base_index.html' %}
 
 {% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
+{% from "_macros/vf_hero.jinja" import vf_hero %}
 
 {% block title %}MLflow | MLOps{% endblock %}
 
@@ -20,9 +21,45 @@
 
 {% block content %}
 
-<section class="p-strip is-shallow">
-  <div class="grid-row--25-75">
-    <div class="grid-col p-section--shallow">
+  {% call(slot) vf_hero(
+    title_text='MLflow made easy',
+    subtitle_text='A seamless start to your machine learning journey with open source',
+    chip_text='Supported with Ubuntu Pro',
+    layout='25/75',
+    blocks=[
+      {
+        "type": "description",
+        "padding": "shallow",
+        "item": {
+          "type": "text",
+          "content": "Charmed MFlow is a lightweight and securely designed machine learning platform for any developer. It can be deployed on your infrastructure of choice, and is backed by expert support."
+        }
+      },
+      {
+        "type": "cta-block",
+        "padding": "shallow",
+        "item": {
+          "primary": {
+            "content_html": "Read about lightweight ML with MLflow",
+            "attrs": {
+              "href": "https://ubuntu.com/engage/lightweight-ml-mlflow"
+            }
+          },
+          "secondaries": [
+            {
+              "content_html": "Contact us",
+              "attrs": {
+                "href": "/mlops/contact-us",
+                "class": "js-invoke-modal",
+                "aria-controls": "mlops-modal"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  ) -%}
+    {%- if slot == 'signpost_image' -%}
       {{ image (
       url="https://assets.ubuntu.com/v1/da0946e1-mlflow.png",
       alt="MLflow",
@@ -32,25 +69,12 @@
       loading="auto",
       ) | safe
       }}
-    </div>
-    <div class="grid-col">
-      <div class="p-section-shallow">
-        <h1 class="u-no-margin--bottom u-no-padding--top">MLflow made easy</h1>
-        <p class="p-heading--2">A seamless start to your machine learning journey with open source</p>
-      </div>
-      <p>
-        Charmed MFlow is a lightweight and securely designed machine learning platform for any developer. It can be
-        deployed on your infrastructure of choice, and is backed by expert support.
-      </p>
-      <a class="p-button--positive" href="https://ubuntu.com/engage/lightweight-ml-mlflow">Read about lightweight ML
-        with MLflow</a>
-      <a class="p-button js-invoke-modal" aria-controls="mlops-modal" href="/mlops/contact-us">Contact us</a>
-    </div>
-  </div>
+    {%- endif -%}
+  {%- endcall -%}
+
   <div class="u-fixed-width u-no-padding u-hide--small u-hide--medium">
     <img class="u-suru-banner-image" src="https://assets.ubuntu.com/v1/7f34ade9-website_suru_25.jpg" alt="" />
   </div>
-</section>
 
 <section class="p-section">
   <div class="grid-row--50-50">

--- a/templates/mlops/mlflow.html
+++ b/templates/mlops/mlflow.html
@@ -59,10 +59,10 @@
   ) -%}
     {%- if slot == 'signpost_image' -%}
       {{ image (
-      url="https://assets.ubuntu.com/v1/da0946e1-mlflow.png",
+      url="https://assets.ubuntu.com/v1/d30b3887-mlflow_hero.png",
       alt="MLflow",
-      width="94",
-      height="37",
+      width="852",
+      height="852",
       hi_def=True,
       loading="auto",
       ) | safe

--- a/yarn.lock
+++ b/yarn.lock
@@ -5960,10 +5960,10 @@ vanilla-framework@4.35.0:
   resolved "https://registry.npmjs.org/vanilla-framework/-/vanilla-framework-4.35.0.tgz"
   integrity sha512-vF8M9vsXiOpJEonFXiTVhY0rXOzNtoWpkhBcCVpyPb4+oHBx0/FaNcX5GAiQpfdT6Q/AAeRYyWwRUDObq6R8uw==
 
-vanilla-framework@4.50.0:
-  version "4.50.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.50.0.tgz#510a56d73b876eb357deb95a6495a8eef5113c9b"
-  integrity sha512-eDGesUKYO0v+uIsRNHvg8XWcb+do0n6SYsLt/P7XVZSneUFvGbAx702mZXma/BliOI4tygB0EGZ/6bXuTsTTPA==
+vanilla-framework@4.56.0:
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.56.0.tgz#237625da8eded879af803a51ae707d43d6f2bc66"
+  integrity sha512-FyMKeYePuhEEXeuvZj18qqZN6u4eHgTvclwCfLBh01OF9dsIroTklP2GGVdlGbJZHZSlbRRbVGIRcVhyjY0NBg==
 
 venobox@2.1.8:
   version "2.1.8"


### PR DESCRIPTION
## Done

- Added the branded "Ubuntu Pro" chip to the hero sections.
- Bumped `vanilla-framework` from `4.50.0` -> `4.56.0`.

## QA
Check relevant pages are covered from [sheet](https://docs.google.com/spreadsheets/d/1LsN8r_BGN7PDRU9Eo9o-cUHkZgRANMAT-HIwssdNxdI/edit?gid=0#gid=0) .
- **Kubeflow** -- demo: https://canonical-com-2842.demos.haus/mlops/kubeflow - live: https://canonical.com/mlops/kubeflow
- **MLflow** -- demo: https://canonical-com-2842.demos.haus/mlops/mlflow - live: https://canonical.com/mlops/mlflow
- **Feast** -- demo: https://canonical-com-2842.demos.haus/mlops/feast - live: https://canonical.com/mlops/feast
- **Apache Spark ** -- demo: https://canonical-com-2842.demos.haus/data/spark live:https://canonical.com/data/spark

Check that each hero renders identically to production apart from the new "Supported with Ubuntu Pro" branded chip (circle-of-friends icon), and that titles, subtitles, descriptions, CTAs, links and the MLflow suru banner are unchanged.
## Notes
### Videos

Videos are intentionally kept in the deprecated `image` slot rather than converted to blocks, tracked in https://warthogs.atlassian.net/browse/WD-38111. (None of the heroes changed in this PR contain videos.)
### Spacing
Spacing on https://canonical-com-2842.demos.haus/mlops/mlflow  is a bit different because of default spacing that comes with hero pattern
## Issue

Fixes WD-37829.
