### PR TITLE
Knowledgehub sitemap fixes

### DIFF
--- a/templates/knowledge/_base_knowledge_markdown.html
+++ b/templates/knowledge/_base_knowledge_markdown.html
@@ -19,7 +19,7 @@
       "name": {{ title | tojson }},
       "headline": {{ title | tojson }},
       "description": {{ description | tojson }},
-      "url": "{{ request.url }}",
+      "url": {{ request.base_url | tojson }},
       "publisher": {
         "@type": "Organization",
         "name": "Canonical",

--- a/templates/knowledge/_base_knowledge_markdown.html
+++ b/templates/knowledge/_base_knowledge_markdown.html
@@ -5,8 +5,30 @@
 {% from "_macros/vf_cta-section.jinja" import vf_cta_section %}
 {% from "_macros/vf_newsletter-signup.jinja" import vf_newsletter_signup %}
 
+{% set category_slug = category | lower | replace('/', '-') | replace(' ', '-') %}
+
 {% block title %}{{ title }} | Knowledge{% endblock title %}
 {% block head_extra %}{{ head_extra }}{% endblock head_extra %}
+
+{% block extra_metatags %}
+  {# djlint: off #}
+  <script type="application/ld+json" nonce="{{ csp_nonce }}">
+    {
+      "@context": "https://schema.org",
+      "@type": "TechArticle",
+      "name": {{ title | tojson }},
+      "headline": {{ title | tojson }},
+      "description": {{ description | tojson }},
+      "url": "{{ request.url }}",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Canonical",
+        "url": "https://canonical.com"
+      }
+    }
+  </script>
+  {# djlint: on #}
+{% endblock extra_metatags %}
 
 {% block meta_description %}{{ description }}{% endblock meta_description %}
 {% block meta_copydoc %}{{ copydoc }}{% endblock meta_copydoc %}
@@ -15,7 +37,6 @@
 
   {% block content %}
 
-  {% set category_slug = category | lower | replace('/', '-') | replace(' ', '-') %}
   {% set breadcrumbs = [
     {"name": category, "href": "/knowledge/" + category_slug},
     {"name": breadcrumb }

--- a/templates/knowledge/sitemap.xml
+++ b/templates/knowledge/sitemap.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {% for section in sections %}
-  <url>
-    <loc>https://canonical.com/knowledge/{{ section.slug }}</loc>
-    <changefreq>monthly</changefreq>
-  </url>
+    {% if section.articles|length > 0 %}
+      <url>
+        <loc>https://canonical.com/knowledge/{{ section.slug }}</loc>
+        <changefreq>monthly</changefreq>
+      </url>
   
-  {% for article in section.articles %}
-  <url>
-    <loc>https://canonical.com{{ article.url }}</loc>
-    <changefreq>monthly</changefreq>
-  </url>
-  {% endfor %}
+      {% for article in section.articles %}
+      <url>
+        <loc>https://canonical.com{{ article.url }}</loc>
+        <changefreq>monthly</changefreq>
+      </url>
+      {% endfor %}
+    {% endif %}
   {% endfor %}
 </urlset>

--- a/templates/knowledge/sitemap.xml
+++ b/templates/knowledge/sitemap.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://canonical.com/knowledge</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+
   {% for section in sections %}
     {% if section.articles|length > 0 %}
       <url>

--- a/templates/sitemap-links.xml
+++ b/templates/sitemap-links.xml
@@ -36,4 +36,8 @@
     <loc>https://canonical.com/company</loc>
     <changefreq>monthly</changefreq>
   </url>
+  <url>
+    <loc>https://canonical.com/knowledge</loc>
+    <changefreq>monthly</changefreq>
+  </url>
 </urlset>


### PR DESCRIPTION
## Done

- only add sections with articles to /knowledge/sitemap.xml
- add /knowledge index to sitemaps
- add JSON-LD for knowledge hub pages

## QA

- Open the [knowledge sitemap](https://canonical-com-2843.demos.haus/knowledge/sitemap.xml)
- See it contains https://canonical.com/knowledge
- See it doesn't contain empty such a https://canonical.com/knowledge/company (more can be found in the [current live sitemap](https://canonical.com/knowledge/sitemap.xml))
- Go to a knowledge hub page (ex. https://canonical-com-2843.demos.haus/knowledge/cloud-and-infrastructure/what-is-container-security)
- Inspect the page html (crtl+u) and find the JSON-LD (find 'ld+json')
- Check there is one for 'TechArticle' and the the content (title, description, etc) match the current page


## Issue / Card

Fixes
https://warthogs.atlassian.net/browse/WD-38118
https://warthogs.atlassian.net/browse/WD-38120
https://warthogs.atlassian.net/browse/WD-38121

