### PR TITLE
feat: add networking contact us page

### DIFF
--- a/templates/solutions/networking/contact-us.html
+++ b/templates/solutions/networking/contact-us.html
@@ -1,0 +1,19 @@
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1QY8VPRi1CMAcrSozevNlRsseUiy2rwZBq8BU2o7J1LM
+{% endblock meta_copydoc %}
+
+{% block title %}Canonical Networking Products Contact Form{% endblock %}
+
+{% block meta_description %}
+  Canonical Networking Products include: OVN and MicroOVN software-defined network orchestration for Canonical Openstack, MicroCloud and Kubernetes, as well as Ubuntu and Ubuntu Core for base operating system layer of Smart NICs, DPUs, routers and switches. Contact us for more information.
+{% endblock %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block content %}
+  {{ load_form("/solutions/networking/contact-us", isModal=false) | safe }}
+{% endblock content %}

--- a/templates/solutions/networking/form-data.json
+++ b/templates/solutions/networking/form-data.json
@@ -1,0 +1,64 @@
+{
+  "form": {
+    "/solutions/networking/contact-us": {
+      "templatePath": "/solutions/networking/contact-us.html",
+      "isModal": false,
+      "formData": {
+        "title": "Get in touch with the Networking team",
+        "introText": "",
+        "formId": "7775",
+        "returnUrl": "/solutions/networking/contact-us#contact-form-success",
+        "product": "networking"
+      },
+      "fieldsets": [
+        {
+          "title": "Which networking product are you interested in?",
+          "id": "networking-product",
+          "inputName": "networking-product",
+          "inputType": "checkbox",
+          "isRequired": true,
+          "noCommentsFromLead": false,
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "ovn-and-ovs",
+              "label": "OVN and OVS",
+              "value": "OVN and OVS"
+            },
+            {
+              "type": "checkbox",
+              "id": "sonic-on-switches",
+              "label": "Long-term support for SONiC on switches",
+              "value": "Long-term support for SONiC on switches"
+            },
+            {
+              "type": "checkbox",
+              "id": "embedded-ubuntu",
+              "label": "Embedding Ubuntu or Ubuntu Core in networking devices",
+              "value": "Embedding Ubuntu or Ubuntu Core in networking devices"
+            },
+            {
+              "type": "checkbox",
+              "id": "other",
+              "label": "Other",
+              "value": "Other"
+            }
+          ]
+        },
+        {
+          "title": "Fill in this form and a member of our team will be in touch shortly.",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Phone number",
+              "isRequired": false
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/templates/solutions/networking/form-data.json
+++ b/templates/solutions/networking/form-data.json
@@ -5,7 +5,7 @@
       "isModal": false,
       "formData": {
         "title": "Get in touch with the Networking team",
-        "introText": "",
+        "introText": null,
         "formId": "7775",
         "returnUrl": "/solutions/networking/contact-us#contact-form-success",
         "product": "networking"


### PR DESCRIPTION
## Done

 - Added new page `/solutions/networking/contact-us` with a "Get in touch" form (Marketo ID 7775)
 - [Copydoc](https://docs.google.com/document/d/1QY8VPRi1CMAcrSozevNlRsseUiy2rwZBq8BU2o7J1LM)
 - Base on the discussion:
      - "Get in touch with the Networking team" is the page header and "Fill in this form and a member of our team will be in touch shortly" is the section title ([see](https://docs.google.com/document/d/1QY8VPRi1CMAcrSozevNlRsseUiy2rwZBq8BU2o7J1LM/edit?disco=AAACE9Gs4u4))
      - "Phone number" should be render at the bottom ([see](https://docs.google.com/document/d/1QY8VPRi1CMAcrSozevNlRsseUiy2rwZBq8BU2o7J1LM/edit?disco=AAACE9Gs4u0))

## QA

- Open the https://canonical-com-2847.demos.haus/solutions/networking/contact-us
- Verify the copy doc changes are applied correctly.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37752

