### PR TITLE
fix: guard modal lookups on pages without a modal

### DIFF
--- a/static/js/modals.js
+++ b/static/js/modals.js
@@ -166,8 +166,8 @@
   // Handle Pagination
   let contactIndex = 1;
   const contactModal = document.querySelector(".p-modal");
-  const modalPaginationButtons = contactModal.querySelectorAll(".pagination a");
-  const paginationContent = contactModal.querySelectorAll(".js-pagination");
+  const modalPaginationButtons = contactModal?.querySelectorAll(".pagination a");
+  const paginationContent = contactModal?.querySelectorAll(".js-pagination");
 
   function setState(index) {
     contactIndex = index;
@@ -175,7 +175,7 @@
   }
 
   function render() {
-    if (paginationContent.length) {
+    if (paginationContent?.length) {
       const currentContent = contactModal.querySelector(
         ".js-pagination--" + contactIndex
       );
@@ -186,7 +186,7 @@
     }
   }
 
-  modalPaginationButtons.forEach(function (modalPaginationButton) {
+  modalPaginationButtons?.forEach(function (modalPaginationButton) {
     modalPaginationButton.addEventListener("click", function (e) {
       e.preventDefault();
       /** @type {HTMLElement} */


### PR DESCRIPTION
## Done

Guarded the `.p-modal` lookups in `static/js/modals.js` so the script doesn't throw on pages where the form isn't in a modal

## QA

- Open the [DEMO](https://canonical-com-2849.demos.haus/solutions/networking/contact-us)
- verify the "Cannot read properties of null" error is solve
- Submit the form and confirm `Comments_from_lead__c` contains the question and selected answers, and no `networking-product` fields are sent
- Check a modal form (for example [/solutions/telco](https://canonical-com-2849.demos.haus/solutions/telco#get-in-touch)) still opens, paginates and submits correctly

## Issue / Card

#2848


