### PR TITLE
feat: Update early careers CTA links

### DIFF
--- a/templates/careers/early-careers.html
+++ b/templates/careers/early-careers.html
@@ -33,7 +33,7 @@
     "primary": {
     "content_html": "Discover our roles",
     "attrs": {
-    "href": "/careers"
+    "href": "/careers/all"
     }
     },
     }
@@ -460,7 +460,7 @@
     "primary": {
     "content_html": "Discover our roles",
     "attrs": {
-    "href": "/careers"
+    "href": "/careers/all"
     }
     },
     }


### PR DESCRIPTION
## Done

- Update both "Discover our roles" CTAs in `canonical.com/careers/early-careers` to point to `canonical.com/careers/all` instead of `canonical.com/careers`

## QA

- Open the [Demo Early Careers Page](https://canonical-com-2851.demos.haus/careers/early-careers)
- Alternatively, check out this feature branch
- Run the site with `dotrun`
- View the relevant page locally in your web browser at: `http://localhost:8002/careers/early-careers`
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Confirm that both "Discover our roles" CTAs in the hero and end sections point to `canonical.com/careers/all`

## Issue / Card

**Copy doc:** https://docs.google.com/document/d/1oytb3L_93susYbg7AaQdeCECrP2ne4CG-6jS5QLqlDs/edit?tab=t.jijjhiya0no5
**Jira ticket:** https://warthogs.atlassian.net/browse/WD-38162

Fixes [WD-38162](https://warthogs.atlassian.net/browse/WD-38162)

## Screenshots

For the following screenshots, note the CTA being hovered by the cursor and the link showing up on the bottom left of the browser.

|              | Before PR                                                                                                                            | After PR                                                                                                                             |
| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
| Hero section | <img width="2879" height="1678" alt="image" src="https://github.com/user-attachments/assets/e83a63aa-cbd4-4b82-bcd3-1d26cc317f14" /> | <img width="2879" height="1678" alt="image" src="https://github.com/user-attachments/assets/a3e04f9f-c1a7-4c2a-8f6f-5ddbe0ce2521" /> |
| End section  | <img width="2879" height="1678" alt="image" src="https://github.com/user-attachments/assets/ec9f24c2-34fb-4255-a585-c76d79c1e4d1" /> | <img width="2879" height="1678" alt="image" src="https://github.com/user-attachments/assets/879e0b18-b637-42ac-bf2c-f81113ca6643" /> |

[WD-38162]: https://warthogs.atlassian.net/browse/WD-38162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
