### PR TITLE
fix(WD-38174): remove bottom border after form title

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 - Open the [DEMO](__DEMO_URL__/)
 - Alternatively, check out this feature branch
-- Run the site using the command `./run serve`
+- Run the site using the command `dotrun`
 - View the site locally in your web browser at: http://0.0.0.0:8002/
 - Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
 - [List additional steps to QA the new features or prove the bug has been resolved]

--- a/static/sass/_pattern_forms.scss
+++ b/static/sass/_pattern_forms.scss
@@ -65,6 +65,13 @@
   }
 
   overflow-x: hidden;
+
+  // Remove the Vanilla `%vf-pseudo-border--bottom` ::after border that
+  // `.p-modal__header` extends; the `u-border-bottom-0` utility only clears
+  // `border-bottom`, not this pseudo-element.
+  .p-modal__header::after {
+    display: none;
+  }
 }
 
 .p-fieldset-section {

--- a/templates/shared/forms/form-template.html
+++ b/templates/shared/forms/form-template.html
@@ -6,7 +6,7 @@
          role="dialog"
          aria-labelledby="modal-title"
          aria-describedby="modal-description">
-        <header class="p-modal__header u-display-block u-border-bottom-0 u-overflow-auto u-padding-left-1-5rem u-padding-top-1rem"
+        <header class="p-modal__header u-display-block u-overflow-auto u-padding-left-1-5rem u-padding-top-1rem"
                >
           <button class="p-modal__close p-modal-close-button js-close-modal u-margin-left-negative-1rem"
                   aria-controls="{{ modalId }}"


### PR DESCRIPTION
## Done

- Removed bottom border
- (drive-by): Updated pull request template to replace the legacy `./run serve` with `dotrun`

## QA

- Open the [DEMO](https://canonical-com-2853.demos.haus/#get-in-touch)
- Alternatively, check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002#get-in-touch
- Verify the redundant bottom border from the title is gone.

## Issue / Card

Fixes [WD-38174](https://warthogs.atlassian.net/browse/WD-38174)

## Screenshots

**Before**

<img width="1261" height="334" alt="image" src="https://github.com/user-attachments/assets/46be8423-46a2-4e7f-842a-67e7a7e7c2c5" />

**After**

<img width="1261" height="334" alt="image" src="https://github.com/user-attachments/assets/f42eedab-f793-4376-816b-b9c1970e0edc" />



[WD-38174]: https://warthogs.atlassian.net/browse/WD-38174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
