### PR TITLE
Add MAAS product pricing centrally

### DIFF
--- a/products.yaml
+++ b/products.yaml
@@ -16,6 +16,85 @@ maas:
   operatingSystem: "Linux"
   applicationCategory: "BusinessApplication"
   url: "https://canonical.com/maas"
+  pricing:
+    standaloneSupport:
+      title: "MAAS standalone support pricing"
+      billing:
+        cadence: "annual"
+        unit: "per managed machine"
+      tiers:
+        - name: "Self-support"
+          price: "Free"
+          summary: "Free for all machines"
+          cta:
+            text: "Install MAAS"
+            url: "https://canonical.com/maas/docs/how-to-get-maas-up-and-running"
+          features:
+            - name: "High availability (HA) support"
+              included: false
+            - name: "Role based access control (RBAC)"
+              included: false
+            - name: "Knowledge Base"
+              included: false
+            - name: "Response time - SLA Sev 1"
+              included: false
+            - name: "Phone and ticket support"
+              included: false
+        - name: "Essential"
+          price: "$30"
+          summary: "per year, per managed machine"
+          cta:
+            text: "Contact us"
+            url: "https://canonical.com/maas/contact-us"
+          features:
+            - name: "High availability (HA) support"
+              included: true
+            - name: "Role based access control (RBAC)"
+              included: true
+            - name: "Knowledge Base"
+              included: true
+            - name: "Response time - SLA Sev 1"
+              included: false
+            - name: "Phone and ticket support"
+              included: false
+        - name: "Standard"
+          price: "$50"
+          summary: "per year, per managed machine"
+          cta:
+            text: "Contact us"
+            url: "https://canonical.com/maas/contact-us"
+          features:
+            - name: "High availability (HA) support"
+              included: true
+            - name: "Role based access control (RBAC)"
+              included: true
+            - name: "Knowledge Base"
+              included: true
+            - name: "Response time - SLA Sev 1"
+              included: true
+              value: "4 hours"
+            - name: "Phone and ticket support"
+              included: true
+              value: "Office hours"
+        - name: "Advanced"
+          price: "$100"
+          summary: "per year, per managed machine"
+          cta:
+            text: "Contact us"
+            url: "https://canonical.com/maas/contact-us"
+          features:
+            - name: "High availability (HA) support"
+              included: true
+            - name: "Role based access control (RBAC)"
+              included: true
+            - name: "Knowledge Base"
+              included: true
+            - name: "Response time - SLA Sev 1"
+              included: true
+              value: "1 hour"
+            - name: "Phone and ticket support"
+              included: true
+              value: "24 hours a day, everyday"
 microk8s:
   name: "MicroK8s"
   description: "High availability Kubernetes with autonomous clusters. MicroK8s is the simplest production-grade conformant K8s for edge and IoT, on Linux, Windows, and macOS."

--- a/products.yaml
+++ b/products.yaml
@@ -94,7 +94,7 @@ maas:
               value: "1 hour"
             - name: "Phone and ticket support"
               included: true
-              value: "24 hours a day, everyday"
+              value: "24 hours a day, every day"
 microk8s:
   name: "MicroK8s"
   description: "High availability Kubernetes with autonomous clusters. MicroK8s is the simplest production-grade conformant K8s for edge and IoT, on Linux, Windows, and macOS."

--- a/templates/maas/index.html
+++ b/templates/maas/index.html
@@ -22,6 +22,21 @@
 {% endblock %}
 
 {% block extra_metatags %}
+  {% set maas_support_pricing = products_yaml.maas.pricing.standaloneSupport %}
+  {% set maas_support_offers = namespace(items=[]) %}
+  {% for tier in maas_support_pricing.tiers %}
+    {% set price = 0 if tier.price == 'Free' else tier.price | replace('$', '') | float %}
+    {% set maas_support_offers.items = maas_support_offers.items + [
+      {
+        '@type': 'Offer',
+        'name': tier.name,
+        'description': tier.summary,
+        'url': tier.cta.url,
+        'price': price,
+        'priceCurrency': 'USD'
+      }
+    ] %}
+  {% endfor %}
   <script type="application/ld+json" nonce="{{ csp_nonce }}">
     {
       "@context": "https://schema.org",
@@ -30,7 +45,15 @@
       "description": {{ products_yaml.maas.description | tojson }},
       "operatingSystem": {{ products_yaml.maas.operatingSystem | tojson }},
       "applicationCategory": {{ products_yaml.maas.applicationCategory | tojson }},
-      "url": {{ products_yaml.maas.url | tojson }}
+      "url": {{ products_yaml.maas.url | tojson }},
+      "offers": {
+        "@type": "AggregateOffer",
+        "priceCurrency": "USD",
+        "lowPrice": 0,
+        "highPrice": 100,
+        "offerCount": {{ maas_support_offers.items | length }},
+        "offers": {{ maas_support_offers.items | tojson }}
+      }
     }
   </script>
 {% endblock %}
@@ -592,7 +615,7 @@
     },
     ]
     },
-    ],) 
+    ],)
   }}
 
 {{ vf_basic_section(
@@ -653,129 +676,40 @@
   ]
 ) }}
 
+  {% set maas_support_pricing = products_yaml.maas.pricing.standaloneSupport %}
+  {% set maas_support_tiers = namespace(tiers=[]) %}
+  {% for tier in maas_support_pricing.tiers %}
+    {% set tier_offerings = namespace(items=[]) %}
+    {% for feature in tier.features %}
+      {% set list_item_content_html = feature.name %}
+      {% if feature.value is defined %}
+        {% set list_item_content_html = feature.name ~ ': ' ~ feature.value %}
+      {% endif %}
+      {% set tier_offerings.items = tier_offerings.items + [
+        {
+          'list_item_style': 'ticked' if feature.included else 'crossed',
+          'list_item_content_html': list_item_content_html
+        }
+      ] %}
+    {% endfor %}
+    {% set tier_price_explanation = 'for all machines' if loop.first else maas_support_pricing.billing.cadence ~ ', ' ~ maas_support_pricing.billing.unit %}
+    {% set tier_cta_html = ('<a href="' ~ tier.cta.url ~ '">' ~ tier.cta.text ~ '&nbsp;&rsaquo;</a>') if loop.first else ('<a href="' ~ tier.cta.url ~ '" class="js-invoke-modal" aria-controls="maas-contact-form">' ~ tier.cta.text ~ '&nbsp;&rsaquo;</a>') %}
+    {% set maas_support_tiers.tiers = maas_support_tiers.tiers + [
+      {
+        'tier_name_text': tier.name,
+        'tier_price_text': tier.price,
+        'tier_price_explanation': tier_price_explanation,
+        'tier_label_text': 'What’s included',
+        'tier_offerings': tier_offerings.items,
+        'cta_html': tier_cta_html | safe
+      }
+    ] %}
+  {% endfor %}
+
   {% call(slot) vf_pricing_block(
-    title_text='MAAS standalone support pricing',
+    title_text=maas_support_pricing.title,
     top_rule_variant="highlighted",
-    tiers=[
-    {
-    'tier_name_text': 'Self-support',
-    'tier_price_text': 'Free',
-    'tier_price_explanation': 'for all machines',
-    'tier_label_text': 'What’s included',
-    'tier_offerings': [
-    {
-    'list_item_style': 'crossed',
-    'list_item_content_html': 'High availability (HA) support'
-    },
-    {
-    'list_item_style': 'crossed',
-    'list_item_content_html': 'Role based access control (RBAC)'
-    },
-    {
-    'list_item_style': 'crossed',
-    'list_item_content_html': 'Knowledge Base'
-    },
-    {
-    'list_item_style': 'crossed',
-    'list_item_content_html': 'Response time - SLA Sev 1'
-    },
-    {
-    'list_item_style': 'crossed',
-    'list_item_content_html': 'Phone and ticket support'
-    }
-    ],
-    'cta_html': '<a href="/maas/docs/how-to-get-maas-up-and-running">Install MAAS&nbsp;&rsaquo;</a>'
-    },
-
-    {
-    'tier_name_text': 'Essential',
-    'tier_price_text': '$30',
-    'tier_price_explanation': 'per year, per managed machine',
-    'tier_label_text': 'What’s included',
-    'tier_offerings': [
-    {
-    'list_item_style': 'ticked',
-    'list_item_content_html': 'High availability (HA) support'
-    },
-    {
-    'list_item_style': 'ticked',
-    'list_item_content_html': 'Role based access control (RBAC)'
-    },
-    {
-    'list_item_style': 'ticked',
-    'list_item_content_html': 'Knowledge Base'
-    },
-    {
-    'list_item_style': 'crossed',
-    'list_item_content_html': 'Response time - SLA Sev 1'
-    },
-    {
-    'list_item_style': 'crossed',
-    'list_item_content_html': 'Phone and ticket support'
-    }
-    ],
-    'cta_html': '<a href="/maas/contact-us" class="js-invoke-modal" aria-controls="maas-contact-form">Contact us&nbsp;&rsaquo;</a>'
-    },
-
-    {
-    'tier_name_text': 'Standard',
-    'tier_price_text': '$50',
-    'tier_price_explanation': 'per year, per managed machine',
-    'tier_label_text': 'What’s included',
-    'tier_offerings': [
-    {
-    'list_item_style': 'ticked',
-    'list_item_content_html': 'High availability (HA) support'
-    },
-    {
-    'list_item_style': 'ticked',
-    'list_item_content_html': 'Role based access control (RBAC)'
-    },
-    {
-    'list_item_style': 'ticked',
-    'list_item_content_html': 'Knowledge Base'
-    },
-    {
-    'list_item_style': 'ticked',
-    'list_item_content_html': 'Response time - SLA Sev 1: 4 hours'
-    },
-    {
-    'list_item_style': 'ticked',
-    'list_item_content_html': 'Phone and ticket support: Office hours'
-    }
-    ],
-    'cta_html': '<a href="/maas/contact-us" class="js-invoke-modal" aria-controls="maas-contact-form">Contact us&nbsp;&rsaquo;</a>'
-    },
-    {
-    'tier_name_text': 'Advanced',
-    'tier_price_text': '$100',
-    'tier_price_explanation': 'per year, per managed machine',
-    'tier_label_text': 'What’s included',
-    'tier_offerings': [
-    {
-    'list_item_style': 'ticked',
-    'list_item_content_html': 'High availability (HA) support'
-    },
-    {
-    'list_item_style': 'ticked',
-    'list_item_content_html': 'Role based access control (RBAC)'
-    },
-    {
-    'list_item_style': 'ticked',
-    'list_item_content_html': 'Knowledge Base'
-    },
-    {
-    'list_item_style': 'ticked',
-    'list_item_content_html': 'Response time - SLA Sev 1: 1 hour'
-    },
-    {
-    'list_item_style': 'ticked',
-    'list_item_content_html': 'Phone and ticket support:<br /> 24 hours a day, everyday'
-    }
-    ],
-    'cta_html': '<a href="/maas/contact-us" class="js-invoke-modal" aria-controls="maas-contact-form">Contact us&nbsp;&rsaquo;</a>'
-    }
-    ]
+    tiers=maas_support_tiers.tiers
     ) -%}
     {%- if slot == 'section_description' -%}
       <p>Choose from a wide range of support options to best suit your needs and deployments.</p>

--- a/templates/maas/index.html
+++ b/templates/maas/index.html
@@ -692,7 +692,7 @@
         }
       ] %}
     {% endfor %}
-    {% set tier_price_explanation = 'for all machines' if loop.first else maas_support_pricing.billing.cadence ~ ', ' ~ maas_support_pricing.billing.unit %}
+    {% set tier_price_explanation = 'for all machines' if loop.first else tier.summary %}
     {% set tier_cta_html = ('<a href="' ~ tier.cta.url ~ '">' ~ tier.cta.text ~ '&nbsp;&rsaquo;</a>') if loop.first else ('<a href="' ~ tier.cta.url ~ '" class="js-invoke-modal" aria-controls="maas-contact-form">' ~ tier.cta.text ~ '&nbsp;&rsaquo;</a>') %}
     {% set maas_support_tiers.tiers = maas_support_tiers.tiers + [
       {

--- a/templates/maas/index.html
+++ b/templates/maas/index.html
@@ -49,8 +49,8 @@
       "offers": {
         "@type": "AggregateOffer",
         "priceCurrency": "USD",
-        "lowPrice": 0,
-        "highPrice": 100,
+        "lowPrice": {{ (maas_support_offers.items | sort(attribute='price') | first).price }},
+        "highPrice": {{ (maas_support_offers.items | sort(attribute='price') | last).price }},
         "offerCount": {{ maas_support_offers.items | length }},
         "offers": {{ maas_support_offers.items | tojson }}
       }


### PR DESCRIPTION
## Done

1. Move the pricing data for MAAS to the central `products.yaml` file and use that in multiple places on the webpage. 
2. Added `offers` as a field in the schema.org which is required for `Product` type objects

_Plan to do more products but one at a time to ensure through QA_

## QA

- Open the demo
- Go to /maas
- Open the production site and see they are the same
