### PR TITLE
fix: keep last side-nav link active and stop sticky nav sliding under header

### DIFF
--- a/static/js/active-nav-scroll.js
+++ b/static/js/active-nav-scroll.js
@@ -1,53 +1,89 @@
 /**
- * Initializes dynamic side navigation functionality.
+ * Marks the side navigation link of the section currently being read with
+ * "is-active", derived from scroll position: the last "section-heading" to
+ * have passed an activation line near the top of the viewport.
  *
- * This function sets up an IntersectionObserver for each section header
- * element on the page. When a section header becomes visible in the viewport,
- * the corresponding side navigation link is highlighted by adding the
- * "is-active" class. Other links have the "is-active" class removed.
+ * Not an IntersectionObserver: a heading less than one viewport height from
+ * the end of the document can never be scrolled up to that line, which left
+ * the final links permanently unhighlighted.
  *
- * The function assumes that:
- * - Section headers have the class "section-heading".
- * - Side navigation links have the class "p-side-navigation__link".
- * - Side navigation links use href attributes that correspond to the IDs of
- *   the section headers (e.g., href="#section-id").
- *
- * IntersectionObserver options:
- * - rootMargin: "-5% 0px -87% 0px" ensures the observer triggers when the
- *   section header is within a specific portion of the viewport.
- * - threshold: 0 means the observer triggers as soon as any part of the
- *   section header is visible.
+ * Links are matched to headings by href, e.g. href="#section-id".
  */
+
+// Fraction of the viewport height a heading must pass to become current.
+const ACTIVATION_LINE_RATIO = 0.13;
+
+// Fractional layout heights mean the scroll offset rarely hits its max exactly.
+const BOTTOM_TOLERANCE = 2;
+
 export function setUpDynamicSideNav() {
-  const sections = Array.prototype.slice.call(
-    document.querySelectorAll(".section-heading")
-  );
+  const sections = Array.prototype.slice
+    .call(document.querySelectorAll(".section-heading"))
+    // An id-less heading matches no link, so it would blank the whole nav.
+    .filter(function (section) {
+      return Boolean(section.id);
+    });
   const navigationLinks = Array.prototype.slice.call(
     document.querySelectorAll(".p-side-navigation__link")
   );
 
-  sections.forEach(function (section) {
-    const observer = new IntersectionObserver(
-      function (entry) {
-        if (entry[0].isIntersecting) {
-          const sectionId = entry[0].target.id;
-          navigationLinks.forEach(function (link) {
-            if (link.getAttribute("href") === `#${sectionId}`) {
-              link.classList.add("is-active");
-            } else {
-              link.classList.remove("is-active");
-            }
-          });
-        }
-      },
-      {
-        rootMargin: "-5% 0px -87% 0px",
-        threshold: 0,
-      }
-    );
+  if (sections.length === 0 || navigationLinks.length === 0) {
+    return;
+  }
 
-    observer.observe(section);
-  });
+  function setActiveLink(sectionId) {
+    navigationLinks.forEach(function (link) {
+      if (link.getAttribute("href") === `#${sectionId}`) {
+        link.classList.add("is-active");
+      } else {
+        link.classList.remove("is-active");
+      }
+    });
+  }
+
+  // The current heading, or null while still above the first one.
+  function getCurrentSection() {
+    const maxScroll =
+      document.documentElement.scrollHeight - window.innerHeight;
+
+    // Trailing headings may never reach the activation line, so once the page
+    // can scroll no further the last section is the one on screen.
+    if (maxScroll > 0 && window.scrollY >= maxScroll - BOTTOM_TOLERANCE) {
+      return sections[sections.length - 1];
+    }
+
+    const activationLine = window.innerHeight * ACTIVATION_LINE_RATIO;
+    let current = null;
+    sections.forEach(function (section) {
+      if (section.getBoundingClientRect().top <= activationLine) {
+        current = section;
+      }
+    });
+    return current;
+  }
+
+  function update() {
+    const current = getCurrentSection();
+    if (current) {
+      setActiveLink(current.id);
+    }
+  }
+
+  let updateQueued = false;
+  function requestUpdate() {
+    if (updateQueued) {
+      return;
+    }
+    updateQueued = true;
+    window.requestAnimationFrame(function () {
+      updateQueued = false;
+      update();
+    });
+  }
+
+  window.addEventListener("scroll", requestUpdate, { passive: true });
+  window.addEventListener("resize", requestUpdate);
+  update();
 }
 
 setUpDynamicSideNav();

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -137,13 +137,6 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 // `vh` first: Vanilla's own `max-height` is `dvh`-only, so without a fallback
 // both declarations drop and the nav grows unbounded where `dvh` is missing.
 @media (min-width: $breakpoint-large) {
-  .p-side-navigation.is-sticky.u-top-3-5rem,
-  [class*="p-side-navigation--"].is-sticky.u-top-3-5rem {
-    max-height: calc(100vh - 3.5rem);
-    max-height: calc(100dvh - 3.5rem);
-    top: 3.5rem;
-  }
-
   .p-side-navigation.is-sticky.u-top-4rem,
   [class*="p-side-navigation--"].is-sticky.u-top-4rem {
     max-height: calc(100vh - 4rem);

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -130,6 +130,30 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   top: 0;
 }
 
+// Vanilla's `.p-side-navigation.is-sticky` pins `top: 0` above
+// $breakpoint-large, outranking the single-class `u-top-*` utilities used to
+// clear the sticky header — so side navigations slid under it. Re-apply the
+// offset at a winning specificity, shortening the scroll area to match.
+@media (min-width: $breakpoint-large) {
+  .p-side-navigation.is-sticky.u-top-3-5rem,
+  [class*="p-side-navigation--"].is-sticky.u-top-3-5rem {
+    max-height: calc(100dvh - 3.5rem);
+    top: 3.5rem;
+  }
+
+  .p-side-navigation.is-sticky.u-top-4rem,
+  [class*="p-side-navigation--"].is-sticky.u-top-4rem {
+    max-height: calc(100dvh - 4rem);
+    top: 4rem;
+  }
+
+  .p-side-navigation.is-sticky.u-top-5rem,
+  [class*="p-side-navigation--"].is-sticky.u-top-5rem {
+    max-height: calc(100dvh - 5rem);
+    top: 5rem;
+  }
+}
+
 // Overide the path to flags for dial codes
 .iti__flag {
   background-image: url("#{$assets-path}685bc1a3-flags.png");

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -134,21 +134,26 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 // $breakpoint-large, outranking the single-class `u-top-*` utilities used to
 // clear the sticky header — so side navigations slid under it. Re-apply the
 // offset at a winning specificity, shortening the scroll area to match.
+// `vh` first: Vanilla's own `max-height` is `dvh`-only, so without a fallback
+// both declarations drop and the nav grows unbounded where `dvh` is missing.
 @media (min-width: $breakpoint-large) {
   .p-side-navigation.is-sticky.u-top-3-5rem,
   [class*="p-side-navigation--"].is-sticky.u-top-3-5rem {
+    max-height: calc(100vh - 3.5rem);
     max-height: calc(100dvh - 3.5rem);
     top: 3.5rem;
   }
 
   .p-side-navigation.is-sticky.u-top-4rem,
   [class*="p-side-navigation--"].is-sticky.u-top-4rem {
+    max-height: calc(100vh - 4rem);
     max-height: calc(100dvh - 4rem);
     top: 4rem;
   }
 
   .p-side-navigation.is-sticky.u-top-5rem,
   [class*="p-side-navigation--"].is-sticky.u-top-5rem {
+    max-height: calc(100vh - 5rem);
     max-height: calc(100dvh - 5rem);
     top: 5rem;
   }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -130,12 +130,9 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
   top: 0;
 }
 
-// Vanilla's `.p-side-navigation.is-sticky` pins `top: 0` above
-// $breakpoint-large, outranking the single-class `u-top-*` utilities used to
-// clear the sticky header — so side navigations slid under it. Re-apply the
-// offset at a winning specificity, shortening the scroll area to match.
-// `vh` first: Vanilla's own `max-height` is `dvh`-only, so without a fallback
-// both declarations drop and the nav grows unbounded where `dvh` is missing.
+// Vanilla pins `.p-side-navigation.is-sticky` to `top: 0`, outranking the
+// `u-top-*` utilities that clear the sticky header, and exposes no variable to
+// set it — hence the specificity bump.
 @media (min-width: $breakpoint-large) {
   .p-side-navigation.is-sticky.u-top-4rem,
   [class*="p-side-navigation--"].is-sticky.u-top-4rem {

--- a/tests/js/active-nav-scroll.test.js
+++ b/tests/js/active-nav-scroll.test.js
@@ -1,27 +1,74 @@
 /** @jest-environment jsdom */
 import { setUpDynamicSideNav } from "../../static/js/active-nav-scroll.js";
 
+/**
+ * Lays out a fake page so scroll position can be simulated in jsdom, which has
+ * no layout engine. Each heading is given a fixed position in the document and
+ * getBoundingClientRect() is derived from the current scroll offset.
+ */
+function buildPage({ viewportHeight, scrollHeight, headings, links }) {
+  document.body.innerHTML = `
+    <div class="p-side-navigation">
+      ${links
+        .map(
+          (href) =>
+            `<a class="p-side-navigation__link" href="${href}">${href}</a>`
+        )
+        .join("")}
+    </div>
+  `;
+
+  headings.forEach(function (heading) {
+    const element = document.createElement("h2");
+    element.className = "section-heading";
+    if (heading.id) {
+      element.id = heading.id;
+    }
+    element.getBoundingClientRect = function () {
+      const top = heading.docTop - window.scrollY;
+      return { top: top, bottom: top + heading.height, height: heading.height };
+    };
+    document.body.appendChild(element);
+  });
+
+  Object.defineProperty(window, "innerHeight", {
+    value: viewportHeight,
+    configurable: true,
+  });
+  Object.defineProperty(document.documentElement, "scrollHeight", {
+    value: scrollHeight,
+    configurable: true,
+  });
+  setScroll(0);
+}
+
+function setScroll(y) {
+  Object.defineProperty(window, "scrollY", { value: y, configurable: true });
+}
+
+function scrollTo(y) {
+  setScroll(y);
+  window.dispatchEvent(new Event("scroll"));
+}
+
+function activeLinks() {
+  return Array.prototype.slice
+    .call(document.querySelectorAll(".p-side-navigation__link"))
+    .filter((link) => link.classList.contains("is-active"))
+    .map((link) => link.getAttribute("href"));
+}
+
 describe("active-nav-scroll", () => {
-  let mockIntersectionObserver;
-  let observerCallbacks = {};
-
   beforeEach(() => {
-    // Clear the document
     document.body.innerHTML = "";
-
-    // Reset callbacks
-    observerCallbacks = {};
-
-    // Mock IntersectionObserver
-    mockIntersectionObserver = jest.fn((callback, options) => {
-      return {
-        observe: jest.fn(),
-        unobserve: jest.fn(),
-        disconnect: jest.fn(),
-      };
-    });
-
-    global.IntersectionObserver = mockIntersectionObserver;
+    // Run animation frame callbacks synchronously so assertions can follow a
+    // dispatched scroll event immediately.
+    jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        callback(0);
+        return 0;
+      });
   });
 
   afterEach(() => {
@@ -29,148 +76,140 @@ describe("active-nav-scroll", () => {
   });
 
   describe("setUpDynamicSideNav function", () => {
-    it("should create IntersectionObserver for each section heading", () => {
-      // Setup DOM
-      document.body.innerHTML = `
-        <div class="section-heading" id="section-1">Section 1</div>
-        <div class="section-heading" id="section-2">Section 2</div>
-        <div class="p-side-navigation__link" href="#section-1">Link 1</div>
-        <div class="p-side-navigation__link" href="#section-2">Link 2</div>
-      `;
+    it("activates the section whose heading has passed the activation line", () => {
+      buildPage({
+        viewportHeight: 1000,
+        scrollHeight: 5000,
+        headings: [
+          { id: "intro", docTop: 500, height: 100 },
+          { id: "features", docTop: 1500, height: 100 },
+          { id: "pricing", docTop: 2500, height: 100 },
+        ],
+        links: ["#intro", "#features", "#pricing"],
+      });
 
       setUpDynamicSideNav();
 
-      // Should create 2 observers (one for each section)
-      expect(mockIntersectionObserver).toHaveBeenCalledTimes(2);
+      // "features" sits at docTop 1500, so it crosses the activation line
+      // (13% of a 1000px viewport = 130px) once scrolled past 1370px.
+      scrollTo(1400);
+      expect(activeLinks()).toEqual(["#features"]);
+
+      scrollTo(2400);
+      expect(activeLinks()).toEqual(["#pricing"]);
     });
 
-    it("should set correct IntersectionObserver options", () => {
-      document.body.innerHTML = `
-        <div class="section-heading" id="section-1">Section 1</div>
-        <div class="p-side-navigation__link" href="#section-1">Link 1</div>
-      `;
+    it("activates the last link at the bottom of the page even when its heading never reaches the activation line", () => {
+      // Regression test: the final section sits less than a viewport height
+      // above the end of the document, so its heading can never be scrolled up
+      // to the activation line. It must still become active.
+      buildPage({
+        viewportHeight: 1200,
+        scrollHeight: 3000,
+        headings: [
+          { id: "intro", docTop: 600, height: 100 },
+          { id: "middle", docTop: 1400, height: 100 },
+          { id: "last", docTop: 2200, height: 100 },
+        ],
+        links: ["#intro", "#middle", "#last"],
+      });
 
       setUpDynamicSideNav();
 
-      // Check that observer was created with correct options
-      expect(mockIntersectionObserver).toHaveBeenCalledWith(
-        expect.any(Function),
-        {
-          rootMargin: "-5% 0px -87% 0px",
-          threshold: 0,
-        }
-      );
+      // Maximum scroll is 3000 - 1200 = 1800, leaving "last" at 400px from the
+      // top of the viewport, far below the 156px activation line.
+      scrollTo(1800);
+      expect(activeLinks()).toEqual(["#last"]);
     });
 
-    it("should add is-active class to matching link when section intersects", () => {
-      document.body.innerHTML = `
-        <div class="section-heading" id="section-1">Section 1</div>
-        <div class="p-side-navigation__link" href="#section-1">Link 1</div>
-        <div class="p-side-navigation__link" href="#section-2">Link 2</div>
-      `;
+    it("ignores section headings that have no id so the nav is never blanked", () => {
+      buildPage({
+        viewportHeight: 1000,
+        scrollHeight: 4000,
+        headings: [
+          { id: "intro", docTop: 500, height: 100 },
+          { id: null, docTop: 2000, height: 100 },
+        ],
+        links: ["#intro"],
+      });
 
       setUpDynamicSideNav();
 
-      // Get the first observer callback (should be for section-1)
-      const firstCallback = mockIntersectionObserver.mock.calls[0][0];
+      scrollTo(600);
+      expect(activeLinks()).toEqual(["#intro"]);
 
-      // Simulate intersection
-      const mockSection = document.querySelector(".section-heading");
-      firstCallback([{ isIntersecting: true, target: mockSection }]);
+      // Scrolling past the id-less heading must not clear the active link.
+      scrollTo(2500);
+      expect(activeLinks()).toEqual(["#intro"]);
 
-      // Check that the correct link has is-active class
-      const link1 = document.querySelector('[href="#section-1"]');
-      const link2 = document.querySelector('[href="#section-2"]');
-
-      expect(link1.classList.contains("is-active")).toBe(true);
-      expect(link2.classList.contains("is-active")).toBe(false);
+      scrollTo(3000);
+      expect(activeLinks()).toEqual(["#intro"]);
     });
 
-    it("should remove is-active class from other links when section intersects", () => {
-      document.body.innerHTML = `
-        <div class="section-heading" id="section-1">Section 1</div>
-        <div class="section-heading" id="section-2">Section 2</div>
-        <div class="p-side-navigation__link is-active" href="#section-1">Link 1</div>
-        <div class="p-side-navigation__link" href="#section-2">Link 2</div>
-      `;
+    it("leaves the active state untouched above the first heading", () => {
+      buildPage({
+        viewportHeight: 1000,
+        scrollHeight: 5000,
+        headings: [{ id: "intro", docTop: 900, height: 100 }],
+        links: ["#intro"],
+      });
 
       setUpDynamicSideNav();
 
-      // Get the second observer callback (should be for section-2)
-      const secondCallback = mockIntersectionObserver.mock.calls[1][0];
-
-      // Simulate intersection for section-2
-      const mockSection = document.querySelector(".section-heading#section-2");
-      secondCallback([{ isIntersecting: true, target: mockSection }]);
-
-      // Check that link2 is active and link1 is not
-      const link1 = document.querySelector('[href="#section-1"]');
-      const link2 = document.querySelector('[href="#section-2"]');
-
-      expect(link1.classList.contains("is-active")).toBe(false);
-      expect(link2.classList.contains("is-active")).toBe(true);
+      scrollTo(100);
+      expect(activeLinks()).toEqual([]);
     });
 
-    it("should handle multiple sections correctly", () => {
-      document.body.innerHTML = `
-        <div class="section-heading" id="intro">Introduction</div>
-        <div class="section-heading" id="features">Features</div>
-        <div class="section-heading" id="pricing">Pricing</div>
-        <div class="p-side-navigation__link" href="#intro">Intro</div>
-        <div class="p-side-navigation__link" href="#features">Features</div>
-        <div class="p-side-navigation__link" href="#pricing">Pricing</div>
-      `;
+    it("recalculates when the viewport is resized", () => {
+      buildPage({
+        viewportHeight: 1000,
+        scrollHeight: 5000,
+        headings: [
+          { id: "intro", docTop: 500, height: 100 },
+          { id: "features", docTop: 1500, height: 100 },
+        ],
+        links: ["#intro", "#features"],
+      });
 
       setUpDynamicSideNav();
 
-      // Should create 3 observers
-      expect(mockIntersectionObserver).toHaveBeenCalledTimes(3);
+      scrollTo(1300);
+      expect(activeLinks()).toEqual(["#intro"]);
 
-      // Test the features section becomes active
-      const featuresSection = document.querySelector(".section-heading#features");
-      const featureCallback = mockIntersectionObserver.mock.calls[1][0];
-      featureCallback([{ isIntersecting: true, target: featuresSection }]);
-
-      const links = document.querySelectorAll(".p-side-navigation__link");
-      expect(links[0].classList.contains("is-active")).toBe(false); // intro
-      expect(links[1].classList.contains("is-active")).toBe(true); // features
-      expect(links[2].classList.contains("is-active")).toBe(false); // pricing
+      // A taller viewport pushes the activation line down to 260px, which
+      // "features" (at 200px) has now crossed.
+      Object.defineProperty(window, "innerHeight", {
+        value: 2000,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event("resize"));
+      expect(activeLinks()).toEqual(["#features"]);
     });
 
-    it("should not add is-active class when section is not intersecting", () => {
-      document.body.innerHTML = `
-        <div class="section-heading" id="section-1">Section 1</div>
-        <div class="p-side-navigation__link" href="#section-1">Link 1</div>
-      `;
-
-      setUpDynamicSideNav();
-
-      const callback = mockIntersectionObserver.mock.calls[0][0];
-      const mockSection = document.querySelector(".section-heading");
-
-      // Simulate non-intersecting entry
-      callback([{ isIntersecting: false, target: mockSection }]);
-
-      const link = document.querySelector('[href="#section-1"]');
-      expect(link.classList.contains("is-active")).toBe(false);
+    it("does not throw when there are no section headings or links", () => {
+      document.body.innerHTML = "";
+      expect(() => setUpDynamicSideNav()).not.toThrow();
     });
 
-    it("should handle sections with no corresponding navigation links", () => {
-      document.body.innerHTML = `
-        <div class="section-heading" id="section-1">Section 1</div>
-        <div class="section-heading" id="section-2">Section 2</div>
-        <div class="p-side-navigation__link" href="#section-1">Link 1</div>
-      `;
+    it("handles sections with no corresponding navigation link", () => {
+      buildPage({
+        viewportHeight: 1000,
+        scrollHeight: 5000,
+        headings: [
+          { id: "intro", docTop: 500, height: 100 },
+          { id: "orphan", docTop: 1500, height: 100 },
+        ],
+        links: ["#intro"],
+      });
 
       expect(() => setUpDynamicSideNav()).not.toThrow();
 
-      // Verify the function still works with section-1
-      const section1 = document.querySelector(".section-heading#section-1");
-      const callback = mockIntersectionObserver.mock.calls[0][0];
-      callback([{ isIntersecting: true, target: section1 }]);
+      scrollTo(600);
+      expect(activeLinks()).toEqual(["#intro"]);
 
-      const link = document.querySelector('[href="#section-1"]');
-      expect(link.classList.contains("is-active")).toBe(true);
+      // The orphan section has no link, so nothing should be highlighted.
+      scrollTo(1400);
+      expect(activeLinks()).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Done

- **Last side-nav links never highlighted.** The `IntersectionObserver` only activated a heading inside a band 5%–13% down the viewport. A heading less than one viewport height from the end of the document can never be scrolled into that band, so trailing links stayed dead. Replaced with scroll-position tracking. This is why it was hard to reproduce — at 1440x900 `/documentation/beyond-canonical` looks fine, at 1512x1200 the last two links are dead.
- **Sticky side nav slid under the header.** Vanilla's `.p-side-navigation.is-sticky` sets `top: 0` above `$breakpoint-large` and outranks the single-class `u-top-*` utility, so the offset never applied. Re-applied it at a winning specificity.
- Drive-by: ignore `section-heading` elements with no `id` — one on `open-roles` matched no link and blanked the whole nav.
- Rewrote the unit tests around scroll position rather than a mocked observer.

## QA

- Open the [DEMO](https://canonical-com-2859.demos.haus/)
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- **Use a tall window (~1200px+) — the bug does not show at 900px.**
- On https://canonical-com-2859.demos.haus/documentation/beyond-canonical, click "Scientific research community", then scroll to the bottom: it stays highlighted. Scrolling top to bottom highlights each of the five links in turn.
- Repeat on https://canonical-com-2859.demos.haus/documentation — "Four pillars" and "Read more" both highlight.
- While scrolling, the side nav sits below the header instead of behind it.

## Issue / Card

https://warthogs.atlassian.net/browse/WD-22273

## Screenshots

_To be attached: sticky nav clearing the header, and the last link active at the bottom of the page._

