### PR TITLE
fix: add conditional meta tag for noindex when no articles are present

### DIFF
--- a/templates/knowledge/_base_knowledge_category.html
+++ b/templates/knowledge/_base_knowledge_category.html
@@ -7,6 +7,12 @@
   is-paper
 {% endblock body_class %}
 
+{% block extra_metatags %}
+  {% if not articles %}
+    <meta name="robots" content="noindex" />
+  {% endif %}
+{% endblock extra_metatags %}
+
 {% block title %}{{ title }} | Knowledge{% endblock title %}
 
 {% block outer_content %}


### PR DESCRIPTION
## Done

- add conditional meta tag for noindex when no articles are present

## QA

- `curl -s http://localhost:8002/knowledge/company | grep -i 'name="robots"'` will return `<meta name="robots" content="noindex" />`
- `curl -s http://localhost:8002/knowledge/cloud-and-infrastructure | grep -i 'name="robots"'`  will return nothing

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38391
