### PR TITLE
chore: Add Valkey and Cassandra sitemaps to index

### DIFF
--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -145,6 +145,12 @@
     <loc>https://canonical.com/data/opensearch/docs/latest/sitemap.xml</loc>
   </sitemap>
   <sitemap>
+    <loc>https://canonical.com/data/valkey/docs/latest/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://canonical.com/data/cassandra/docs/latest/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
     <loc>https://canonical.com/data/spark/docs/latest/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>


### PR DESCRIPTION
## Done

Add Valkey sitemap to sitemap index.
Add Cassandra sitemap to sitemap index.

## QA

Check the links - they are working and showing XML of a sitemap.