### PR TITLE
chore: add sitemap entry for mediawiki k8s charm docs

### DIFF
--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -156,4 +156,7 @@
   <sitemap>
     <loc>https://canonical.com/ceph/docs/stable/doc-sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://canonical.com/juju/docs/mediawiki-k8s-charm/doc-sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
The URL for this documentation has been migrated from `https://documentation.ubuntu.com/mediawiki-k8s-charm/` to `https://canonical.com/juju/docs/mediawiki-k8s-charm/`.

This PR updates the sitemap index with the latter entry.
