### PR TITLE
chore: replace 10 years with 15 years of support

### DIFF
--- a/templates/data/mysql/index.html
+++ b/templates/data/mysql/index.html
@@ -57,7 +57,7 @@
       <div class="col">
         <ul class="p-list--divided">
           <li class="p-list__item u-no-padding">
-            <p class="p-heading--2">Up to 10 years of security maintenance</p>
+            <p class="p-heading--2">Up to 15 years of security maintenance</p>
           </li>
           <li class="p-list__item u-no-padding">
             <p class="p-heading--2">Hybrid and multi-cloud ready</p>
@@ -239,7 +239,7 @@
           </div>
         </div>
         <p>
-          Charmed MySQL comes with up to 10 years of security maintenance. It also ships with hardened configurations to help you comply with the most stringent requirements in terms of encryption, auditing, logging, authentication and authorisation.
+          Charmed MySQL comes with up to 15 years of security maintenance. It also ships with hardened configurations to help you comply with the most stringent requirements in terms of encryption, auditing, logging, authentication and authorisation.
         </p>
       </div>
     </div>
@@ -264,7 +264,7 @@
             }}
           </div>
         </div>
-        <p>Get comprehensive, 24/7 or weekday support for Charmed MySQL, covering the entire solution for up to 10 years.</p>
+        <p>Get comprehensive, 24/7 or weekday support for Charmed MySQL, covering the entire solution for up to 15 years.</p>
         <hr class="p-rule--muted" />
         <p>
           <a class="p-button" href="https://ubuntu.com/pro/subscribe">Subscribe now<span class="u-off-screen">Subscribe for ubuntu pro service</span></a>
@@ -357,7 +357,7 @@
               <p class="u-align-text--right u-text--muted">Per node, per year</p>
             </div>
           </div>
-          <p>24/7, weekday or advanced fire-fighting support for MySQL from Canonical for up to 10 years per release track.</p>
+          <p>24/7, weekday or advanced fire-fighting support for MySQL from Canonical for up to 15 years per release track.</p>
           <hr class="p-rule--muted" />
           <div class="p-section--shallow u-no-margin--bottom">
             <ul class="p-list--divided u-no-margin--bottom">

--- a/templates/data/postgresql/index.html
+++ b/templates/data/postgresql/index.html
@@ -54,7 +54,7 @@
       <div class="col">
         <ul class="p-list--divided">
           <li class="p-list__item u-no-padding">
-            <p class="p-heading--2">Up to 10 years of security maintenance</p>
+            <p class="p-heading--2">Up to 15 years of security maintenance</p>
           </li>
           <li class="p-list__item u-no-padding">
             <p class="p-heading--2">Hybrid and multi-cloud ready</p>
@@ -234,7 +234,7 @@
           </div>
         </div>
         <p>
-          Charmed PostgreSQL comes with up to 10 years of security maintenance. It also ships with hardened configurations to help you comply with the most stringent requirements in terms of encryption, auditing, logging, authentication and authorisation.
+          Charmed PostgreSQL comes with up to 15 years of security maintenance. It also ships with hardened configurations to help you comply with the most stringent requirements in terms of encryption, auditing, logging, authentication and authorisation.
         </p>
       </div>
       <div class="col">
@@ -252,7 +252,7 @@
           </div>
         </div>
         <p>
-          Get comprehensive, 24/7 or weekday support for Charmed PostgreSQL, covering the entire solution for up to 10 years.
+          Get comprehensive, 24/7 or weekday support for Charmed PostgreSQL, covering the entire solution for up to 15 years.
         </p>
         <hr class="p-rule--muted" />
         <p>
@@ -338,7 +338,7 @@
             </div>
           </div>
           <p>
-            24/7, weekday or advanced fire-fighting support for PostgreSQL from Canonical for up to 10 years per release track.
+            24/7, weekday or advanced fire-fighting support for PostgreSQL from Canonical for up to 15 years per release track.
           </p>
           <hr class="p-rule--muted" />
           <div class="p-section--shallow u-no-margin--bottom">


### PR DESCRIPTION
Originally flagged [here](https://github.com/canonical/canonical.com/pull/2899#discussion_r3880581177).

Confirmed by Rhys on MM.

## Done

- replaced "10" with "15" years of support

## QA

- Visit https://canonical-com-2900.demos.haus/data/mysql and verify it mentions "15" years of support
- Visit https://canonical-com-2900.demos.haus/data/postgresql and verify it mentions "15" years of support

