### PR TITLE
feat: Add link to datasheet

### DIFF
--- a/templates/solutions/infrastructure/sovereign-cloud.html
+++ b/templates/solutions/infrastructure/sovereign-cloud.html
@@ -63,7 +63,18 @@
           </p>
         "
         }
+      },
+      {
+      "type": "cta-block",
+      "item": {
+        "link": {
+          "content_html": "Learn more in the datasheet&nbsp;&rsaquo;",
+          "attrs": {
+            "href": "https://assets.ubuntu.com/v1/c3d7aa30-open_source_sovereign_cloud_v03.pdf"
+          }
+        }
       }
+    },
     ]) 
   }}
 


### PR DESCRIPTION
## Done

- Added a link to a datasheet to the 'Sovereign cloud' page.

## QA

- Open [/solutions/infrastructure/sovereign-cloud](https://canonical-com-2901.demos.haus/solutions/infrastructure/sovereign-cloud)
- Check that there is a new "Learn more in the datasheet" link under "What is a sovereign cloud?"

## Screenshots

<img width="1275" height="288" alt="Screenshot 2026-08-31 at 10 36 08 am" src="https://github.com/user-attachments/assets/3a1d6b01-f7cf-4eb6-b006-dfad129c9724" />

## Issue / Card

https://warthogs.atlassian.net/browse/WD-38568
