### PR TITLE
fix: inject nonce into gtm container script

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -240,6 +240,9 @@
                   j = d.createElement(s),
                   dl = l != 'dataLayer' ? '&l=' + l : '';
                   j.async = true;
+                  // nonce lets gtm.js propagate it to tags the container injects
+                  j.setAttribute('nonce', '{{ csp_nonce }}');
+                  j.nonce = '{{ csp_nonce }}';
                   j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
                   f.parentNode.insertBefore(j, f);
                 })(window, document, 'script', 'dataLayer', containerId);


### PR DESCRIPTION
## Done
- added nonce for gtm containers to abide by CSP.

## QA
- Navigate to the landing page
- Open browser console and ensure that there are no GTM errors relating to CSP.

## Issue / Card
https://warthogs.atlassian.net/browse/WD-38667


