### PR TITLE
chore: Update /maas subnav links

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -773,6 +773,7 @@ maas/index(.html)?: "/maas/"
 maas/tour: "/maas/features"
 maas/(?P<path>.+)/index(.html)?: "/maas/{path}"
 maas/how-it-works: "/maas/how-maas-works"
+maas/blog: "/blog/tag/maas"
 # Docs redirects
 maas/docs/(devel|2.6|stable|en|devel/en|stable/en|2.6/en): /maas/docs
 maas/docs/(devel|2.6|stable|en|devel/en|stable/en|2.6/en)/(?P<path>.*): /maas/docs/{path}

--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -442,10 +442,6 @@ maas:
       path: /maas/features
     - title: Tutorials
       path: /maas/tutorials
-    - title: Blog
-      path: /maas/blog
-    - title: Forum
-      path: https://discourse.maas.io/
 
 mir:
   title: Mir Display Server


### PR DESCRIPTION
## Done

- Removed `Forum` and `Blog` subnav links 
- Added redirect for blog

## QA

- Open the [DEMO](https://canonical-com-2903.demos.haus/maas)
- See that the subnav no longer includes `Forum` or `Blog`
- Visit https://canonical-com-2903.demos.haus/maas/blog and see that you are redirected to https://canonical-com-2903.demos.haus/blog/tag/maas


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38526
