### PR TITLE
fix: generate google domains list at build time

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - domains-csp
   workflow_dispatch:
     inputs:
       environment:
@@ -218,55 +219,55 @@ jobs:
           juju refresh canonical-com-careers --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
           juju wait-for application canonical-com --query='name=="canonical-com" && (status=="active" || status=="idle")'
 
-  deploy-production:
-    runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-medium]
-    if: |
-      always() &&
-      needs.pack-charm.result == 'success' &&
-      needs.publish-image.result == 'success' &&
-      (needs.deploy-staging.result == 'success' || needs.deploy-staging.result == 'skipped') &&
-      (
-        github.event_name == 'push' ||
-        (
-          github.event_name == 'workflow_dispatch' &&
-          github.event.inputs.environment == 'production' &&
-          github.event.inputs.branch == 'main'
-        )
-      )
-    needs: [pack-charm, publish-image, deploy-staging]
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-  
-      - name: Install Dependencies
-        run: |
-          sudo snap install juju --channel=3.6/stable --classic
-          sudo snap install vault --classic
-  
-      - name: Download Charm Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: canonical-com-charm
-  
-      - name: Configure Vault and Juju
-        run: |
-          export VAULT_ADDR=https://vault.admin.canonical.com:8200
-          export TF_VAR_login_approle_role_id=${{ secrets.PROD_VAULT_APPROLE_ROLE_ID }}
-          export TF_VAR_login_approle_secret_id=${{ secrets.PROD_VAULT_APPROLE_SECRET_ID }}
-          export VAULT_SECRET_PATH_ROLE=secret/prodstack6/roles/prod-canonical-com
-          export VAULT_SECRET_PATH_COMMON=secret/prodstack6/juju/common
-          VAULT_TOKEN=$(vault write -f -field=token auth/approle/login role_id=${TF_VAR_login_approle_role_id} secret_id=${TF_VAR_login_approle_secret_id}) 
-          export VAULT_TOKEN
-          mkdir -p ~/.local/share/juju
-          vault read -field=controller_config "${VAULT_SECRET_PATH_COMMON}/controllers/juju-controller-36-production-ps6" | base64 -d > ~/.local/share/juju/controllers.yaml
-          USERNAME=$(vault read -field=username "${VAULT_SECRET_PATH_ROLE}/juju")
-          PASSWORD=$(vault read -field=password "${VAULT_SECRET_PATH_ROLE}/juju")
-          printf "controllers:\n  juju-controller-36-production-ps6:\n    user: %s\n    password: %s\n" "$USERNAME" "$PASSWORD" > ~/.local/share/juju/accounts.yaml
-  
-      - name: Deploy Application to production
-        run: |
-          export JUJU_MODEL=admin/prod-canonical-com
-          juju refresh canonical-com --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
-          juju refresh canonical-com-blog --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
-          juju refresh canonical-com-careers --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
-          juju wait-for application canonical-com --query='name=="canonical-com" && (status=="active" || status=="idle")'
+#   deploy-production:
+#     runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-medium]
+#     if: |
+#       always() &&
+#       needs.pack-charm.result == 'success' &&
+#       needs.publish-image.result == 'success' &&
+#       (needs.deploy-staging.result == 'success' || needs.deploy-staging.result == 'skipped') &&
+#       (
+#         github.event_name == 'push' ||
+#         (
+#           github.event_name == 'workflow_dispatch' &&
+#           github.event.inputs.environment == 'production' &&
+#           github.event.inputs.branch == 'main'
+#         )
+#       )
+#     needs: [pack-charm, publish-image, deploy-staging]
+#     steps:
+#       - name: Checkout Code
+#         uses: actions/checkout@v3
+#   
+#       - name: Install Dependencies
+#         run: |
+#           sudo snap install juju --channel=3.6/stable --classic
+#           sudo snap install vault --classic
+#   
+#       - name: Download Charm Artifact
+#         uses: actions/download-artifact@v4
+#         with:
+#           name: canonical-com-charm
+#   
+#       - name: Configure Vault and Juju
+#         run: |
+#           export VAULT_ADDR=https://vault.admin.canonical.com:8200
+#           export TF_VAR_login_approle_role_id=${{ secrets.PROD_VAULT_APPROLE_ROLE_ID }}
+#           export TF_VAR_login_approle_secret_id=${{ secrets.PROD_VAULT_APPROLE_SECRET_ID }}
+#           export VAULT_SECRET_PATH_ROLE=secret/prodstack6/roles/prod-canonical-com
+#           export VAULT_SECRET_PATH_COMMON=secret/prodstack6/juju/common
+#           VAULT_TOKEN=$(vault write -f -field=token auth/approle/login role_id=${TF_VAR_login_approle_role_id} secret_id=${TF_VAR_login_approle_secret_id}) 
+#           export VAULT_TOKEN
+#           mkdir -p ~/.local/share/juju
+#           vault read -field=controller_config "${VAULT_SECRET_PATH_COMMON}/controllers/juju-controller-36-production-ps6" | base64 -d > ~/.local/share/juju/controllers.yaml
+#           USERNAME=$(vault read -field=username "${VAULT_SECRET_PATH_ROLE}/juju")
+#           PASSWORD=$(vault read -field=password "${VAULT_SECRET_PATH_ROLE}/juju")
+#           printf "controllers:\n  juju-controller-36-production-ps6:\n    user: %s\n    password: %s\n" "$USERNAME" "$PASSWORD" > ~/.local/share/juju/accounts.yaml
+#   
+#       - name: Deploy Application to production
+#         run: |
+#           export JUJU_MODEL=admin/prod-canonical-com
+#           juju refresh canonical-com --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+#           juju refresh canonical-com-blog --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+#           juju refresh canonical-com-careers --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+#           juju wait-for application canonical-com --query='name=="canonical-com" && (status=="active" || status=="idle")'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - domains-csp
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -219,55 +219,55 @@ jobs:
           juju refresh canonical-com-careers --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
           juju wait-for application canonical-com --query='name=="canonical-com" && (status=="active" || status=="idle")'
 
-#   deploy-production:
-#     runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-medium]
-#     if: |
-#       always() &&
-#       needs.pack-charm.result == 'success' &&
-#       needs.publish-image.result == 'success' &&
-#       (needs.deploy-staging.result == 'success' || needs.deploy-staging.result == 'skipped') &&
-#       (
-#         github.event_name == 'push' ||
-#         (
-#           github.event_name == 'workflow_dispatch' &&
-#           github.event.inputs.environment == 'production' &&
-#           github.event.inputs.branch == 'main'
-#         )
-#       )
-#     needs: [pack-charm, publish-image, deploy-staging]
-#     steps:
-#       - name: Checkout Code
-#         uses: actions/checkout@v3
-#   
-#       - name: Install Dependencies
-#         run: |
-#           sudo snap install juju --channel=3.6/stable --classic
-#           sudo snap install vault --classic
-#   
-#       - name: Download Charm Artifact
-#         uses: actions/download-artifact@v4
-#         with:
-#           name: canonical-com-charm
-#   
-#       - name: Configure Vault and Juju
-#         run: |
-#           export VAULT_ADDR=https://vault.admin.canonical.com:8200
-#           export TF_VAR_login_approle_role_id=${{ secrets.PROD_VAULT_APPROLE_ROLE_ID }}
-#           export TF_VAR_login_approle_secret_id=${{ secrets.PROD_VAULT_APPROLE_SECRET_ID }}
-#           export VAULT_SECRET_PATH_ROLE=secret/prodstack6/roles/prod-canonical-com
-#           export VAULT_SECRET_PATH_COMMON=secret/prodstack6/juju/common
-#           VAULT_TOKEN=$(vault write -f -field=token auth/approle/login role_id=${TF_VAR_login_approle_role_id} secret_id=${TF_VAR_login_approle_secret_id}) 
-#           export VAULT_TOKEN
-#           mkdir -p ~/.local/share/juju
-#           vault read -field=controller_config "${VAULT_SECRET_PATH_COMMON}/controllers/juju-controller-36-production-ps6" | base64 -d > ~/.local/share/juju/controllers.yaml
-#           USERNAME=$(vault read -field=username "${VAULT_SECRET_PATH_ROLE}/juju")
-#           PASSWORD=$(vault read -field=password "${VAULT_SECRET_PATH_ROLE}/juju")
-#           printf "controllers:\n  juju-controller-36-production-ps6:\n    user: %s\n    password: %s\n" "$USERNAME" "$PASSWORD" > ~/.local/share/juju/accounts.yaml
-#   
-#       - name: Deploy Application to production
-#         run: |
-#           export JUJU_MODEL=admin/prod-canonical-com
-#           juju refresh canonical-com --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
-#           juju refresh canonical-com-blog --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
-#           juju refresh canonical-com-careers --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
-#           juju wait-for application canonical-com --query='name=="canonical-com" && (status=="active" || status=="idle")'
+  deploy-production:
+    runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-medium]
+    if: |
+      always() &&
+      needs.pack-charm.result == 'success' &&
+      needs.publish-image.result == 'success' &&
+      (needs.deploy-staging.result == 'success' || needs.deploy-staging.result == 'skipped') &&
+      (
+        github.event_name == 'push' ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.environment == 'production' &&
+          github.event.inputs.branch == 'main'
+        )
+      )
+    needs: [pack-charm, publish-image, deploy-staging]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+  
+      - name: Install Dependencies
+        run: |
+          sudo snap install juju --channel=3.6/stable --classic
+          sudo snap install vault --classic
+  
+      - name: Download Charm Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: canonical-com-charm
+  
+      - name: Configure Vault and Juju
+        run: |
+          export VAULT_ADDR=https://vault.admin.canonical.com:8200
+          export TF_VAR_login_approle_role_id=${{ secrets.PROD_VAULT_APPROLE_ROLE_ID }}
+          export TF_VAR_login_approle_secret_id=${{ secrets.PROD_VAULT_APPROLE_SECRET_ID }}
+          export VAULT_SECRET_PATH_ROLE=secret/prodstack6/roles/prod-canonical-com
+          export VAULT_SECRET_PATH_COMMON=secret/prodstack6/juju/common
+          VAULT_TOKEN=$(vault write -f -field=token auth/approle/login role_id=${TF_VAR_login_approle_role_id} secret_id=${TF_VAR_login_approle_secret_id}) 
+          export VAULT_TOKEN
+          mkdir -p ~/.local/share/juju
+          vault read -field=controller_config "${VAULT_SECRET_PATH_COMMON}/controllers/juju-controller-36-production-ps6" | base64 -d > ~/.local/share/juju/controllers.yaml
+          USERNAME=$(vault read -field=username "${VAULT_SECRET_PATH_ROLE}/juju")
+          PASSWORD=$(vault read -field=password "${VAULT_SECRET_PATH_ROLE}/juju")
+          printf "controllers:\n  juju-controller-36-production-ps6:\n    user: %s\n    password: %s\n" "$USERNAME" "$PASSWORD" > ~/.local/share/juju/accounts.yaml
+  
+      - name: Deploy Application to production
+        run: |
+          export JUJU_MODEL=admin/prod-canonical-com
+          juju refresh canonical-com --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+          juju refresh canonical-com-blog --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+          juju refresh canonical-com-careers --path ./canonical-com_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+          juju wait-for application canonical-com --query='name=="canonical-com" && (status=="active" || status=="idle")'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -82,6 +82,38 @@ jobs:
       - name: Pre-generate sitemap lastmod manifest
         run: python3 scripts/generate-lastmod-manifest.py generate-lastmod
 
+      - name: Refresh Google CSP domains
+        run: |
+          python3 - <<'PY'
+          import re
+          import urllib.request
+
+          body = urllib.request.urlopen(
+              "https://www.google.com/supported_domains", timeout=10
+          ).read().decode()
+          domains = sorted(
+              {
+                  "www" + line.strip()
+                  for line in body.splitlines()
+                  if line.strip().startswith(".google.")
+              }
+          )
+          assert domains, "empty response from supported_domains"
+
+          block = "GOOGLE_DOMAINS = [\n"
+          block += "".join(f'    "{d}",\n' for d in domains)
+          block += "]"
+
+          path = "webapp/handlers.py"
+          src = open(path).read()
+          new_src, count = re.subn(
+              r"GOOGLE_DOMAINS = \[.*?\]", block, src, count=1, flags=re.S
+          )
+          assert count == 1, "GOOGLE_DOMAINS block not found"
+          open(path, "w").write(new_src)
+          print(f"handlers.py: refreshed with {len(domains)} domains")
+          PY
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -109,6 +109,10 @@ env:
       key: secret
       name: sitemaps
 
+# Increases the size limit for the response header so it supports the
+# updated domains list for CSP
+nginxProxyBufferSize: 16k
+
 extraHosts:
   - domain: blog.canonical.com
   - domain: design.canonical.com

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -177,7 +177,8 @@ GOOGLE_DOMAINS = [
     "www.google.no",
     "www.google.nr",
     "www.google.nu",
-    "www.google.pl",
+    # will be uncommented after testing
+    # "www.google.pl",
     "www.google.pn",
     "www.google.ps",
     "www.google.pt",

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -60,7 +60,8 @@ GOOGLE_DOMAINS = [
     "www.google.co.th",
     "www.google.co.tz",
     "www.google.co.ug",
-    "www.google.co.uk",
+    # will be uncommented
+    # "www.google.co.uk",
     "www.google.co.uz",
     "www.google.co.ve",
     "www.google.co.vi",
@@ -177,8 +178,7 @@ GOOGLE_DOMAINS = [
     "www.google.no",
     "www.google.nr",
     "www.google.nu",
-    # will be uncommented after testing
-    # "www.google.pl",
+    "www.google.pl",
     "www.google.pn",
     "www.google.ps",
     "www.google.pt",

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -1,7 +1,6 @@
 import logging
 import time
 
-import requests
 import secrets
 import sentry_sdk
 from urllib.parse import urlparse
@@ -12,81 +11,200 @@ from canonicalwebteam.discourse import RateLimitedError
 
 logger = logging.getLogger(__name__)
 
-# Used if the live fetch from Google fails at startup. Covers the regions
-# we've historically seen in CSP reports.
-_GOOGLE_DOMAINS_FALLBACK = [
-    "www.google.com",
-    # Europe
+# Regional google.<tld> domains used by GTM, from
+# https://www.google.com/supported_domains. Refreshed at build time by
+# the "Refresh Google CSP domains" step in .github/workflows/deploy.yaml
+# (fetching at app startup isn't reliable - production egress isn't
+# always up yet, which silently truncated this list before).
+GOOGLE_DOMAINS = [
+    "www.google.ad",
+    "www.google.ae",
+    "www.google.al",
+    "www.google.am",
+    "www.google.as",
     "www.google.at",
+    "www.google.az",
+    "www.google.ba",
     "www.google.be",
-    "www.google.ch",
-    "www.google.co.uk",
-    "www.google.cz",
-    "www.google.de",
-    "www.google.dk",
-    "www.google.es",
-    "www.google.fi",
-    "www.google.fr",
-    "www.google.gr",
-    "www.google.hu",
-    "www.google.ie",
-    "www.google.it",
-    "www.google.nl",
-    "www.google.no",
-    "www.google.pl",
-    "www.google.pt",
-    "www.google.ro",
-    "www.google.se",
-    # Americas
+    "www.google.bf",
+    "www.google.bg",
+    "www.google.bi",
+    "www.google.bj",
+    "www.google.bs",
+    "www.google.bt",
+    "www.google.by",
     "www.google.ca",
+    "www.google.cat",
+    "www.google.cd",
+    "www.google.cf",
+    "www.google.cg",
+    "www.google.ch",
+    "www.google.ci",
     "www.google.cl",
-    "www.google.co",
-    "www.google.com.ar",
-    "www.google.com.br",
-    "www.google.com.mx",
-    "www.google.com.pe",
-    # Asia & Pacific
+    "www.google.cm",
+    "www.google.cn",
+    "www.google.co.ao",
+    "www.google.co.bw",
+    "www.google.co.ck",
+    "www.google.co.cr",
     "www.google.co.id",
+    "www.google.co.il",
     "www.google.co.in",
     "www.google.co.jp",
+    "www.google.co.ke",
     "www.google.co.kr",
+    "www.google.co.ls",
+    "www.google.co.ma",
+    "www.google.co.mz",
     "www.google.co.nz",
     "www.google.co.th",
+    "www.google.co.tz",
+    "www.google.co.ug",
+    "www.google.co.uk",
+    "www.google.co.uz",
+    "www.google.co.ve",
+    "www.google.co.vi",
+    "www.google.co.za",
+    "www.google.co.zm",
+    "www.google.co.zw",
+    "www.google.com",
+    "www.google.com.af",
+    "www.google.com.ag",
+    "www.google.com.ar",
     "www.google.com.au",
+    "www.google.com.bd",
+    "www.google.com.bh",
+    "www.google.com.bn",
+    "www.google.com.bo",
+    "www.google.com.br",
+    "www.google.com.bz",
+    "www.google.com.co",
+    "www.google.com.cu",
+    "www.google.com.cy",
+    "www.google.com.do",
+    "www.google.com.ec",
+    "www.google.com.eg",
+    "www.google.com.et",
+    "www.google.com.fj",
+    "www.google.com.gh",
+    "www.google.com.gi",
+    "www.google.com.gt",
     "www.google.com.hk",
+    "www.google.com.jm",
+    "www.google.com.kh",
+    "www.google.com.kw",
+    "www.google.com.lb",
+    "www.google.com.ly",
+    "www.google.com.mm",
+    "www.google.com.mt",
+    "www.google.com.mx",
     "www.google.com.my",
+    "www.google.com.na",
+    "www.google.com.ng",
+    "www.google.com.ni",
+    "www.google.com.np",
+    "www.google.com.om",
+    "www.google.com.pa",
+    "www.google.com.pe",
+    "www.google.com.pg",
     "www.google.com.ph",
+    "www.google.com.pk",
+    "www.google.com.pr",
+    "www.google.com.py",
+    "www.google.com.qa",
+    "www.google.com.sa",
+    "www.google.com.sb",
     "www.google.com.sg",
+    "www.google.com.sl",
+    "www.google.com.sv",
+    "www.google.com.tj",
+    "www.google.com.tr",
     "www.google.com.tw",
+    "www.google.com.ua",
+    "www.google.com.uy",
+    "www.google.com.vc",
     "www.google.com.vn",
+    "www.google.cv",
+    "www.google.cz",
+    "www.google.de",
+    "www.google.dj",
+    "www.google.dk",
+    "www.google.dm",
+    "www.google.dz",
+    "www.google.ee",
+    "www.google.es",
+    "www.google.fi",
+    "www.google.fm",
+    "www.google.fr",
+    "www.google.ga",
+    "www.google.ge",
+    "www.google.gg",
+    "www.google.gl",
+    "www.google.gm",
+    "www.google.gr",
+    "www.google.gy",
+    "www.google.hn",
+    "www.google.hr",
+    "www.google.ht",
+    "www.google.hu",
+    "www.google.ie",
+    "www.google.im",
+    "www.google.iq",
+    "www.google.is",
+    "www.google.it",
+    "www.google.je",
+    "www.google.jo",
+    "www.google.kg",
+    "www.google.ki",
+    "www.google.kz",
+    "www.google.la",
+    "www.google.li",
+    "www.google.lk",
+    "www.google.lt",
+    "www.google.lu",
+    "www.google.lv",
+    "www.google.md",
+    "www.google.me",
+    "www.google.mg",
+    "www.google.mk",
+    "www.google.ml",
+    "www.google.mn",
+    "www.google.mu",
+    "www.google.mv",
+    "www.google.mw",
+    "www.google.ne",
+    "www.google.nl",
+    "www.google.no",
+    "www.google.nr",
+    "www.google.nu",
+    "www.google.pl",
+    "www.google.pn",
+    "www.google.ps",
+    "www.google.pt",
+    "www.google.ro",
+    "www.google.rs",
+    "www.google.ru",
+    "www.google.rw",
+    "www.google.sc",
+    "www.google.se",
+    "www.google.sh",
+    "www.google.si",
+    "www.google.sk",
+    "www.google.sm",
+    "www.google.sn",
+    "www.google.so",
+    "www.google.sr",
+    "www.google.st",
+    "www.google.td",
+    "www.google.tg",
+    "www.google.tl",
+    "www.google.tm",
+    "www.google.tn",
+    "www.google.to",
+    "www.google.tt",
+    "www.google.vu",
+    "www.google.ws",
 ]
-
-
-def _fetch_google_supported_domains():
-    """
-    Fetch Google's published list of regional search domains so GTM can
-    reach the user's local google.<tld>. Falls back to a hardcoded list
-    if the request fails so CSP remains valid.
-    """
-    try:
-        response = requests.get(
-            "https://www.google.com/supported_domains", timeout=5
-        )
-        response.raise_for_status()
-        domains = [
-            "www" + line.strip()
-            for line in response.text.splitlines()
-            if line.strip().startswith(".google.")
-        ]
-        if domains:
-            return domains
-        logger.warning("Google supported_domains response was empty")
-    except requests.RequestException as exc:
-        logger.warning("Failed to fetch Google supported_domains: %s", exc)
-    return _GOOGLE_DOMAINS_FALLBACK
-
-
-GOOGLE_DOMAINS = _fetch_google_supported_domains()
 
 # Same-origin endpoint registered below in init_handlers(); browsers send
 # CSP violation reports here regardless of the page's own connect-src.
@@ -164,8 +282,7 @@ CSP = {
         "ws.zoominfo.com",
         "youtube.com",
         "google.com",
-        # Regional google.<tld> domains used by GTM, sourced live from
-        # https://www.google.com/supported_domains at app startup.
+        # Regional google.<tld> domains, see GOOGLE_DOMAINS above.
         *GOOGLE_DOMAINS,
         "fonts.google.com",
         "maps.googleapis.com",

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -60,8 +60,7 @@ GOOGLE_DOMAINS = [
     "www.google.co.th",
     "www.google.co.tz",
     "www.google.co.ug",
-    # will be uncommented
-    # "www.google.co.uk",
+    "www.google.co.uk",
     "www.google.co.uz",
     "www.google.co.ve",
     "www.google.co.vi",


### PR DESCRIPTION
## Done
- Updated domains list to include 187 different domains.
- Added build step to fetch and generate domain list during build time.

## QA
- Set your VPN to a location that's not included in the domains fallback list [here](https://github.com/canonical/canonical.com/blob/48f22d15a5bcd6e107739a63df402fddc99edeaa/webapp/handlers.py#L17)
- Check out staging.canonical.com. **Note:** run the deploy action again if there have been more commits since the last time this branch was deployed to staging.
- Open your browser console. 
- Ensure you're not getting a CSP error related to a regional google domain.

## Issue / Card
https://warthogs.atlassian.net/browse/WD-38410

