### PR TITLE
chore: add sitemap for Concierge

### DIFF
--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -25,6 +25,9 @@
     <loc>https://canonical.com/juju/docs/charmlibs/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>
+    <loc>https://canonical.com/juju/docs/concierge/doc-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
     <loc>https://canonical.com/juju/docs/jubilant/doc-sitemap.xml</loc>
   </sitemap>
   <sitemap>


### PR DESCRIPTION
This PR adds the Concierge docs sitemap. Concierge is a new doc site that was published today.