### PR TITLE
chore: bump djlint to 1.44.2 for multiline jinja tag support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,20 @@ yarn format-prettier  # prettier
 djlint templates/path/to/file.html --lint --profile=jinja   # djlint for html/jinja - uses `.djlintrc`
 ```
 
+djLint is pinned in `requirements.txt`. Keep it at **1.41.0 or later**: older versions
+cannot read a template tag spanning several lines, so they flatten the contents of a
+multiline `{{ macro(...) }}` call to one indent level and then report the file as
+correctly formatted. The damage is silent.
+
+This repo runs under dotrun, so `.venv` is built inside the container and editor
+plugins cannot execute it. **Your global djLint is what formats templates in your
+editor**, regardless of the pin, which only governs CI and the container:
+
+```bash
+djlint --version          # what your editor runs
+python -m pip install -U djlint
+```
+
 ## External Service Dependencies
 
 | Service       | Purpose                          | Key Env Vars |

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ google-api-python-client==2.173.0
 google-auth-httplib2==0.2.0
 google-auth-oauthlib==0.8.0
 pytz==2024.2
-djlint==1.36.4
+djlint==1.44.2
 responses==0.25.7
 pycountry==24.6.1
 scikit-learn==1.6.1


### PR DESCRIPTION
## Done

Bumped djlint from 1.36.4 to 1.44.2 so it stops flattening the contents of multiline jinja tags, a formatter bug djlint fixed in 1.41.0. Added a note to `AGENTS.md` that this repo's editor formatting comes from your global djlint, not the pin, because dotrun builds `.venv` inside the container where editor plugins cannot reach it.

`.djlintrc` is deliberately unchanged. The equivalent ubuntu.com change needed `ignore_blocks` and two rule ignores; neither applies here, so nothing is suppressed that currently catches anything.

## QA

Nothing changes on the site. This only affects the formatter and linter.

- Open the [DEMO](https://canonical-com-2912.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- `djlint templates --lint --profile=jinja --extension=html` reports 0 errors on 378 files, the same as main. The bump introduces no new lint failures, so CI stays green.
- The change is visible in the formatter, not the linter. On a file with a multiline `{{ ... }}` call such as `templates/index.html`, `djlint templates/index.html --check` now nests the arguments instead of collapsing them to one level.

No templates are reformatted in this PR. Around 293 files still differ from djlint's output, unchanged from main, so that stays a separate job.

Worth knowing when you do reformat something: a block whose opening `{{` line also contains a closed HTML tag, such as `<br />`, still flattens on 1.44.2. Hoisting the string into a `{% set %}` works around it, and it will be reported upstream.

## Issue / Card

WD-38520

## Screenshots

N/A

https://claude.ai/code/session_01A4jozykGLxQxJfeorhpDvX

