### PR TITLE
feat: add data-nosnippet to newsletter

### DIFF
--- a/templates/partial/_notifications.html
+++ b/templates/partial/_notifications.html
@@ -8,7 +8,7 @@
     </div>
   </div>
 </div>
-<div id="newsletter-signup" class="p-popup-notification">
+<div id="newsletter-signup" class="p-popup-notification" data-nosnippet>
   <div class="p-notification--positive u-no-margin--bottom">
     <div class="p-notification__content">
       <p class="p-notification__message">


### PR DESCRIPTION
## Done
- Added `data-nosnippet` to `_notifications.html` so that crawlers don't see newsletter form data on certain routes. The Ubuntu Pro routes for example.

## QA
-  Newsletter signup
   - `curl -s "<any page>" | grep -c data-nosnippet`  # expect 3 (nav, footer, newsletter-signup)
   - `curl -s "<any page>" | grep 'id="newsletter-signup"`   # confirm data-nosnippet attr present

- Cookie banner
  - Open incognito, let banner auto-open
  - Run `document.querySelector('.cookie-policy')?.hasAttribute('data-nosnippet')` in browser console. Should return true.
  - Reopen banner once more, recheck

## Issue / Card
https://warthogs.atlassian.net/browse/WD-38500


