### PR TITLE
Revert "Revert "chore: update gtm container""

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -155,7 +155,7 @@
         <body class=" 
           {% block body_class %}{% endblock %} l-site">
           <!-- Google Tag Manager (noscript) -->
-          <noscript><iframe class="u-display-none u-visibility-hidden" src="https://www.googletagmanager.com/ns.html?id=GTM-M5BPGQ6"
+          <noscript><iframe class="u-display-none u-visibility-hidden" src="https://www.googletagmanager.com/ns.html?id=GTM-N384JMX2"
         height="0"
         width="0"
        ></iframe></noscript>
@@ -227,10 +227,7 @@
               }
               window.gtmDidInit = true; // flag to ensure script does not get added to DOM more than once.
 
-              var containersToLoad = ['GTM-M5BPGQ6'];
-              {% if gtm_container_id %}
-              containersToLoad.push('{{ gtm_container_id }}');
-              {% endif %}
+              var containersToLoad = ['GTM-N384JMX2'];
 
               containersToLoad.forEach(function(containerId) {
                 (function(w, d, s, l, i) {

--- a/templates/maas/index.html
+++ b/templates/maas/index.html
@@ -1,7 +1,5 @@
 {% extends "base_index.html" %}
 
-{% set gtm_container_id = "GTM-N384JMX2" %}
-
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 {% from "_macros/vf_basic-section.jinja" import vf_basic_section %}


### PR DESCRIPTION
Reverts canonical/canonical.com#2916

**Context from Gianluigi:**
Both the GA4 properties called ubuntu.com and canonical.com will not receive data from the pages where the new GTM has been deployed. The new dashboard to be used is the Combined Tracker (it is the only enterprise GA4 dashboard and offers a lot more insights on what happens on the website)

## Issue
https://warthogs.atlassian.net/browse/WD-38709