### PR TITLE
Fix pixelated blog thumbnail images (WD-38727)

### DIFF
--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -6,10 +6,15 @@
   columns="4",
   link="/blog/" ~ article.slug,
   heading=article.title.rendered | safe,
-  image={
-    "src": article.image.source_url if article.image and article.image.source_url else "https://assets.ubuntu.com/v1/94c82a15-blog_fallback_image.png",
-    "alt": article.title.rendered | striptags
-  },
+  image=image(
+    url=article.image.source_url if article.image and article.image.source_url else "https://assets.ubuntu.com/v1/94c82a15-blog_fallback_image.png",
+    alt=article.title.rendered | striptags,
+    width="384",
+    height="216",
+    hi_def=True,
+    loading="auto",
+    output_mode="attrs"
+  ),
   footer={
     "content_type": article.group.name if article.group else "Company"
   },

--- a/templates/blog/featured-article.html
+++ b/templates/blog/featured-article.html
@@ -8,10 +8,15 @@
   columns="8",
   link="/blog/" ~ article.slug,
   heading=article.title.rendered | safe,
-  image={
-    "src": article.image.source_url if article.image and article.image.source_url else "https://assets.ubuntu.com/v1/94c82a15-blog_fallback_image.png",
-    "alt": article.title.rendered | striptags
-  },
+  image=image(
+    url=article.image.source_url if article.image and article.image.source_url else "https://assets.ubuntu.com/v1/94c82a15-blog_fallback_image.png",
+    alt=article.title.rendered | striptags,
+    width="768",
+    height="432",
+    hi_def=True,
+    loading="auto",
+    output_mode="attrs"
+  ),
   footer={
     "content_type": article.group.name if article.group else "Company"
   },


### PR DESCRIPTION
## Done

Blog card and featured article thumbnails on `canonical.com`'s blog use `vf_card`'s `image` param, but were being fed a raw dict built directly from `article.image.source_url` — bypassing Cloudinary's **`image_template`** helper entirely. That meant no auto format/quality optimisation, and images rendered at native/incorrect resolution, causing visible pixelation on smaller card sizes and high-DPI screens.

This mirrors the same bug fixed in [canonical/ubuntu.com#16738](https://github.com/canonical/ubuntu.com/pull/16738), adapted for this repo's fallback-image logic (`article.image.source_url` can be missing, in which case a fallback image URL is used).

Builds the `image` dict via `image_template` (registered as `image` in the Jinja context) with `output_mode="attrs"` in:

| Template | Width | Height |
| --- | --- | --- |
| `templates/blog/blog-card.html` | 384 | 216 |
| `templates/blog/featured-article.html` | 768 | 432 |

This generates optimised Cloudinary URLs with `hi_def` support for retina displays, while preserving the existing fallback-image behaviour.

## QA

- Visit `/blog` and check the blog card grid and the featured article at the top — thumbnails should load via `res.cloudinary.com` fetch URLs (inspect the `<img>` `src`) instead of the raw WordPress `source_url`, and should look sharp on a high-DPI/retina display.
- Confirm posts without a featured image still fall back to the `blog_fallback_image.png` placeholder.

## Notes

- No new tests added — this is a template markup change with no existing test coverage for `blog-card`/`featured-article`, matching the precedent set by the linked ubuntu.com PR.

## Issue / Card

Related: [WD-38727](https://warthogs.atlassian.net/browse/WD-38727) (same root-cause fix as canonical/ubuntu.com#16738, applied here to canonical.com's blog templates)


[WD-38727]: https://warthogs.atlassian.net/browse/WD-38727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
