### PR TITLE
WD-38725: Remove mention of MLOps Workshop

### DIFF
--- a/templates/mlops/index.html
+++ b/templates/mlops/index.html
@@ -276,23 +276,10 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_1' -%}
-  <h3 class="p-heading--5">Kick start your AI/ML journey with an MLOps Workshop</h3>
-  {%- endif -%}
-
-  {%- if slot == 'list_item_description_1' -%}
-  <div class="p-section--shallow">
-    <p>Build your tailored MLOps architecture in just 5 days. In a custom workshop, we'll help you design AI infrastructure for any use case and level up your in-house expertise to accelerate your machine learning initiatives.</p>
-    <div class="p-cta-block">
-      <a href="/mlops/mlops-workshop">More on MLOps workshops &rsaquo;</a>
-    </div>
-  </div>
-  {%- endif -%}
-
-  {%- if slot == 'list_item_title_2' -%}
   <h3 class="p-heading--5">MLOps Consulting</h3>
   {%- endif -%}
 
-  {%- if slot == 'list_item_description_2' -%}
+  {%- if slot == 'list_item_description_1' -%}
   <div class="p-section--shallow">
     <p>Move faster with Canonical's MLOps consulting services. Our experts can design and deploy your full stack AI environment from the ground up on your substrate of choice.</p>
     <div class="p-cta-block">
@@ -301,11 +288,11 @@
   </div>
   {%- endif -%}
 
-  {%- if slot == 'list_item_title_3' -%}
+  {%- if slot == 'list_item_title_2' -%}
   <h3 class="p-heading--5">Managed MLOps</h3>
   {%- endif -%}
 
-  {%- if slot == 'list_item_description_3' -%}
+  {%- if slot == 'list_item_description_2' -%}
   <p>Let us run the platform so your team can focus on developing and deploying models. Streamline operational service delivery and offload the design, implementation and management of your MLOps environment.</p>
   <div class="p-cta-block">
     <a class="js-invoke-modal" href="/mlops/contact-us" aria-controls="mlops-modal" aria-expanded="false">


### PR DESCRIPTION
## Done

- Remove mention of the MLOps Workshop from `/mlops`

## QA

- Open the [DEMO](https://canonical-com-2930.demos.haus/mlops)
- Alternatively, check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/mlops
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

- [WD-38725](https://warthogs.atlassian.net/browse/WD-38725)
- [Copy doc](https://docs.google.com/document/d/1k3-ZBUmzaiel-iTvsznJfMeV8ggkzgkSzpjMJIBd0d8/edit?tab=t.0)


[WD-38725]: https://warthogs.atlassian.net/browse/WD-38725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
