### PR TITLE
WD-38398: Add Firefighting support to Products navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -294,7 +294,7 @@ products:
             url: https://ubuntu.com/confidential-computing
           - title: Firefighting support
             description: Enhanced support coverage
-            url: https://ubuntu.com/support
+            url: https://ubuntu.com/support/firefighting
 
       secondary_links:
         title: Quick links

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -292,6 +292,9 @@ products:
           - title: Confidential computing
             description: Protect your data in use
             url: https://ubuntu.com/confidential-computing
+          - title: Firefighting support
+            description: Enhanced support coverage
+            url: https://ubuntu.com/support
 
       secondary_links:
         title: Quick links


### PR DESCRIPTION
## Done

- Added Firefighting support to the Products -> Security and support navigation.
- Linked it to the refreshed Ubuntu.com Firefighting Support page.
- Used the navigation title, description, placement, and destination specified in the copydocs.

## QA

- Open the Canonical.com demo.
- Open the Products navigation.
- Under Security and support, verify "Firefighting support" appears immediately after "Confidential computing".
- Verify the description is "Enhanced support coverage".
- Verify the link opens:
  https://ubuntu.com/support/firefighting
- Test the navigation on desktop and mobile.

## References

- [WD-38398](https://warthogs.atlassian.net/browse/WD-38398)
- [Canonical navigation copydoc](https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?tab=t.0)
- [Ubuntu Firefighting page copydoc](https://docs.google.com/document/d/1jixskQiq_lsTqCp2qMX9OdUWT2cZoyzfqzQTmoKG5LA/edit?tab=t.jijjhiya0no5#heading=h.5aa3xm7ho5ld)
- [Figma](https://www.figma.com/design/YdmmtZxcCdEVJE4JmSqfeD/ubuntu.com-support---Sites?node-id=2239-2989&p=f&m=dev)
- [Ubuntu.com implementation PR #16751](https://github.com/canonical/ubuntu.com/pull/16751)


[WD-38398]: https://warthogs.atlassian.net/browse/WD-38398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ