### PR TITLE
WD-38856:Copy update templates/legal/systems-information-notice.md

### DIFF
--- a/templates/legal/systems-information-notice.md
+++ b/templates/legal/systems-information-notice.md
@@ -1,14 +1,19 @@
 ---
 wrapper_template: "legal/_base_legal_markdown.html"
 context:
-  title: "Notice on System Information Collection"
-  update_date: "Mar 2026"
+  title: "Product Data Collection and Usage Notice"
+  update_date: "September 2026"
   copydoc: "https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM"
 ---
 
-# Notice on System Information Collection
+# Product Data Collection and Usage Notice
 
-This Notice on System Information Collection provides you with an overview of the system information Canonical collects from you which you can choose to share with us, when you interact with Ubuntu, such as on first login to Ubuntu, periodically and on release upgrades.
+This Product Data Collection and Usage Notice provides you with an overview of the system information Canonical collects from you, which you can choose to share with us, when you interact with our products, such as on first login, periodically and on release upgrades.
+
+This Notice covers information collected by the following products
+
+- Ubuntu
+- Multipass
 
 ## Who are we?
 
@@ -16,33 +21,13 @@ We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A
 
 ## What system information do we collect?
 
-When you first install Ubuntu or at first login, you will have the option to share with Canonical the following system information. Should you choose not to share the system information, Canonical will not recieve any item of system information. 
+When you first install a product or at first login, you will have the option to share with Canonical the following system information. Should you choose not to share the system information, Canonical will not receive any system information related to that product.
 
-During installation of Ubuntu, non-personally-identifiable system information may be shared with Canonical, including the following:
+During installation or use of our products, the following non-personally-identifiable system information may be shared with Canonical:
 
-### Metrics collected by Ubuntu Report
+### Ubuntu
 
-- Version
-- OEM (Vendor, Product)
-- BIOS (Vendor, Version)
-- CPU (Vendor, Family, Model, Stepping)
-- GPU (Vendor, Model)
-- RAM
-- Partition sizes
-- Screens (Resolution, Frequence)
-- Whether Autologin is enabled during install or not
-- Whether LivePatch is enabled during install or not
-- Session (Desktop Environment, Name, Type)
-- Selected Timezone
-- Install information
-  - MediaType (USB, DVD, etc)
-  - Partition Method (manual or automatic)
-  - Download Updates during install selected or not
-  - Language
-  - Minimal install selected or not
-  - Restricted Add-ons selected or not
-
-### Metrics collected by Ubuntu Insights
+#### Metrics collected by Ubuntu Insights
 
 - Common Metrics
   - Insights Version
@@ -64,6 +49,12 @@ During installation of Ubuntu, non-personally-identifiable system information ma
     - Device Name
     - Vendor
     - Driver
+  - Accelerators (Per)
+    - Name
+    - Device
+    - Vendor
+    - Driver
+    - Type
   - Memory
     - Total Physical Size
   - Disks and Partitions
@@ -112,11 +103,123 @@ During installation of Ubuntu, non-personally-identifiable system information ma
   - Session Name
   - Session Type
 
+#### Metrics collected by Ubuntu Report
+
+(Included in Ubuntu 26.04 and older)
+
+- Version
+- OEM (Vendor, Product)
+- BIOS (Vendor, Version)
+- CPU (Vendor, Family, Model, Stepping)
+- GPU (Vendor, Model)
+- RAM
+- Partition sizes
+- Screens (Resolution, Frequence)
+- Whether Autologin is enabled during install or not
+- Whether LivePatch is enabled during install or not
+- Session (Desktop Environment, Name, Type)
+- Selected Timezone
+- Install information
+  - MediaType (USB, DVD, etc)
+  - Partition Method (manual or automatic)
+  - Download Updates during install selected or not
+  - Language
+  - Minimal install selected or not
+  - Restricted Add-ons selected or not
+
+#### Metrics collected by Ubuntu Certified client
+
+If you choose to check if your system is [Ubuntu Certified](https://ubuntu.com/certified), non-personally-identifiable system information will be shared with Canonical, including the following:
+
+- Device
+  - Manufacturer
+  - Model
+  - Architecture
+- BIOS
+  - Manufacturer
+  - Version
+  - Revision
+  - Firmware revision
+  - Release date
+- Board
+  - Manufacturer
+  - Product name
+  - Version
+- Chassis
+  - Manufacturer
+  - Chassis type
+  - Version
+  - SKU number
+- Processor
+  - Vendor
+  - Version/model string
+  - Max frequency
+  - Identifier
+- Operating system
+  - Distributor name
+  - Version
+  - Codename
+  - Kernel
+    - Name
+    - Version
+    - Signature
+    - Loaded kernel modules
+- PCI and USB peripherals
+  - ID
+  - Device name
+  - Vendor
+  - Status *(working or broken, if known)*
+
+### Multipass
+
+#### Metrics collected by Multipass using Ubuntu Insights
+
+The following information may be collected specifically during installation, first usage, and while using Multipass:
+
+- Multipass general data
+  - Daemon/service version
+  - GUI client version
+  - Primary instance name
+  - User settings
+    - Open on start-up
+    - Active driver/backend
+    - Number of aliases per alias context
+  - Authorized users count
+  - Client usage
+    - CLI usage count
+    - GUI usage count
+  - User satisfaction value
+- Multipass virtual machines (instances) data
+  - Total number of created instances since installation
+  - Total number of instances created as primary
+  - Total number of created instances since last data collection
+  - Configuration details for each created instance since last data collection
+    - Used image
+    - Alias used to create
+    - CPU count
+    - Memory
+    - Disk size
+    - Bridge enabled
+    - Mounts count
+  - Configuration details for each active instance
+    - Used image
+    - CPU count
+    - Memory usage
+    - Disk usage
+    - Bridge enabled
+    - Mounts count
+    - Current status
+    - Uptime
+    - Availability Zone
+    - Snapshot count
+
 ## What do we do with your system information?
 
-Your system information will be used by Canonical and selected third parties for engineering purposes and to make improvements to Ubuntu by allowing us to focus more specifically on typical user hardware setup and selected features and for other related services.
+Your system information will be used by Canonical and selected third parties for engineering purposes and to make improvements to our products by allowing us to focus more specifically on typical user hardware setup and selected features and for other related services.
 
-Your system information is stored in our systems and may be processed by Canonical globally. Aggregated system information for Ubuntu may be made publicly available.
+In the case of the Ubuntu Certified client, your system information will be used to check against our certified hardware database if your system is indeed certified.
+
+Your system information is stored in our systems and may be processed by Canonical globally. Aggregated system information may be made publicly available.
 
 ## How long do we keep your system information for?
 


### PR DESCRIPTION
## Done
As specified in [this copydoc](https://docs.google.com/document/d/1hS5D5H-QSf91z3Fv0YLGI28FbRDrJTPoBiop3M2DHik/edit?tab=t.yckhqa8gja0):

- Renamed the notice to "Product Data Collection and Usage Notice"
- Broadened scope from Ubuntu to all covered products (Ubuntu, Multipass), and added the Multipass metrics section
- Added "Metrics collected by Ubuntu Certified client" and Accelerators data under Ubuntu Insights

## QA

- Open the [DEMO](__DEMO_URL__/)
- Alternatively, check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)

## Issue / Card

Fixes [WD-38856](https://warthogs.atlassian.net/browse/WD-38856)

## Screenshots

[if relevant, include a screenshot]


[WD-38856]: https://warthogs.atlassian.net/browse/WD-38856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ