### PR TITLE
WD-38779 - copyupdate /microcloud - #2938

### DIFF
--- a/templates/microcloud/index.html
+++ b/templates/microcloud/index.html
@@ -43,7 +43,7 @@
       class="p-button--positive">
       Install MicroCloud
     </a>
-    <a href="/microcloud/contact-us" class="js-invoke-modal p-button" aria-controls="microcloud-modal">Get in touch</a>
+    <a href="https://ubuntu.com/engage/intro-to-microcloud" class="p-button">Intro to MicroCloud</a>
   {%- endif -%}
   {% endcall -%}
 
@@ -84,9 +84,11 @@
         "type": "description",
         "item": {
           "type": "html",
-          "content": "<p>
+          "content": '<p>
             Learn more about Canonical’s lightweight open source cloud platform in our video.
-          </p>"
+          </p>
+           <a href="/microcloud/contact-us" class="js-invoke-modal p-button" aria-controls="microcloud-modal">Talk to our experts</a>
+          '
         }
       }
     ]


### PR DESCRIPTION
## Done

- Replaced `Get in touch` button with `Intro to MicroCloud` CTA
- Moved `Get in touch` down, changing its label to "Talk to our experts"

Copydoc: https://docs.google.com/document/d/17iBbFCINLYjPBOYWpgoq9SreyYNkR0Sb5jgx5iTo6MA/

## QA

- Open the [DEMO](https://canonical-com-2939.demos.haus/)
- Alternatively, check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #WD-38779

## Screenshots

<img width="2244" height="436" alt="image" src="https://github.com/user-attachments/assets/b4caad15-478c-4662-be08-4216a30b05f6" />
<img width="2246" height="918" alt="image" src="https://github.com/user-attachments/assets/794d48d0-71ca-4443-bba9-9bad1dd7edf4" />

