### PR TITLE
chore: add OpenStack docs sitemap

### DIFF
--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -162,4 +162,7 @@
   <sitemap>
     <loc>https://canonical.com/juju/docs/mediawiki-k8s-charm/doc-sitemap.xml</loc>
   </sitemap>
+    <sitemap>
+    <loc>https://canonical.com/openstack/docs/latest/doc-sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

Added the OpenStack documentation sitemaps to the `templates/sitemap-index.xml` file. The docs are now hosted on https://canonical.com/openstack/docs.

## Screenshots

Tested that the sitemap exists on all versions. On `latest`:
<img width="1850" height="941" alt="image" src="https://github.com/user-attachments/assets/14f09685-4fb1-4cee-bf85-b5f85acfeb04" />
